### PR TITLE
feat: Add environment identifier to libvirt VM name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tkc-lvlab"
-version = "0.1.10"
+version = "0.1.11"
 description = "The Libvirt Labs project provides the `lvlab` Python application which can be used to manage Libvirt based development environments in a familiar way."
 authors = ["Chris Row <1418370+memblin@users.noreply.github.com>"]
 readme = "README.md"

--- a/tkc_lvlab/cli.py
+++ b/tkc_lvlab/cli.py
@@ -399,8 +399,11 @@ def status():
 
     click.echo("Machines Defined:\n")
     for machine in machines:
-        if machine["vm_name"] in current_vms:
-            vm = conn.lookupByName(machine["vm_name"])
+        libvirt_vm_name = (
+            machine["vm_name"] + "_" + environment.get("name", "LvLabEnvironment")
+        )
+        if libvirt_vm_name in current_vms:
+            vm = conn.lookupByName(libvirt_vm_name)
             _, _, vm_status, vm_status_reason = get_machine_state(vm.state())
             click.echo(
                 f"  - { machine['vm_name'] } is {vm_status} ({vm_status_reason})"

--- a/tkc_lvlab/utils/libvirt.py
+++ b/tkc_lvlab/utils/libvirt.py
@@ -42,7 +42,6 @@ class Machine:
 
         # Setup a machine file path to contain all of the files associated
         # with the instance of a machine.
-        # vm_name = machine.get("vm_name", machine.get("hostname", None) + machine.get("domain", None))
         vm_name = machine.get("vm_name")
         config_fpath = os.path.expanduser(
             os.path.join(
@@ -58,6 +57,9 @@ class Machine:
 
         self.environment = environment
         self.vm_name = vm_name
+        self.libvirt_vm_name = (
+            vm_name + "_" + environment.get("name", "LvLabEnvironment")
+        )
         self.hostname = machine.get("hostname", None)
         self.domain = config_defaults.get("domain", None)
         # If we don't have an os by now set a default of Generic Linux 2022
@@ -223,7 +225,7 @@ class Machine:
         command = [
             "virt-install",
             f"--connect={uri}",
-            f"--name={self.vm_name}",
+            f"--name={self.libvirt_vm_name}",
             f"--memory={self.memory}",
             f"--vcpus={self.cpu}",
             "--import",
@@ -269,8 +271,8 @@ class Machine:
 
         current_vms = [dom.name() for dom in conn.listAllDomains()]
 
-        if self.vm_name in current_vms:
-            vm = conn.lookupByName(self.vm_name)
+        if self.libvirt_vm_name in current_vms:
+            vm = conn.lookupByName(self.libvirt_vm_name)
             vm_state, _, _, _ = get_machine_state(vm.state())
 
             if vm_state in ["VIR_DOMAIN_RUNNING", "VIR_DOMAIN_PAUSED"]:
@@ -335,8 +337,8 @@ class Machine:
         conn = connect_to_libvirt(uri)
         current_vms = [dom.name() for dom in conn.listAllDomains()]
 
-        if self.vm_name in current_vms:
-            vm = conn.lookupByName(self.vm_name)
+        if self.libvirt_vm_name in current_vms:
+            vm = conn.lookupByName(self.libvirt_vm_name)
             state, state_reason, _, _ = get_machine_state(vm.state())
             exists = True
 
@@ -349,8 +351,8 @@ class Machine:
         conn = connect_to_libvirt(uri)
         current_vms = [dom.name() for dom in conn.listAllDomains()]
 
-        if self.vm_name in current_vms:
-            vm = conn.lookupByName(self.vm_name)
+        if self.libvirt_vm_name in current_vms:
+            vm = conn.lookupByName(self.libvirt_vm_name)
             snapshots = vm.listAllSnapshots()
 
         conn.close()
@@ -362,8 +364,8 @@ class Machine:
         conn = connect_to_libvirt(uri)
         current_vms = [dom.name() for dom in conn.listAllDomains()]
 
-        if self.vm_name in current_vms:
-            vm = conn.lookupByName(self.vm_name)
+        if self.libvirt_vm_name in current_vms:
+            vm = conn.lookupByName(self.libvirt_vm_name)
 
             if not snapshot_description:
                 snapshot_description = f"Snapshot of {vm.name()}"
@@ -389,9 +391,9 @@ class Machine:
         conn = connect_to_libvirt(uri)
         current_vms = [dom.name() for dom in conn.listAllDomains()]
 
-        if self.vm_name in current_vms:
+        if self.libvirt_vm_name in current_vms:
             try:
-                vm = conn.lookupByName(self.vm_name)
+                vm = conn.lookupByName(self.libvirt_vm_name)
                 snapshot = vm.snapshotLookupByName(snapshot_name)
 
                 if snapshot:
@@ -408,8 +410,8 @@ class Machine:
         conn = connect_to_libvirt(uri)
         current_vms = [dom.name() for dom in conn.listAllDomains()]
 
-        if self.vm_name in current_vms:
-            vm = conn.lookupByName(self.vm_name)
+        if self.libvirt_vm_name in current_vms:
+            vm = conn.lookupByName(self.libvirt_vm_name)
             vm_state, _, _, _ = get_machine_state(vm.state())
 
             if vm_state in ["VIR_DOMAIN_SHUTOFF", "VIR_DOMAIN_CRASHED"]:
@@ -431,8 +433,8 @@ class Machine:
         # Get a list of current VMs
         current_vms = [dom.name() for dom in conn.listAllDomains()]
 
-        if self.vm_name in current_vms:
-            vm = conn.lookupByName(self.vm_name)
+        if self.libvirt_vm_name in current_vms:
+            vm = conn.lookupByName(self.libvirt_vm_name)
             vm_state, _, _, _ = get_machine_state(vm.state())
 
             if vm_state in [


### PR DESCRIPTION
This is a breaking change to add VM name handling in an effort to avoid VM name collision when Lvlabs is used to manage more than one lab on a particular host. Many times verious labs may need to share VM names, with the previous version that meant name collisions in Libvirt.

The changes in this PR introduce the concept of a `libvirt_vm_name` which is an underscore separated string of `hostname` + `environment.name`

This allows us to use the `libvirt_vm_name` for Libvirt operations while using the original `vm_name` for human output and file storage pathing.

Environment VMs from earlier versions of lvlab may be able to be re-named to be able to meet the new standard and not need a full redeployment.

## Testing Output

```bash
# Show lvlab status
(lvlab) crow@laptop01:~/repos/github/memblin/lvlab-examples$ lvlab status

LvLab Environment Name: lvlab-example

Machines Defined:

  - salt.local is undeployed
  - vault.local is undeployed
  - jenkins.local is undeployed
  - dhcpconfig.local is undeployed

Images Used:

  - fedora40 from https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2
  - debian12 from https://cloud.debian.org/images/cloud/bookworm/20240717-1811/debian-12-generic-amd64-20240717-1811.qcow2
  - debian11 from https://cloud.debian.org/images/cloud/bullseye/20240717-1811/debian-11-generic-amd64-20240717-1811.qcow2
  - debian10 from https://cloud.debian.org/images/cloud/buster/20240703-1797/debian-10-generic-amd64-20240703-1797.qcow2
  - NoValidate from https://cloud.debian.org/images/cloud/buster/20240703-1797/debian-10-generic-amd64-20240703-1797.qcow2

# Bring up salt.local
(lvlab) crow@laptop01:~/repos/github/memblin/lvlab-examples$ lvlab up salt.local
Creating virtual machine: salt.local
Creating Virtual Disk: /var/lib/libvirt/images/lvlab/lvlab-example/salt.local/disk0.qcow2 at 30G
Virtual Disk Created Successfully
Writing cloud-init network config file /var/lib/libvirt/images/lvlab/lvlab-example/salt.local/network-config
Writing cloud-init meta-data file /var/lib/libvirt/images/lvlab/lvlab-example/salt.local/meta-data
Ignoring config_defaults:cloud_init:runcmd for salt.local
Pubkey appears to be a file path, attempting to read contents
Successfully read ssh-ed25519 pubkey
Writing cloud-init user-data file /var/lib/libvirt/images/lvlab/lvlab-example/salt.local/user-data
Writing cloud-init config ISO file /var/lib/libvirt/images/lvlab/lvlab-example/salt.local/cidata.iso
Writing cloud-init config ISO successful
Attempting to start virtual maching: salt.local
Virtual machine deployment complete.

# Show lvlab status again
(lvlab) crow@laptop01:~/repos/github/memblin/lvlab-examples$ lvlab status

LvLab Environment Name: lvlab-example

Machines Defined:

  - salt.local is the machine is running (normal startup from boot)
  - vault.local is undeployed
  - jenkins.local is undeployed
  - dhcpconfig.local is undeployed

Images Used:

  - fedora40 from https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2
  - debian12 from https://cloud.debian.org/images/cloud/bookworm/20240717-1811/debian-12-generic-amd64-20240717-1811.qcow2
  - debian11 from https://cloud.debian.org/images/cloud/bullseye/20240717-1811/debian-11-generic-amd64-20240717-1811.qcow2
  - debian10 from https://cloud.debian.org/images/cloud/buster/20240703-1797/debian-10-generic-amd64-20240703-1797.qcow2
  - NoValidate from https://cloud.debian.org/images/cloud/buster/20240703-1797/debian-10-generic-amd64-20240703-1797.qcow2
```

- Virtual Machine Manager Screenshot

This shows a pre-existing `salt.local` VM that is not a part of a lvlabs managed lab along with the one deployed in the shell snippets above named `salt.local_lvlab-example`.

In this case `lvlab-example` is the name of my lvlab environment.

![VirtManagerExample](https://github.com/user-attachments/assets/3dd4c250-40d5-441c-9c64-b463b21ac0ef)


```bash
# Destroy the salt.local VM in the lvlab-example environment
(lvlab) crow@laptop01:~/repos/github/memblin/lvlab-examples$ lvlab destroy salt.local
Are you sure you want to destroy salt.local? [y/N]: y
Forcefully shutting down salt.local
Undefining salt.local
Removing file /var/lib/libvirt/images/lvlab/lvlab-example/salt.local/disk0.qcow2.
Removing file /var/lib/libvirt/images/lvlab/lvlab-example/salt.local/network-config.
Removing file /var/lib/libvirt/images/lvlab/lvlab-example/salt.local/meta-data.
Removing file /var/lib/libvirt/images/lvlab/lvlab-example/salt.local/user-data.
Removing file /var/lib/libvirt/images/lvlab/lvlab-example/salt.local/cidata.iso.
Removing machine directory /var/lib/libvirt/images/lvlab/lvlab-example/salt.local.
Destruction appears successful for salt.local.
```
