### PR TITLE
feat: osinfo is rocky9 not rockylinux9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tkc-lvlab"
-version = "0.2.3"
+version = "0.2.4"
 description = "The Libvirt Labs project provides the `lvlab` Python application which can be used to manage Libvirt based development environments in a familiar way."
 authors = ["Chris Row <1418370+memblin@users.noreply.github.com>"]
 readme = "README.md"

--- a/tkc_lvlab/utils/libvirt.py
+++ b/tkc_lvlab/utils/libvirt.py
@@ -149,7 +149,14 @@ class Machine:
         # file in /etc/cloud/templates too.
         template_file_mapping = {
             "hosts.debian.tmpl": ["debian", "ubuntu"],
-            "hosts.redhat.tmpl": ["fedora", "rockylinux", "almalinux", "rhel"],
+            "hosts.redhat.tmpl": [
+                "fedora",
+                "rocky",
+                "rockylinux",
+                "alma",
+                "almalinux",
+                "rhel",
+            ],
         }
         template_fpath = None
 


### PR DESCRIPTION
Add rocky and alma as shortnames for rockylinux and almalinux to align with osinfo.