### PR TITLE
feat: add centralized stdlib logging facade

### DIFF
--- a/tkc_lvlab/_logging.py
+++ b/tkc_lvlab/_logging.py
@@ -1,0 +1,95 @@
+"""Centralized logging configuration for the lvlab CLI.
+
+The CLI previously emitted diagnostic output via a mix of ``print()`` and
+``click.echo()`` calls. This module provides a single project-rooted logger
+hierarchy (``tkc_lvlab``) so that diagnostic / informational / error output
+can be routed consistently to stderr while leaving user-facing CLI output
+(``click.echo``) on stdout.
+
+Usage::
+
+    from tkc_lvlab._logging import get_logger
+
+    logger = get_logger(__name__)
+    logger.info("Doing the thing")
+
+The root group in :mod:`tkc_lvlab.cli` calls :func:`configure_logging` once
+at startup, translating ``-v`` / ``-q`` into a level on the project root
+logger. Module-level loggers obtained via :func:`get_logger` inherit that
+level through the standard ``logging`` propagation chain.
+"""
+
+import logging
+import sys
+
+#: Root logger name for the whole project. All :func:`get_logger` calls
+#: return descendants of this logger, so a single ``setLevel`` on it
+#: controls verbosity for every module.
+ROOT_LOGGER_NAME = "tkc_lvlab"
+
+#: Format string used by the stderr handler. ``%(name)s`` makes it easy to
+#: see which module produced a message once Phase 2 brings more call sites.
+LOG_FORMAT = "%(asctime)s %(levelname)-7s %(name)s: %(message)s"
+
+#: Sentinel attribute set on the stderr handler so repeat invocations of
+#: :func:`configure_logging` (e.g. from tests) replace it cleanly instead
+#: of stacking duplicate handlers.
+_HANDLER_ATTR = "_lvlab_stderr_handler"
+
+
+def configure_logging(verbosity: int = 0, quiet: bool = False) -> logging.Logger:
+    """Configure the project root logger.
+
+    Args:
+        verbosity: ``-v`` count from the CLI. ``0`` is the default (WARNING),
+            ``1`` (``-v``) raises to INFO, ``2`` or more (``-vv``) raises to
+            DEBUG.
+        quiet: ``-q`` flag from the CLI. When true the logger is pinned to
+            ERROR regardless of ``verbosity`` so destructive paths still
+            surface failures even when the user has silenced chatter.
+
+    Returns:
+        The project root logger, already configured. Callers normally do not
+        need this — :func:`get_logger` is the usual entry point.
+    """
+    if quiet:
+        level = logging.ERROR
+    elif verbosity >= 2:
+        level = logging.DEBUG
+    elif verbosity == 1:
+        level = logging.INFO
+    else:
+        level = logging.WARNING
+
+    root = logging.getLogger(ROOT_LOGGER_NAME)
+    root.setLevel(level)
+    # Keep our hierarchy self-contained; don't double-log through the
+    # global root if some downstream lib configures it.
+    root.propagate = False
+
+    # Replace any prior handler we installed so repeat calls (tests, REPL)
+    # don't stack duplicates. Leave handlers added by other code alone.
+    for handler in list(root.handlers):
+        if getattr(handler, _HANDLER_ATTR, False):
+            root.removeHandler(handler)
+
+    handler = logging.StreamHandler(stream=sys.stderr)
+    handler.setLevel(level)
+    handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    setattr(handler, _HANDLER_ATTR, True)
+    root.addHandler(handler)
+
+    return root
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a child logger under the project root.
+
+    ``name`` is normally ``__name__`` from the calling module. If the caller
+    is already inside the ``tkc_lvlab`` package the returned logger is its
+    standard dotted child; otherwise the name is grafted under the project
+    root so log records still pick up our configured handler/level.
+    """
+    if name == ROOT_LOGGER_NAME or name.startswith(ROOT_LOGGER_NAME + "."):
+        return logging.getLogger(name)
+    return logging.getLogger(f"{ROOT_LOGGER_NAME}.{name}")

--- a/tkc_lvlab/cli.py
+++ b/tkc_lvlab/cli.py
@@ -6,6 +6,7 @@ import sys
 import click
 import libvirt
 
+from ._logging import configure_logging, get_logger
 from .config import parse_config, generate_hosts
 from .utils.cloud_init import CloudInitIso, MetaData, NetworkConfig, UserData
 from .utils.libvirt import (
@@ -18,10 +19,26 @@ from .utils.vdisk import VirtualDisk
 from .utils.images import CloudImage
 
 
+logger = get_logger(__name__)
+
+
 @click.group(context_settings=dict(help_option_names=["-h", "--help"]))
-def run():
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    help="Increase log verbosity (-v for INFO, -vv for DEBUG).",
+)
+@click.option(
+    "-q",
+    "--quiet",
+    is_flag=True,
+    default=False,
+    help="Suppress informational logs (ERROR only). Overrides -v.",
+)
+def run(verbose, quiet):
     """A command-line tool for managing VMs."""
-    pass
+    configure_logging(verbosity=verbose, quiet=quiet)
 
 
 @click.command()
@@ -42,7 +59,7 @@ def cloudinit(vm_name):
     try:
         environment, images, config_defaults, machines = parse_config()
     except TypeError as e:
-        click.echo("Could not parse config file.")
+        logger.error("Could not parse config file.")
         sys.exit(1)
 
     machine = Machine(
@@ -65,7 +82,7 @@ def destroy(vm_name, force=False):
     try:
         environment, _, config_defaults, machines = parse_config()
     except TypeError as e:
-        click.echo("Could not parse config file.")
+        logger.error("Could not parse config file.")
         sys.exit(1)
 
     machine_config = get_machine_by_vm_name(machines, vm_name)
@@ -87,18 +104,21 @@ def destroy(vm_name, force=False):
                             f"Destruction appears successful for {machine.vm_name}."
                         )
                     else:
-                        click.echo(
-                            f"Destruction appears to have failed for {machine.vm_name}."
+                        logger.error(
+                            "Destruction appears to have failed for %s.",
+                            machine.vm_name,
                         )
 
                 else:
                     click.echo(f"Destruction aborted for {machine.vm_name}.")
             else:
-                click.echo(
-                    f"Machine {machine.vm_name} is not deployed to the configured in {libvirt_endpoint}."
+                logger.warning(
+                    "Machine %s is not deployed to the configured in %s.",
+                    machine.vm_name,
+                    libvirt_endpoint,
                 )
     else:
-        click.echo(f"Machine not found in manifest: {vm_name}")
+        logger.error("Machine not found in manifest: %s", vm_name)
 
 
 @click.command()
@@ -108,7 +128,7 @@ def down(vm_name):
     try:
         environment, _, config_defaults, machines = parse_config()
     except TypeError as e:
-        click.echo("Could not parse config file.")
+        logger.error("Could not parse config file.")
         sys.exit(1)
 
     machine_config = get_machine_by_vm_name(machines, vm_name)
@@ -129,7 +149,7 @@ def down(vm_name):
                     machine.shutdown(environment.get("libvirt_uri", "qemu:///session"))
                     > 0
                 ):
-                    click.echo(f"Shutdown appears to have failed.")
+                    logger.error("Shutdown appears to have failed.")
                 else:
                     click.echo(
                         f"Shutdown appears successful. The virtual machine may take a short time to complete shutdown."
@@ -140,7 +160,7 @@ def down(vm_name):
                 )
 
     else:
-        click.echo(f"Machine {vm_name} not found in manifest.")
+        logger.error("Machine %s not found in manifest.", vm_name)
 
 
 @click.command()
@@ -170,7 +190,7 @@ def hosts(append=False, heredoc=False):
     try:
         environment, _, config_defaults, machines = parse_config()
     except TypeError as e:
-        click.echo("Could not parse config file.")
+        logger.error("Could not parse config file.")
         sys.exit()
 
     hosts_snippet = generate_hosts(environment, config_defaults, machines)
@@ -178,11 +198,11 @@ def hosts(append=False, heredoc=False):
     if append:
         etc_hosts = "/etc/hosts"
         if os.access(etc_hosts, os.W_OK):
-            click.echo("Appending hosts file snippet to /etc/hosts")
+            logger.info("Appending hosts file snippet to /etc/hosts")
             with open(etc_hosts, "a") as hosts_file:
                 hosts_file.write(hosts_snippet)
         else:
-            click.echo("No write access available for /etc/hosts")
+            logger.error("No write access available for /etc/hosts")
 
     if heredoc:
         hosts_snippet = generate_hosts(
@@ -198,7 +218,7 @@ def init():
     try:
         environment, images, config_defaults, _ = parse_config()
     except TypeError as e:
-        click.echo("Could not parse config file.")
+        logger.error("Could not parse config file.")
         sys.exit()
 
     click.echo()
@@ -212,11 +232,11 @@ def init():
         if image.exists_locally("image"):
             click.echo(f"CloudImage {image.name} exists locally: {image.image_fpath}")
         else:
-            click.echo(f"Attempting to download image: {image.image_url}")
+            logger.info("Attempting to download image: %s", image.image_url)
             if image.download_image():
                 click.echo(f"CloudImage downloaded to {image.image_fpath}")
             else:
-                click.echo("CloudImage download failed")
+                logger.error("CloudImage download failed")
 
         if image.checksum_url_gpg:
             if image.exists_locally(file_type=("checksum_gpg")):
@@ -229,7 +249,7 @@ def init():
                         f"CloudImage checksum GPG file downloaded to {image.checksum_gpg_fpath}"
                     )
                 else:
-                    click.echo(f"CloudImage checksum GPG file download failed")
+                    logger.error("CloudImage checksum GPG file download failed")
 
         if image.checksum_url:
             if image.exists_locally(file_type="checksum"):
@@ -237,27 +257,31 @@ def init():
                     f"CloudImage {image.name} checksum file exists locally: {image.checksum_fpath}"
                 )
             else:
-                click.echo(
-                    f"Attempting to download checksum file URL: {image.checksum_url}"
+                logger.info(
+                    "Attempting to download checksum file URL: %s", image.checksum_url
                 )
                 if image.download_checksum():
                     click.echo(
                         f"CloudImage {image.name} checksum file downloaded to {image.checksum_fpath}"
                     )
                 else:
-                    click.echo("CloudImage {image.name} checksum file download failed")
+                    logger.error(
+                        "CloudImage %s checksum file download failed", image.name
+                    )
 
         if image.checksum_url_gpg and image.exists_locally(file_type=("checksum_gpg")):
             if image.gpg_verify_checksum_file():
                 click.echo(f"CloudImage {image.name} checksum file GPG validation OK")
             else:
-                click.echo(f"CloudImage {image.name} checksum file GPG validation BAD")
+                logger.error(
+                    "CloudImage %s checksum file GPG validation BAD", image.name
+                )
 
         if image.checksum_url and image.exists_locally(file_type=("checksum")):
             if image.checksum_verify_image():
                 click.echo(f"CloudImage {image.name} checksum verification OK")
             else:
-                click.echo(f"CloudImage {image.name} checksum verification BAD")
+                logger.error("CloudImage %s checksum verification BAD", image.name)
 
         click.echo()
 
@@ -275,7 +299,7 @@ def list(vm_name):
     try:
         environment, _, config_defaults, machines = parse_config()
     except TypeError as e:
-        click.echo("Could not parse config file.")
+        logger.error("Could not parse config file.")
         sys.exit(1)
 
     machine_config = get_machine_by_vm_name(machines, vm_name)
@@ -297,11 +321,13 @@ def list(vm_name):
                 else:
                     click.echo(f"No snapshots found for {machine.vm_name}")
             else:
-                click.echo(
-                    f"Machine {machine.vm_name} is not deployed to the configured in {libvirt_endpoint}."
+                logger.warning(
+                    "Machine %s is not deployed to the configured in %s.",
+                    machine.vm_name,
+                    libvirt_endpoint,
                 )
     else:
-        click.echo(f"Machine not found in manifest: {vm_name}")
+        logger.error("Machine not found in manifest: %s", vm_name)
 
 
 @snapshot.command()
@@ -313,7 +339,7 @@ def create(vm_name, snapshot_name, snapshot_description=None):
     try:
         environment, _, config_defaults, machines = parse_config()
     except TypeError as e:
-        click.echo("Could not parse config file.")
+        logger.error("Could not parse config file.")
         sys.exit(1)
 
     machine_config = get_machine_by_vm_name(machines, vm_name)
@@ -335,13 +361,15 @@ def create(vm_name, snapshot_name, snapshot_description=None):
                         f"Snapshot {snapshot_status.getName()} created for {machine.vm_name}"
                     )
                 else:
-                    click.echo(f"Snapshot creation failed for {machine.vm_name}")
+                    logger.error("Snapshot creation failed for %s", machine.vm_name)
             else:
-                click.echo(
-                    f"Machine {machine.vm_name} is not deployed to the configured in {libvirt_endpoint}."
+                logger.warning(
+                    "Machine %s is not deployed to the configured in %s.",
+                    machine.vm_name,
+                    libvirt_endpoint,
                 )
     else:
-        click.echo(f"Machine not found in manifest: {vm_name}")
+        logger.error("Machine not found in manifest: %s", vm_name)
 
 
 @snapshot.command()
@@ -353,7 +381,7 @@ def delete(vm_name, snapshot_name, force=False):
     try:
         environment, _, config_defaults, machines = parse_config()
     except TypeError as e:
-        click.echo("Could not parse config file.")
+        logger.error("Could not parse config file.")
         sys.exit(1)
 
     machine_config = get_machine_by_vm_name(machines, vm_name)
@@ -382,15 +410,19 @@ def delete(vm_name, snapshot_name, force=False):
                 if snapshot_status == 0:
                     click.echo(f"Snapshot deleted for {machine.vm_name}")
                 else:
-                    click.echo(
-                        f"Snapshot deletion failed for {machine.vm_name}: {snapshot_status}"
+                    logger.error(
+                        "Snapshot deletion failed for %s: %s",
+                        machine.vm_name,
+                        snapshot_status,
                     )
             else:
-                click.echo(
-                    f"Machine {machine.vm_name} is not deployed to the configured in {libvirt_endpoint}."
+                logger.warning(
+                    "Machine %s is not deployed to the configured in %s.",
+                    machine.vm_name,
+                    libvirt_endpoint,
                 )
     else:
-        click.echo(f"Machine not found in manifest: {vm_name}")
+        logger.error("Machine not found in manifest: %s", vm_name)
 
 
 @click.command()
@@ -399,7 +431,7 @@ def status():
     try:
         environment, images, _, machines = parse_config()
     except TypeError as e:
-        click.echo("Could not parse config file.")
+        logger.error("Could not parse config file.")
         sys.exit(1)
 
     click.echo()
@@ -440,7 +472,7 @@ def up(vm_name):
     try:
         environment, images, config_defaults, machines = parse_config()
     except TypeError as e:
-        click.echo("Could not parse config file.")
+        logger.error("Could not parse config file.")
         sys.exit(1)
 
     machine_config = get_machine_by_vm_name(machines, vm_name)
@@ -455,7 +487,7 @@ def up(vm_name):
             if status in ["VIR_DOMAIN_SHUTOFF", "VIR_DOMAIN_CRASHED"]:
                 click.echo(f"Starting virtual machine {machine.vm_name}")
                 if machine.poweron(environment.get("libvirt_uri", None)) > 0:
-                    click.echo(f"Problem powering on VM {machine.vm_name}")
+                    logger.error("Problem powering on VM %s", machine.vm_name)
             elif status in ["VIR_DOMAIN_RUNNING"]:
                 click.echo(f"The virtual machine {machine.vm_name} is running already")
 
@@ -480,11 +512,11 @@ def up(vm_name):
                 network_config_fpath,
                 os.path.join(machine.config_fpath, "cidata.iso"),
             )
-            click.echo(f"Writing cloud-init config ISO file {iso.fpath}")
+            logger.info("Writing cloud-init config ISO file %s", iso.fpath)
             if iso.write(iso.fpath):
-                click.echo(f"Writing cloud-init config ISO successful")
+                logger.info("Writing cloud-init config ISO successful")
             else:
-                click.echo(f"Writing cloud-init config ISO failed.")
+                logger.error("Writing cloud-init config ISO failed.")
                 sys.exit(1)
 
             # virt-install the VM and check status
@@ -496,10 +528,10 @@ def up(vm_name):
             ):
                 click.echo(f"Virtual machine deployment complete.")
             else:
-                click.echo(f"Virtual machine installation failed.")
+                logger.error("Virtual machine installation failed.")
 
     else:
-        click.echo(f"Machine {vm_name} not found in manifest.")
+        logger.error("Machine %s not found in manifest.", vm_name)
 
 
 # Bulid the CLI

--- a/tkc_lvlab/utils/cloud_init.py
+++ b/tkc_lvlab/utils/cloud_init.py
@@ -1,12 +1,16 @@
 """Module containing all things cloud-init"""
 
-import click
 import os
 import re
 import pycdlib
 from dataclasses import dataclass
 from enum import Enum
 from jinja2 import Environment, PackageLoader, select_autoescape
+
+from .._logging import get_logger
+
+
+logger = get_logger(__name__)
 
 
 class NetworkVersion(Enum):
@@ -86,7 +90,9 @@ class UserData:
     def __post_init__(self):
         pubkey_config = self.cloud_init.get("pubkey", None)
         if "~" in pubkey_config or "/" in pubkey_config:
-            click.echo("Pubkey appears to be a file path, attempting to read contents")
+            logger.debug(
+                "Pubkey appears to be a file path, attempting to read contents"
+            )
             pubkey_path = os.path.expanduser(self.cloud_init.get("pubkey", None))
             if os.path.isfile(pubkey_path):
                 with open(pubkey_path, "r", encoding="utf-8") as pubkey_file:
@@ -96,16 +102,16 @@ class UserData:
                 is_pubkey, pubkey_type = self._is_valid_ssh_public_key(pubkey_content)
 
                 if is_pubkey:
-                    click.echo(f"Successfully read {pubkey_type} pubkey")
+                    logger.debug("Successfully read %s pubkey", pubkey_type)
                     # Swap the file path for the content
                     self.cloud_init["pubkey"] = pubkey_content.strip()
                 else:
-                    click.echo(
-                        f"Read file contents does not appear to be an SSH pubkey"
+                    logger.warning(
+                        "Read file contents does not appear to be an SSH pubkey"
                     )
         else:
             if self._is_valid_ssh_public_key(pubkey_config):
-                click.echo("Pubkey appears to be a pubkey, using as-is")
+                logger.debug("Pubkey appears to be a pubkey, using as-is")
 
     def render_config(self) -> str:
         """Render a Jinja2 template with the data"""
@@ -164,5 +170,5 @@ class CloudInitIso:
             return True
 
         except Exception as e:
-            click.echo(f"Error writting ISO: {e}")
+            logger.error("Error writting ISO: %s", e)
             return False

--- a/tkc_lvlab/utils/images.py
+++ b/tkc_lvlab/utils/images.py
@@ -5,10 +5,14 @@ import os
 import re
 from urllib.parse import urlparse
 
-import click
 import gnupg
 import requests
 from tqdm import tqdm
+
+from .._logging import get_logger
+
+
+logger = get_logger(__name__)
 
 
 # pylint: disable=too-many-instance-attributes
@@ -77,7 +81,7 @@ class CloudImage:
     def _download_file(url, destination):
         """Download a file associated with the cloud image."""
 
-        click.echo(f"downloading to: {destination}")
+        logger.info("downloading to: %s", destination)
         response = requests.get(url, stream=True, timeout=10)
 
         total_size = int(response.headers.get("content-length", 0))
@@ -102,7 +106,7 @@ class CloudImage:
             image_dir = self.image_dir
 
         if not os.path.isdir(image_dir):
-            click.echo(f"CloudImage creating image directory: {image_dir}")
+            logger.info("CloudImage creating image directory: %s", image_dir)
             os.makedirs(image_dir, exist_ok=True)
 
     def download_image(self) -> bool:
@@ -147,8 +151,8 @@ class CloudImage:
         if os.path.isfile(self.checksum_gpg_fpath) and os.path.isfile(
             self.checksum_fpath
         ):
-            click.echo(
-                f"CloudImage {self.name} GPG verification of {self.checksum_fpath}"
+            logger.info(
+                "CloudImage %s GPG verification of %s", self.name, self.checksum_fpath
             )
 
             gpg = gnupg.GPG()

--- a/tkc_lvlab/utils/libvirt.py
+++ b/tkc_lvlab/utils/libvirt.py
@@ -2,15 +2,18 @@
 
 import glob
 import os
-import click
 import libvirt
 import re
 import subprocess
 import sys
 
+from .._logging import get_logger
 from ..config import parse_config, generate_hosts
 from .vdisk import VirtualDisk
 from .cloud_init import MetaData, NetworkConfig, UserData
+
+
+logger = get_logger(__name__)
 
 
 class Machine:
@@ -87,7 +90,7 @@ class Machine:
             try:
                 os.makedirs(self.config_fpath)
             except Exception as e:  # pylint: disable=broad-except
-                click.echo(f"Exception creating : {e}")
+                logger.error("Exception creating %s: %s", self.config_fpath, e)
                 sys.exit(1)
 
         # Render and write cloud-init: network-config
@@ -96,7 +99,7 @@ class Machine:
         )
         rendered_network_config = network_config.render_config()
         network_config_fpath = os.path.join(self.config_fpath, "network-config")
-        click.echo(f"Writing cloud-init network config file {network_config_fpath}")
+        logger.info("Writing cloud-init network config file %s", network_config_fpath)
         with open(network_config_fpath, "w", encoding="utf-8") as network_config_file:
             network_config_file.write(rendered_network_config)
 
@@ -104,7 +107,7 @@ class Machine:
         metadata_config = MetaData(self.libvirt_vm_name, self.fqdn)
         rendered_metadata_config = metadata_config.render_config()
         metadata_config_fpath = os.path.join(self.config_fpath, "meta-data")
-        click.echo(f"Writing cloud-init meta-data file {metadata_config_fpath}")
+        logger.info("Writing cloud-init meta-data file %s", metadata_config_fpath)
         with open(metadata_config_fpath, "w", encoding="utf-8") as metadata_config_file:
             metadata_config_file.write(rendered_metadata_config)
 
@@ -113,7 +116,9 @@ class Machine:
 
         # Apply cloud_init defaults
         if self.cloud_init_config.get("runcmd_ignore_defaults", False):
-            click.echo(f"Ignoring config_defaults:cloud_init:runcmd for {self.vm_name}")
+            logger.debug(
+                "Ignoring config_defaults:cloud_init:runcmd for %s", self.vm_name
+            )
             cloud_init_defaults_filtered = {
                 k: v for k, v in cloud_init_defaults.items() if k != "runcmd"
             }
@@ -122,8 +127,8 @@ class Machine:
                 **self.cloud_init_config,
             }
         else:
-            click.echo(
-                f"Including config_defaults:cloud_init:runcmd for {self.vm_name}"
+            logger.debug(
+                "Including config_defaults:cloud_init:runcmd for %s", self.vm_name
             )
             cloud_init_config = {**cloud_init_defaults, **self.cloud_init_config}
 
@@ -138,7 +143,7 @@ class Machine:
         try:
             _, _, _, machines = parse_config()
         except TypeError as e:
-            click.echo("Could not parse config file.")
+            logger.error("Could not parse config file.")
             sys.exit()
 
         hosts_snippet = generate_hosts(
@@ -189,7 +194,7 @@ class Machine:
         )
         rendered_userdata_config = userdata_config.render_config()
         userdata_config_fpath = os.path.join(self.config_fpath, "user-data")
-        click.echo(f"Writing cloud-init user-data file {userdata_config_fpath}")
+        logger.info("Writing cloud-init user-data file %s", userdata_config_fpath)
         with open(userdata_config_fpath, "w", encoding="utf-8") as userdata_config_file:
             userdata_config_file.write(rendered_userdata_config)
 
@@ -209,14 +214,14 @@ class Machine:
             )
 
             if vdisk.exists():
-                click.echo(f"Virtual Disk: {vdisk.name} exists at {vdisk.fpath}")
+                logger.info("Virtual Disk: %s exists at %s", vdisk.name, vdisk.fpath)
             else:
-                click.echo(f"Creating Virtual Disk: {vdisk.fpath} at {vdisk.size}")
+                logger.info("Creating Virtual Disk: %s at %s", vdisk.fpath, vdisk.size)
                 if vdisk.create():
                     if vdisk.exists():
-                        click.echo(f"Virtual Disk Created Successfully")
+                        logger.info("Virtual Disk Created Successfully")
                 else:
-                    click.echo(f"Failed to create Virtual Disk: {vdisk.fpath}")
+                    logger.error("Failed to create Virtual Disk: %s", vdisk.fpath)
 
     def deploy(self, config_path, config_defaults, uri):
         """Use virt-install to create a virtual machine"""
@@ -256,8 +261,8 @@ class Machine:
             )
             return True
         except subprocess.CalledProcessError as e:
-            click.echo(f"Error in virt-install call: {e}")
-            click.echo(f"{' '.join(command)}")
+            logger.error("Error in virt-install call: %s", e)
+            logger.error("%s", " ".join(command))
             return False
 
     def destroy(self, uri):
@@ -274,22 +279,22 @@ class Machine:
             vm_state, _, _, _ = get_machine_state(vm.state())
 
             if vm_state in ["VIR_DOMAIN_RUNNING", "VIR_DOMAIN_PAUSED"]:
-                click.echo(f"Forcefully shutting down {self.vm_name}")
+                logger.warning("Forcefully shutting down %s", self.vm_name)
                 if vm.destroy() > 0:
-                    click.echo(f"Failed to forcefully shutdown {self.vm_name}")
+                    logger.error("Failed to forcefully shutdown %s", self.vm_name)
                 vm_state, _, _, _ = get_machine_state(vm.state())
 
             if vm_state in ["VIR_DOMAIN_SHUTOFF", "VIR_DOMAIN_CRASHED"]:
                 if vm.hasCurrentSnapshot():
-                    click.echo(f"Deleting all snapshots for {self.vm_name}")
+                    logger.warning("Deleting all snapshots for %s", self.vm_name)
                     for snapshot in vm.listAllSnapshots():
-                        click.echo(f"Deleting snapshot {snapshot.getName()}")
+                        logger.info("Deleting snapshot %s", snapshot.getName())
                         snapshot.delete()
 
-                click.echo(f"Undefining {self.vm_name}")
+                logger.info("Undefining %s", self.vm_name)
                 if vm.undefine() > 0:
-                    click.echo(
-                        f"Failed to undefine (remove from Libvirt) {self.vm_name} "
+                    logger.error(
+                        "Failed to undefine (remove from Libvirt) %s ", self.vm_name
                     )
                 else:
                     # Done with libvirt connection
@@ -298,30 +303,31 @@ class Machine:
                         machine_files = glob.glob(os.path.join(self.config_fpath, "*"))
                         for file in machine_files:
                             if os.path.isfile(file):
-                                click.echo(f"Removing file {file}.")
+                                logger.info("Removing file %s.", file)
                                 os.remove(file)
                     except Exception as e:
-                        click.echo(f"Exception when removing machine files {e}")
+                        logger.error("Exception when removing machine files %s", e)
                         return False
 
                     try:
                         # Check if the directory is empty and then remove it
                         if not os.listdir(self.config_fpath):
-                            click.echo(
-                                f"Removing machine directory {self.config_fpath}."
+                            logger.info(
+                                "Removing machine directory %s.", self.config_fpath
                             )
                             os.rmdir(self.config_fpath)
                         else:
-                            click.echo(
-                                f"Machine directory {self.config_fpath} is not empty."
+                            logger.warning(
+                                "Machine directory %s is not empty.", self.config_fpath
                             )
                     except Exception as e:
-                        click.echo(f"Exception when removing machine files {e}")
+                        logger.error("Exception when removing machine files %s", e)
                         return False
 
         else:
-            click.echo(
-                f"The virtual machine {self.vm_name} does not exist in this Libvirt URI"
+            logger.warning(
+                "The virtual machine %s does not exist in this Libvirt URI",
+                self.vm_name,
             )
             conn.close()
             return False
@@ -416,8 +422,9 @@ class Machine:
                 create_status = vm.create()
 
         else:
-            click.echo(
-                f"The virtual machine {self.vm_name} does not exist in this Libvirt URI"
+            logger.warning(
+                "The virtual machine %s does not exist in this Libvirt URI",
+                self.vm_name,
             )
 
         conn.close()
@@ -444,10 +451,12 @@ class Machine:
                 shutdown_status = vm.shutdown()
 
             if shutdown_status > 0:
-                click.echo(f"Error with machine.shutdown")
+                logger.error("Error with machine.shutdown")
 
         else:
-            click.echo(f"The virtual machine {self.vm_name} does not exist in Libvirt")
+            logger.warning(
+                "The virtual machine %s does not exist in Libvirt", self.vm_name
+            )
 
         conn.close()
         return shutdown_status

--- a/tkc_lvlab/utils/vdisk.py
+++ b/tkc_lvlab/utils/vdisk.py
@@ -3,7 +3,10 @@
 import os
 import subprocess
 
-import click
+from .._logging import get_logger
+
+
+logger = get_logger(__name__)
 
 
 class VirtualDisk:
@@ -54,7 +57,9 @@ class VirtualDisk:
             try:
                 os.makedirs(os.path.dirname(self.fpath))
             except Exception as e:  # pylint: disable=broad-except
-                click.echo(f"Exception creating : {e}")
+                logger.error(
+                    "Exception creating %s: %s", os.path.dirname(self.fpath), e
+                )
                 return False
 
         try:
@@ -66,7 +71,7 @@ class VirtualDisk:
             )
             return True
         except subprocess.CalledProcessError as e:
-            click.echo(f"Error in qemu-img call: {e}")
+            logger.error("Error in qemu-img call: %s", e)
             return False
 
     def delete(self):
@@ -75,4 +80,4 @@ class VirtualDisk:
             try:
                 os.remove(self.fpath)
             except Exception as e:  # pylint: disable=broad-except
-                click.echo(f"Exception removing vdisk: {e}")
+                logger.error("Exception removing vdisk: %s", e)


### PR DESCRIPTION
## Summary

- New `tkc_lvlab/_logging.py` with `get_logger()` and `configure_logging(verbosity)`.
- `-v`/`-vv`/`-q` flags wired into the Click root group; default WARNING, `-v` INFO, `-vv` DEBUG, `-q` ERROR.
- 77 of 115 diagnostic `print()` / `click.echo()` lines converted to logger calls (stderr); 38 user-facing outputs kept as `click.echo` (stdout).

## Why

Phase 2 of the roadmap (libvirt-python → virsh port) rewrites every libvirt call site. Landing logging first so the new code inherits the facade rather than retrofitting later. Also makes destructive-path diagnostics (`destroy`, `snapshot delete`) actually useful — CLAUDE.md flags these as VM-damage risk surfaces.

## Test plan

- [x] `pre-commit run --all-files` passes (black, EOF, trailing-whitespace, YAML)
- [x] `uv run lvlab --help` shows new `-v`/`-q` flags
- [x] `lvlab -v hosts` (no Lvlab.yml) emits `ERROR tkc_lvlab.cli: Could not parse config file.` to stderr
- [ ] Manual smoke on a real `lvlab up` run

## Risk

- Low. Stderr/stdout split: diagnostics now go to stderr where some users may have been capturing stdout. Format string is `%(asctime)s %(levelname)-7s %(name)s: %(message)s` — verbose by design.
- Decisions documented in commit:
  - Pubkey detection messages and runcmd-defaults merge messages demoted to DEBUG (chatty per-VM diagnostics).
  - "Machine X is not deployed" demoted to WARNING (normal during status, surface during destroy).
  - tqdm download progress kept (interactive user-facing, not a log line).

Closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)