### PR TITLE
feat: Allow for multiple versions of Debian cloud-images checksum files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tkc-lvlab"
-version = "0.2.2"
+version = "0.2.3"
 description = "The Libvirt Labs project provides the `lvlab` Python application which can be used to manage Libvirt based development environments in a familiar way."
 authors = ["Chris Row <1418370+memblin@users.noreply.github.com>"]
 readme = "README.md"

--- a/tkc_lvlab/utils/images.py
+++ b/tkc_lvlab/utils/images.py
@@ -44,12 +44,15 @@ class CloudImage:
         if self.checksum_url:
             # Debian 10, 11, and 12 use a checksum file name that conflicts
             # with one another so we need to put a suffix on the checksum file.
+            #
+            # A simple version suffix here was not enough. Version updates
+            # became a problem due to overwriting the checksum file. We chose
+            # to use the whole image file name to ensure uniqueness.
             match = re.search(r"debian-(\d+)", self.filename.lower())
             if match:
-                version = match.group(1)
                 checksum_filename = (
-                    os.path.basename(urlparse(self.checksum_url).path)
-                    + f".debian{version}"
+                    f"{self.filename.replace('qcow2', '')}"
+                    + os.path.basename(urlparse(self.checksum_url).path)
                 )
                 self.checksum_fpath = os.path.join(
                     os.path.expanduser(self.image_dir), checksum_filename


### PR DESCRIPTION
This PR contains content to update the way we handle the filename used for storing the checksum file associated with an upstream Debian cloud-image.

Debian cloud-images checksum files are always named `SHA512SUMS` in the repository but are nested in a versioned directory with the image files. Previously we were downloading the checksum file and appending the generic Debian version such as `debian12` or `debian11` as the checksum file name so we could have both a Debian 11 and 12 image.

This approach broke down as soon as we needed to allow more than one Debian 12 cloud-image because of an on-disk layout like this causing overwrites of the checksum file leading to checksum validation failures.

```console
-rw-r--r--. 1 qemu qemu  357079552 Aug  8 20:37 debian-11-generic-amd64-20240717-1811.qcow2
-rw-r--r--. 1 user user  358902784 Jan 15 22:18 debian-11-generic-amd64-20241202-1949.qcow2
-rw-r--r--. 1 qemu qemu  439956480 Aug  8 20:14 debian-12-generic-amd64-20240717-1811.qcow2
-rw-r--r--. 1 qemu qemu  445527552 Jan 15 22:17 debian-12-generic-amd64-20250115-1993.qcow2
-rw-r--r--. 1 user user       7354 Aug  8 20:37 SHA512SUMS.debian11
-rw-r--r--. 1 user user       7698 Aug  8 20:35 SHA512SUMS.debian12
```

After this update our files should be stored in a much more unique way that will allow us to maintain as many versions of a Debian cloud-image as we need to for our own personal testing needs.

```console
-rw-r--r--. 1 user user  358902784 Jan 15 22:18 debian-11-generic-amd64-20241202-1949.qcow2
-rw-r--r--. 1 user user       7354 Feb  2 08:01 debian-11-generic-amd64-20241202-1949.SHA512SUMS
-rw-r--r--. 1 qemu qemu  444917760 Feb  2 08:06 debian-12-generic-amd64-20250112-1990.qcow2
-rw-r--r--. 1 user user       7698 Feb  2 08:06 debian-12-generic-amd64-20250112-1990.SHA512SUMS
-rw-r--r--. 1 qemu qemu  445527552 Jan 15 22:17 debian-12-generic-amd64-20250115-1993.qcow2
-rw-r--r--. 1 user user       7698 Feb  2 08:01 debian-12-generic-amd64-20250115-1993.SHA512SUMS
```

closes #45 

## Deployment Ramifications

For any existing deployment a fresh `lvlab init` will be necessary to download the original checksum files into the new file names. No Lvlab.yml config changes should be required.

A manual clean-up of the checksum files with the legacy filename will also be necessary to ensure they are removed before we forget where they came from.

## Commit Message

  - Change CloudImage self.checksum_fpath generation for Debian cloud-images to create a filename with guaranteed uniqueness by using the full image name in the generated self.checksum_fpath.
  - Remove unused version variable from CloudImage class self.checksum_url processing logic tree
  - Patch version bump for functionality change