### PR TITLE
docs: add CLAUDE.md and TODO.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+`tkc-lvlab` (binary: `lvlab`) is a Click-based CLI that manages local libvirt+QEMU lab VMs from a single declarative YAML manifest (`Lvlab.yml`). It is meant for end-to-end integration testing of configuration-management code (Salt, Ansible, etc.) on a developer workstation — not for production VM management.
+
+A run of `lvlab init` followed by `lvlab up <vm_name>` will:
+1. Download and verify a cloud image (checksum + optional GPG of the checksum file).
+2. Create a qcow2 disk that uses the cloud image as a backing file (via `qemu-img`).
+3. Render cloud-init `meta-data`, `user-data`, and `network-config` from Jinja2 templates, pack them into a `cidata.iso` (built in-process with `pycdlib`), and attach it as a cdrom.
+4. Shell out to `virt-install` to define and launch the domain.
+
+Because state lives in libvirt + on-disk qcow2 files, **bugs here can damage real VMs the developer cares about.** Treat destructive paths (`destroy`, `down`, snapshot `delete`) with care — there is no separate test hypervisor.
+
+## Build / dev / lint commands
+
+This project uses Poetry. There is **no test suite yet** — `tests/__init__.py` is empty. Don't claim something is "tested" because CI is green; CI only runs pre-commit.
+
+```bash
+# Install deps (needs libvirt-dev / pkg-config on the host for libvirt-python)
+poetry install
+
+# Run the CLI from a checkout without installing
+poetry run lvlab --help
+
+# Build a wheel into ./dist
+poetry build
+
+# Format + basic hygiene (black, trailing whitespace, EOF, yaml check)
+pre-commit run --all-files
+```
+
+Python is pinned to `^3.10` in `pyproject.toml`. The release workflow builds with 3.13.
+
+## Architecture
+
+The code is organized around the `Lvlab.yml` manifest. Read `parse_config()` first — every command starts there.
+
+`Lvlab.yml` has two top-level sections:
+- `environment[0]` — exactly one environment with `name`, `libvirt_uri`, `config_defaults` (cpu/memory/disks/interfaces/cloud_init that apply to every machine), and a list of `machines`.
+- `images` — a dict of named cloud images (URL + checksum + GPG + cloud-init network schema version).
+
+### Core flow (cli.py → utils/)
+
+`tkc_lvlab/cli.py` defines the Click command group. Every command follows the same shape:
+
+1. `parse_config()` returns `(environment, images, config_defaults, machines)`.
+2. `get_machine_by_vm_name(machines, vm_name)` finds the manifest entry.
+3. `Machine(machine_config, environment, config_defaults)` merges defaults into the machine and exposes operations against libvirt.
+4. For `up`, a `CloudImage` + `VirtualDisk` + `CloudInitIso` are constructed alongside the `Machine`.
+
+`tkc_lvlab/utils/libvirt.py` — `Machine` is the central object. Key things to know:
+- The libvirt domain name is **not** `vm_name`; it's `f"{vm_name}_{environment_name}"` (see `self.libvirt_vm_name`). This namespacing is what lets multiple lvlab environments coexist on one hypervisor. Anything that looks up a domain by name must use `libvirt_vm_name`.
+- `Machine.__init__` merges `config_defaults` into the machine dict (interfaces, disks, and top-level keys). When adding a new configurable field, follow that same pattern instead of reading from `config_defaults` at call sites.
+- `Machine.deploy()` shells out to `virt-install`. The `--os-variant` value is derived by splitting `self.os` on `-` and taking the first segment — this is why custom images must be named `{os_variant}-{anything}` (see `docs/Walkthrough.md` "Image Naming").
+- `Machine.cloud_init()` is also where per-machine `runcmd` gets composed with the defaults (`runcmd_ignore_defaults: true` skips defaults), and where the manifest-wide `/etc/hosts` snippet is injected at the **top** of `runcmd` so it lands before anything that does DNS-ish work.
+
+`tkc_lvlab/utils/cloud_init.py` — three dataclasses (`NetworkConfig`, `MetaData`, `UserData`) each render one Jinja template from `tkc_lvlab/templates/`. `CloudInitIso` uses `pycdlib` to build an ISO9660 + Joliet + Rock Ridge image with the three files at the names cloud-init's NoCloud datasource expects (`meta-data`, `user-data`, `network-config`). `UserData.__post_init__` will read an SSH public key from disk if `cloud_init.pubkey` looks like a path; otherwise it treats the value as a literal key.
+
+`tkc_lvlab/utils/images.py` — `CloudImage` knows how to download, GPG-verify the checksum file, and checksum-verify the image. Two non-obvious bits:
+- Debian's `SHA512SUMS` file is the **same filename** across releases, so Debian images get a per-image-prefix checksum filename to avoid clobber when multiple Debian versions are configured. The detector is a regex on `debian-(\d+)` in the image filename.
+- The checksum file parser handles both Fedora's `SHA256 (file) = hash` format and Debian's `hash  file` format.
+- When GPG verification succeeds, the verified plaintext is written to `<checksum>.verified` and subsequent operations prefer that file.
+
+`tkc_lvlab/utils/vdisk.py` — `VirtualDisk` is a thin wrapper around `qemu-img create -b <cloud_image>` for qcow2 backing-file disks. One disk per entry in `machine.disks`, named `disk{index}.qcow2`.
+
+`tkc_lvlab/config.py` — `parse_config()` (manifest loader) and `generate_hosts()` (renders `templates/hosts.j2`, used both for stdout output by the `hosts` command and for the in-VM `/etc/hosts` cloud-init snippet — see `heredoc` parameter for the dual-mode rendering).
+
+### Templates
+
+`tkc_lvlab/templates/` contains the Jinja2 templates loaded via `PackageLoader("tkc_lvlab")`. They are packaged into the wheel through the `include = ["tkc_lvlab/templates/*.j2"]` entry in `pyproject.toml` — if you add a new template, make sure it matches that glob or it won't ship.
+
+- `network-config.v1.j2` and `network-config.v2.j2` — selected by `image.network_version` (1 = ENI-style, 2 = netplan-style). Each image entry in the manifest pins which version cloud-init should emit.
+- `hosts.j2` renders both stdout-friendly output and a `cat <<EOF` heredoc form for runcmd injection.
+
+### Host /etc/hosts handling inside the guest
+
+`Machine.cloud_init` appends two heredocs to `runcmd`: one for `/etc/hosts` and one for the distro-appropriate `/etc/cloud/templates/hosts.{debian,redhat}.tmpl`. The template choice is a startswith-match on `self.os` against `template_file_mapping` (lowercased). If you add support for a new distro family, extend that mapping or `cloud_init()` will raise `ValueError`.
+
+## Conventions and gotchas
+
+- **Line length is 150** (`.pylintrc`). black is configured by default (88) via pre-commit; both are in effect — black formats, pylint just won't yell about long lines. If you see a line over 88, black either accepted it (string literal, URL, etc.) or it hasn't been run.
+- **No type-hint discipline yet.** `docs/Design.md` calls this out as a known inconsistency; don't refactor existing signatures just to add annotations unless asked.
+- The CLI mixes business logic into `cli.py` (e.g. orchestration of vdisk creation, ISO writing, deploy). When extending, prefer adding methods to the relevant `Machine` / `CloudImage` / etc. class rather than growing the command body.
+- `parse_config()` is called repeatedly (e.g. once in the command, again inside `Machine.cloud_init` to regenerate the hosts list). Cheap because it's just a file read, but keep that in mind if you ever cache state.
+- Several `destroy`/cleanup paths leave files behind on purpose or by oversight — see `docs/Walkthrough.md`. Don't "fix" this without checking whether the user relied on it.
+- A sibling project `lvscripts-py` (allowed via `.claude/settings.local.json`) is referenced for porting advanced features into this repo. Don't import from it; read it and adapt.
+
+## Releasing
+
+Tagging `X.Y.Z` on `main` triggers `.github/workflows/build-release.yml`, which runs `poetry build` and uploads the wheel to a GitHub release. Bump `version` in `pyproject.toml` to match the tag before pushing it, or the artifact filename won't line up with the release.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,177 @@
+# TODO
+
+Roadmap for the next few sessions. Phases are ordered by dependency, not strict
+calendar. Phase 3 onward is blocked until the Claude session is restarted so
+the `.claude/settings.local.json` grant for `lvscripts-py` takes effect.
+
+---
+
+## Phase 1 — Migrate Poetry → uv, refresh deps, add Python matrix
+
+**Goal:** one-command env setup with `uv`, a real `uv.lock`, and a build/test
+matrix that runs on Python 3.11, 3.12, 3.13, and 3.14.
+
+- [ ] Use `uv_build` as the PEP 517 build backend. **No hatchling, no
+      setuptools — uv all the way.** `[build-system]` becomes
+      `requires = ["uv_build>=0.5"]` / `build-backend = "uv_build"` (pin to
+      whatever uv ships current at migration time).
+- [ ] Rewrite `pyproject.toml`:
+  - [ ] Replace `[tool.poetry]` with PEP 621 `[project]` (name, version,
+        description, authors, readme, license, classifiers, `requires-python = ">=3.11"`).
+  - [ ] Move `[tool.poetry.dependencies]` → `[project.dependencies]`.
+  - [ ] Move `[tool.poetry.scripts]` → `[project.scripts]`.
+  - [ ] Drop the Poetry-only `include = ["tkc_lvlab/templates/*.j2"]`.
+        `uv_build` ships package data by default for files inside the import
+        package, so `tkc_lvlab/templates/*.j2` is picked up automatically.
+        Verify with `uv build && unzip -l dist/*.whl | grep templates`.
+        If anything needs explicit inclusion, configure it under
+        `[tool.uv.build-backend]` per uv docs — **do not** reach for hatch
+        or setuptools tables.
+  - [ ] Add a `[dependency-groups]` entry (PEP 735) with `pytest`,
+        `pytest-cov`, and any other test/lint extras. Install via
+        `uv sync --group dev`.
+- [ ] Remove `poetry.lock`; generate `uv.lock` via `uv lock`.
+- [ ] Remove `requirements.txt` (only used by old CI). If we still want a
+      pinned export, generate it with `uv export --format requirements-txt`.
+- [ ] Refresh all dep versions to current latest-compatible. Spot-check:
+  - [ ] `libvirt-python` — confirm a wheel exists for 3.13 / 3.14.
+  - [ ] `pycdlib`, `python-gnupg` — same.
+  - [ ] `click`, `jinja2`, `requests`, `tqdm`, `pyyaml` — bump as resolver allows.
+- [ ] Update `.github/workflows/build-release.yml`:
+  - [ ] Replace `pip install --user poetry; poetry build` with
+        `uv build` (using `astral-sh/setup-uv` action).
+  - [ ] Drop `pip install --user -r requirements.txt`.
+- [ ] Update `README.md` install instructions:
+  - [ ] `uv tool install tkc-lvlab` as the recommended path.
+  - [ ] Or local dev: `uv sync && uv run lvlab --help`.
+  - [ ] Drop the manual venv + pip recipe (or move it to an "Alternatives"
+        section).
+- [ ] Update `CLAUDE.md` "Build / dev / lint commands" section to show `uv`.
+- [ ] Verify `pre-commit` still works after the migration (it's independent
+      of the build backend; mostly checking nothing references Poetry).
+
+### Phase 1.5 — Test infrastructure (lands together with Phase 1 matrix)
+
+- [ ] Add `.github/workflows/test.yml`:
+  - [ ] Matrix: `python-version: ['3.11', '3.12', '3.13', '3.14']`.
+  - [ ] Job step: `uv sync --all-extras && uv run pytest -m "not integration"`.
+  - [ ] Mark Python 3.14 `continue-on-error: true` until libvirt-python ships
+        a 3.14 wheel (revisit when it does).
+- [ ] Create `tests/conftest.py` with the safety scaffolding (see
+      "Cross-cutting safety rules" below).
+- [ ] Seed a small set of pure-unit tests (no libvirt, no qemu-img) to prove
+      the matrix runs end-to-end before we start writing real coverage:
+  - [ ] `parse_config()` happy / missing-file / bad-yaml cases.
+  - [ ] `parse_file_from_url()`.
+  - [ ] `CloudImage._parse_checksum_file()` — both Fedora and Debian formats,
+        including the `.verified` swap.
+  - [ ] `UserData._is_valid_ssh_public_key()`.
+  - [ ] `Machine.libvirt_vm_name` construction (`vm_name_environment`).
+- [ ] Mark anything that touches libvirt or `qemu-img` with
+      `@pytest.mark.integration`; require `LVLAB_INTEGRATION=1` to opt in
+      and never enable it in CI.
+
+---
+
+## Phase 2 — Documentation pass after uv migration
+
+- [ ] `docs/Walkthrough.md` — replace any `poetry build` / pip-install lines
+      with uv equivalents.
+- [ ] `docs/CONTRIBUTING.md` (if it references Poetry — verify).
+- [ ] `README.md` Requirements section is libvirt-focused (good) but confirm
+      no Poetry remnants.
+
+---
+
+## Phase 3 — Survey `lvscripts-py` (blocked on session restart)
+
+The sibling repo at `/home/tkcadmin/repos/github/memblin/lvscripts-py` becomes
+readable after the next Claude restart (the `additionalDirectories` grant we
+just added).
+
+- [ ] Read `lvscripts-py/CLAUDE.md` and `README.md` to understand intent.
+- [ ] Inventory the public surface: what scripts ship, what flags they take,
+      what they do top-to-bottom.
+- [ ] Map functional overlap with `tkc-lvlab`:
+  - cloud-image download/verify
+  - cloud-init ISO build
+  - qcow2 backing-disk creation
+  - virt-install invocation
+  - libvirt domain lifecycle (define / start / shutdown / destroy / undefine)
+- [ ] Identify capabilities lvlab does **not** have today, especially:
+  - [ ] One-off `createvm <name> --os ... --memory ... --disk ...` style entry
+        without needing an `Lvlab.yml`.
+  - [ ] Anything around image building / customization, NAT/bridge wiring,
+        or post-create provisioning.
+- [ ] Decide on per-feature disposition: **port**, **adapt**, **skip**, or
+      **leave to lvscripts**.
+
+---
+
+## Phase 4 — Merge `createvm` / `destroyvm` into `lvlab`
+
+Outcome: one package providing both the lab manifest workflow and one-off VM
+creation, sharing the same `Machine` / `CloudImage` / `VirtualDisk` /
+`CloudInitIso` machinery.
+
+- [ ] CLI shape:
+  - [ ] `lvlab vm create <name> [--os …] [--memory …] [--cpu …] [--disk …] [--network …] [--pubkey …]` — manifest-less one-off.
+  - [ ] `lvlab vm destroy <name>` — one-off teardown (no Lvlab.yml lookup).
+  - [ ] Existing `lvlab up` / `lvlab destroy` / `lvlab status` continue to be
+        manifest-driven and unchanged.
+  - [ ] Expose `createvm` and `destroyvm` as additional `[project.scripts]`
+        thin shims to the same Click commands (for muscle memory from users
+        coming from lvscripts).
+- [ ] Refactor where the merge exposes duplication:
+  - [ ] If lvscripts has a cleaner abstraction we want, port it and make
+        manifest-driven commands use it too — don't keep two implementations.
+- [ ] Naming guard: one-off VMs should still be namespaced. Either reuse
+      `{vm_name}_{environment}` with a sentinel environment like `_oneoff`,
+      or introduce a distinct prefix like `oneoff-{vm_name}`. **Decide
+      explicitly** — this affects how `status`/listing finds them.
+- [ ] Tests for both code paths (manifest and one-off) share the same safety
+      fixture (see below).
+- [ ] Docs: extend `README.md` and `docs/Walkthrough.md` with the one-off
+      workflow. Add a section explaining when to use which.
+
+---
+
+## Cross-cutting safety rules (apply to every phase that writes tests)
+
+**Hard rule: no test, fixture, or teardown step ever touches a libvirt
+domain, qcow2 file, or ISO whose name does not start with the per-run test
+prefix.** Existing developer VMs on the same hypervisor must be invisible to
+the test suite.
+
+- [ ] `tests/conftest.py` exports:
+  - [ ] `LVLAB_TEST_PREFIX` — generated once per session:
+        `f"lvlab-test-{epoch_ms}-{random4}-"` (epoch + short random to avoid
+        collisions across parallel runs).
+  - [ ] `make_test_name(base) -> str` — the only sanctioned way for tests to
+        name a resource. Returns `f"{LVLAB_TEST_PREFIX}{base}"`.
+  - [ ] `assert_owned_by_test(name) -> None` — raises if `name` does not
+        start with `LVLAB_TEST_PREFIX`. Called before every destructive op
+        in test helpers.
+  - [ ] A session-scoped teardown that lists libvirt domains *filtered by
+        the prefix* and reaps any that survived a crashing test. **Never
+        list all domains; only ones matching the prefix.**
+- [ ] Same prefix applies to:
+  - [ ] On-disk paths (`disk_image_basedir` for tests must be a temp dir,
+        not the developer's shared `~/.local/lvlab/...`).
+  - [ ] Cloud-init ISOs and the per-VM config directory.
+- [ ] Add a lint/grep check (or pytest plugin) that fails CI if a test calls
+      `virDomain.undefine()` / `destroy()` / `os.remove()` on a name that
+      didn't come from `make_test_name`.
+- [ ] Integration tests **must** use a dedicated `libvirt_uri` or at least a
+      dedicated network and storage pool so cleanup can be scoped further.
+
+---
+
+## Decisions still open (call these out before Phase 4 lands)
+
+1. ~~Build backend~~ — decided: `uv_build`. No hatchling, no setuptools.
+2. One-off VM namespacing: sentinel environment `_oneoff` vs distinct prefix.
+3. Whether to keep `createvm` / `destroyvm` as separate console_scripts, or
+   only expose `lvlab vm create` / `lvlab vm destroy`.
+4. Whether to drop Python 3.10 (currently `^3.10` in `pyproject.toml`) when
+   moving to 3.11+ as the floor. Tentative: yes, drop it.


### PR DESCRIPTION
CLAUDE.md captures the architecture, manifest-driven flow, and non-obvious gotchas (libvirt domain namespacing, --os-variant parsing, Debian checksum filename collision, distro-template mapping) so future Claude sessions can get productive without re-reading the whole tree.

TODO.md captures the roadmap: Poetry → uv_build migration, Python 3.11-3.14 matrix, test-safety scaffolding (prefix every test resource, guard every destructive call), and the planned merge of lvscripts-py createvm / destroyvm functionality behind an `lvlab vm …` subcommand group.