### PR TITLE
fix: verify before appending in lvlab hosts --append

### DIFF
--- a/tkc_lvlab/cli.py
+++ b/tkc_lvlab/cli.py
@@ -6,7 +6,12 @@ import sys
 import click
 import libvirt
 
-from .config import parse_config, generate_hosts
+from .config import (
+    parse_config,
+    generate_hosts,
+    generate_hosts_entries,
+    parse_hosts_file,
+)
 from .utils.cloud_init import CloudInitIso, MetaData, NetworkConfig, UserData
 from .utils.libvirt import (
     connect_to_libvirt,
@@ -177,10 +182,49 @@ def hosts(append=False, heredoc=False):
 
     if append:
         etc_hosts = "/etc/hosts"
-        if os.access(etc_hosts, os.W_OK):
+        try:
+            existing_ips, existing_names = parse_hosts_file(etc_hosts)
+        except OSError as e:
+            click.echo(f"Unable to read {etc_hosts}: {e}")
+            sys.exit(1)
+
+        candidates = generate_hosts_entries(config_defaults, machines)
+        to_append = []
+        for entry in candidates:
+            conflict_reasons = []
+            if entry["ip4"] in existing_ips:
+                conflict_reasons.append(f"IP {entry['ip4']} already present")
+            if entry["hostname"] and entry["hostname"].lower() in existing_names:
+                conflict_reasons.append(f"hostname {entry['hostname']} already present")
+            if entry["fqdn"] and entry["fqdn"].lower() in existing_names:
+                conflict_reasons.append(f"fqdn {entry['fqdn']} already present")
+
+            if conflict_reasons:
+                click.echo(
+                    f"Skipping {entry['ip4']} {entry['fqdn']} {entry['hostname']}: "
+                    + "; ".join(conflict_reasons)
+                )
+            else:
+                to_append.append(entry)
+
+        if not to_append:
+            click.echo("No new entries to append to /etc/hosts.")
+        elif os.access(etc_hosts, os.W_OK) or (
+            not os.path.exists(etc_hosts)
+            and os.access(os.path.dirname(etc_hosts) or ".", os.W_OK)
+        ):
             click.echo("Appending hosts file snippet to /etc/hosts")
-            with open(etc_hosts, "a") as hosts_file:
-                hosts_file.write(hosts_snippet)
+            header = f"\n# Libvirt Labs /etc/hosts snippet\n# Environment: {environment.get('name', '')}\n"
+            try:
+                with open(etc_hosts, "a", encoding="utf-8") as hosts_file:
+                    hosts_file.write(header)
+                    for entry in to_append:
+                        line = f"{entry['ip4']} {entry['fqdn']} {entry['hostname']}\n"
+                        hosts_file.write(line)
+                        click.echo(f"Appended: {line.rstrip()}")
+            except OSError as e:
+                click.echo(f"Unable to write {etc_hosts}: {e}")
+                sys.exit(1)
         else:
             click.echo("No write access available for /etc/hosts")
 

--- a/tkc_lvlab/config.py
+++ b/tkc_lvlab/config.py
@@ -6,17 +6,12 @@ import click
 import yaml
 
 
-def generate_hosts(environment, config_defaults, machines, heredoc=None):
-    """Generte hosts file entry content from config
+def generate_hosts_entries(config_defaults, machines):
+    """Build the list of /etc/hosts entries for the configured machines.
 
-    Parses the manifest to create sets of /etc/hosts
-    entries for each defined machine.
-
-    Output created by rendering a jinja template
-    with the data
+    Returns a list of dicts with keys: ip4, fqdn, hostname. Entries are
+    only emitted for machines whose first interface defines an ip4 address.
     """
-    env = Environment(loader=PackageLoader("tkc_lvlab"), autoescape=select_autoescape())
-
     hosts = []
     for machine in machines:
         if len(machine.get("interfaces", [])) > 0 and machine["interfaces"][0].get(
@@ -35,6 +30,60 @@ def generate_hosts(environment, config_defaults, machines, heredoc=None):
                 "hostname": machine["hostname"],
             }
             hosts.append(hosts_entry)
+    return hosts
+
+
+def parse_hosts_file(fpath):
+    """Parse an /etc/hosts-style file into a structured view.
+
+    Returns a tuple of (ips, names) where:
+      - ips: set of IP addresses already present (loopback IPs excluded so
+        a VM whose hostname matches the workstation's own hostname does not
+        get blocked from being added).
+      - names: set of hostnames and aliases present on non-loopback lines
+        (lowercased).
+
+    Comments (lines starting with '#' or trailing '#' content) and blank lines
+    are ignored. If the file does not exist this returns two empty sets so the
+    caller treats every candidate as new.
+    """
+    ips = set()
+    names = set()
+
+    if not os.path.exists(fpath):
+        return ips, names
+
+    with open(fpath, "r", encoding="utf-8") as f:
+        for raw_line in f:
+            line = raw_line.split("#", 1)[0].strip()
+            if not line:
+                continue
+            tokens = line.split()
+            if len(tokens) < 2:
+                continue
+            ip = tokens[0]
+            entry_names = [t.lower() for t in tokens[1:]]
+            # Skip loopback entries so they cannot block a real VM record.
+            if ip.startswith("127.") or ip == "::1":
+                continue
+            ips.add(ip)
+            names.update(entry_names)
+
+    return ips, names
+
+
+def generate_hosts(environment, config_defaults, machines, heredoc=None):
+    """Generte hosts file entry content from config
+
+    Parses the manifest to create sets of /etc/hosts
+    entries for each defined machine.
+
+    Output created by rendering a jinja template
+    with the data
+    """
+    env = Environment(loader=PackageLoader("tkc_lvlab"), autoescape=select_autoescape())
+
+    hosts = generate_hosts_entries(config_defaults, machines)
 
     config = {
         "env": environment,


### PR DESCRIPTION
## Summary

- `lvlab hosts --append` now parses the target file (default `/etc/hosts`) and skips entries whose IP, hostname, or FQDN is already present.
- Adds `parse_hosts_file()` and `generate_hosts_entries()` helpers in `tkc_lvlab/config.py` so the entry list is reusable.
- Output clearly distinguishes appended vs skipped lines.

## Why

Repeated `lvlab hosts --append` invocations previously stacked duplicate entries in `/etc/hosts`. Makes the command idempotent.

## What changed

- `tkc_lvlab/config.py` — extracted `generate_hosts_entries()` from `generate_hosts()`; added `parse_hosts_file()`.
- `tkc_lvlab/cli.py` — rewrote the `if append:` branch of the `hosts` command.

## Parse strategy

Per-line: strip everything after `#`, `.strip()`, skip empty. Tokenize on whitespace. Require ≥2 tokens. First token is IP; rest are names/aliases. Loopback (`127.*`, `::1`) entries excluded from the conflict set so a workstation hostname colliding with a VM hostname doesn't block the entry.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] Manual: re-running `--append` after a clean run reports all entries as skipped
- [ ] Verify behavior with a `/etc/hosts` containing inline comments

## Risk

- Low. Append-path now writes its own header + per-line records (so duplicate headers don't accumulate across runs). Stdout path unchanged.

Closes #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)