### PR TITLE
feat: allow custom images with naming standard

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+# .github/release.yml
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: New Features
+      labels:
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"

--- a/docs/Lvlab.example.yml
+++ b/docs/Lvlab.example.yml
@@ -83,3 +83,13 @@ images:
     checksum_url: https://cloud.debian.org/images/cloud/buster/20240703-1797/SHA512SUMS
     checksum_type: sha512
     network_version: 1
+  # Custom images should follow a specific naming standard of $(--os-variant value)-$(ImageName)
+  # The ImageName can be free-form but the start of the name must align with a valid --os-variant
+  # value or the virt-install command will fail. See examples below, two debian12 based images
+  # with varied software installed.
+  debian12-salt:
+    image_url: http://192.168.122.1:8080/cloud_images/debian-12-salt-20250121-0215.qcow2
+    network_version: 2
+  debian12-vault:
+    image_url: http://192.168.122.1:8080/cloud_images/debian-12-vault-20250121-0716.qcow2
+    network_version: 2

--- a/docs/Walkthrough.md
+++ b/docs/Walkthrough.md
@@ -52,6 +52,39 @@ there is no need to duplicate images for multiple environments.
 
 It's cleanup is also manual for now.
 
+### Image Naming
+
+To enable the use of custom images or multiple versions of the same OS version
+we have introudced a naming standard. (Added v0.2.2)
+
+Images should be named: `$(os_variant)-$(whatever_you_want)`
+
+We split on the hyphen and pass the os_variant to the virt-install command as
+the `--os-variant` parameter.
+
+These are valid examples:
+
+- debian12-CustomImage
+- debian12-generic-amd64-20240717-1811
+- fedora40-idM-v0.1.3
+
+You can list the available options on a specific Libvirt host with:
+
+```bash
+# virt-install wrapper for osinfo-query
+virt-install --os-variant list
+
+# Or right to osinfo-query
+osinfo-query os
+```
+
+This value is also parsed to determine which `/etc/cloud/templates/hosts.*`
+template should be updated which ensures `/etc/hosts` changes made during
+cloud-init will persist.
+
+There are still some shortcomings with custom image checksuming that
+will be handled in a future release.
+
 ## status
 
 Read the config and query libvirt for VM status for each VM in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tkc-lvlab"
-version = "0.2.1"
+version = "0.2.2"
 description = "The Libvirt Labs project provides the `lvlab` Python application which can be used to manage Libvirt based development environments in a familiar way."
 authors = ["Chris Row <1418370+memblin@users.noreply.github.com>"]
 readme = "README.md"


### PR DESCRIPTION
  - Add github release.yml to try out auto-release notes
  - Add image naming standard info to the Lvlab.example.yml
  - Add image naming standard info to the Walkthrough
  - Match on os.lower().startswith instead of exact match for the template_file_mapping
  - Bump patch version

Closes #46 