### PR TITLE
build: configure pytest-cov to emit coverage.xml for SonarQube

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,17 @@ dev = [
     "pytest>=8",
     "pytest-cov>=5",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=tkc_lvlab --cov-report=xml --cov-report=term"
+
+[tool.coverage.run]
+source = ["tkc_lvlab"]
+branch = true
+
+[tool.coverage.xml]
+output = "coverage.xml"
+
+[tool.coverage.report]
+show_missing = true


### PR DESCRIPTION
## Summary

- Wire `pytest-cov` into `pyproject.toml` so `uv run pytest` emits a Cobertura-format `coverage.xml` at the repo root.
- Sonar's `sonar.python.coverage.reportPaths=coverage.xml` (already in `sonar-project.properties`) now resolves to a real report instead of warning.

## Why

`pytest>=8` and `pytest-cov>=5` were already in the dev dep group, but nothing told pytest to load the plugin or emit XML. The Sonar Cobertura sensor logged `No report was found for sonar.python.coverage.reportPaths using pattern coverage.xml` on every scan. This wires it up so coverage data starts flowing once tests exist.

## What changed

`pyproject.toml` (one file, additive only):
- `[tool.pytest.ini_options]` → `testpaths = ["tests"]`, `addopts = "--cov=tkc_lvlab --cov-report=xml --cov-report=term"`
- `[tool.coverage.run]` → `source = ["tkc_lvlab"]`, `branch = true`
- `[tool.coverage.xml]` → `output = "coverage.xml"` (matches the sonar config)
- `[tool.coverage.report]` → `show_missing = true`

Commit: `c085ce3 build: configure pytest-cov to emit coverage.xml for SonarQube`

## Test plan

- [x] `uv sync --group dev` — clean install
- [x] `uv run pytest` — writes `coverage.xml` (Cobertura, 823 stmts, 0% today since `tests/` is empty besides `__init__.py`)
- [x] `uv run pysonar -t "$SONARQUBE_CLI_TOKEN" --sonar-host-url "$SONARQUBE_CLI_SERVER"` — Cobertura sensor now logs `Parsing report '.../coverage.xml'` and the quality gate stays `OK` / CaYC-compliant
- [x] `pre-commit run --all-files` (executed via pre-commit hook on the commit; black/yaml skipped, no matching files)

## Risk

- Low. Config-only change, additive. No behavior change to `lvlab` runtime, no touch to libvirt/VM paths.
- One caveat: `pytest` exits **5** ("no tests collected") while `tests/` is empty. Not breaking anything today — no CI job runs `pytest` (only `pre-commit.yml` and `build-release.yml`). When a `pytest` CI job is added later, gate it on tests existing or treat exit 5 as success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)