### PR TITLE
feat: bug fix, feature, and some docs

### DIFF
--- a/Lvlab.yml
+++ b/Lvlab.yml
@@ -53,7 +53,7 @@ environment:
             ip4gw: 192.168.122.1
       - vm_name: ghar.local
         hostname: ghar
-        os: fedora40
+        os: debian12
         interfaces:
           - name: eth0
             ip4: 192.168.122.17/24
@@ -71,3 +71,8 @@ images:
     checksum_url: https://cloud.debian.org/images/cloud/bookworm/20240717-1811/SHA512SUMS
     checksum_type: sha512
     network_version: 2
+  debian11:
+    image_url: https://cloud.debian.org/images/cloud/bullseye/20240717-1811/debian-11-generic-amd64-20240717-1811.qcow2
+    checksum_url: https://cloud.debian.org/images/cloud/bullseye/20240717-1811/SHA512SUMS
+    checksum_type: sha512
+    network_version: 1

--- a/docs/Libvirt.md
+++ b/docs/Libvirt.md
@@ -1,0 +1,13 @@
+# Libvirt Notes
+
+## virt-install
+
+Getting help:
+
+```bash
+# Show --network parameter options
+virt-install --network=?
+
+# Set extra params
+virt-install ... --network bridge=br0,model=virtio,mac=52:54:00:c2:de:ce,address.type=pci,address.domain=0,address.bus=1,address.slot=0,address.function=0 ...
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tkc-lvlab"
-version = "0.1.3"
+version = "0.1.4"
 description = "The Libvirt Labs project provides the `lvlab` Python application which can be used to manage Libvirt based development environments in a familiar way."
 authors = ["Chris Row <1418370+memblin@users.noreply.github.com>"]
 readme = "README.md"

--- a/tkc_lvlab/cli.py
+++ b/tkc_lvlab/cli.py
@@ -201,7 +201,7 @@ def destroy(vm_name):
     )
 
     if machine:
-        click.echo(f"Destroying virtual machine: {vm_name}")
+        # TODO: Ask for confirmation before destroying, control with feature flag?
         if machine.destroy(
             machine.config_fpath, environment.get("libvirt_uri", "qemu:///session")
         ):

--- a/tkc_lvlab/templates/meta-data.j2
+++ b/tkc_lvlab/templates/meta-data.j2
@@ -1,4 +1,4 @@
-instance-id: iid-{{ config.hostname }}
+instance-id: iid-{{ config.vm_name }}
 local-hostname: {{ config.hostname }}
 
 {# Ensure newline at end of rendered file #}


### PR DESCRIPTION
This PR fixes the bug where the domain name was being attached to the VM name. This bug was a remnant of building the vm_name from the hostname + domain name  that proved a little rigid in use.

While working on this I found another but where my Debian test VM came up on enp2s0 instead of enp1s0. I've adjusted the virt-install command to always specify bus 1 so we should consistently get enp1s0 (or eth0) at least for Debian (enp1s0), Ubuntu (enp1s0), and Fedora (eth0)

Running a `lvstatus` should not correctly report the reason for the current state if the state is shutdown or running. Other states still need to be added.

Updated the cloud-init meta-data template to use the vm_name for the instance id.

## Testing

Tested against Fedora 40, Debian 12, and Debian 11 images.

## Commit Message

  - fix vm_name bug
  - fix interface bus id bug
  - add feature to interpret running state status
  - update cloud-init meta-data template
  - version bump, patch