### PR TITLE
feat: per-VM shared_directories with extend-and-override semantics

### DIFF
--- a/docs/Lvlab.example.yml
+++ b/docs/Lvlab.example.yml
@@ -38,6 +38,13 @@ environment:
           - name: enp1s0
             ip4: 192.168.122.12/24
             ip4gw: 192.168.122.1
+        # shared_directories defined here extend the config_defaults list.
+        # An entry with the same mount_tag as a default overrides that default;
+        # other defaults still apply. Below, salt.local mounts both `gitrepos`
+        # (from defaults) and an additional `saltsrc` mount.
+        shared_directories:
+          - source: /home/crow/salt
+            mount_tag: saltsrc
 
       - vm_name: vault.local
         hostname: vault

--- a/tkc_lvlab/utils/libvirt.py
+++ b/tkc_lvlab/utils/libvirt.py
@@ -37,6 +37,19 @@ class Machine:
             )
             machine["disks"][index] = {**disk_defaults, **disk}
 
+        # Apply shared_directories defaults.
+        # Defaults always apply; per-machine entries extend the list and override any
+        # default whose mount_tag they share. Result is a list keyed-by-mount_tag.
+        default_shared_dirs = config_defaults.get("shared_directories", []) or []
+        machine_shared_dirs = machine.get("shared_directories", []) or []
+        merged_shared_dirs = {sd["mount_tag"]: sd for sd in default_shared_dirs}
+        for sd in machine_shared_dirs:
+            merged_shared_dirs[sd["mount_tag"]] = {
+                **merged_shared_dirs.get(sd["mount_tag"], {}),
+                **sd,
+            }
+        machine["shared_directories"] = list(merged_shared_dirs.values())
+
         # Apply machine defaults
         machine = {**config_defaults, **machine}
 
@@ -78,6 +91,7 @@ class Machine:
             "nameservers", config_defaults["interfaces"].get("nameservers", {})
         )
         self.disks = machine.get("disks", [])
+        self.shared_directories = machine.get("shared_directories", [])
         self.cloud_init_config = machine.get("cloud_init", {})
         self.config_fpath = config_fpath
 
@@ -239,10 +253,12 @@ class Machine:
             "--noautoconsole",
         ]
 
-        # Extend the command to enable shared_directories if found in the config
-        if config_defaults.get("shared_directories", None):
+        # Extend the command to enable shared_directories if found in the config.
+        # self.shared_directories is the merged result of config_defaults and the
+        # per-machine entries (see Machine.__init__).
+        if self.shared_directories:
             command.append("--memorybacking=source.type=memfd,access.mode=shared")
-            for filesystem in config_defaults.get("shared_directories", None):
+            for filesystem in self.shared_directories:
                 command.append(
                     f'--filesystem={filesystem["source"]},{filesystem["mount_tag"]},driver.type=virtiofs'
                 )


### PR DESCRIPTION
## Summary

- `shared_directories` defined under a machine entry now merge with `config_defaults.shared_directories` at `Machine.__init__` time (matching the existing pattern for `interfaces`/`disks`).
- Merge semantics: **extend** by default; per-VM entries with the same `mount_tag` as a default override that default. Other defaults remain.
- `Machine.deploy()` reads from `self.shared_directories` instead of `config_defaults` directly.

## Why

Implements issues #20 (defaults respected) and #47 (per-VM control). Both touch the same code; shipping together avoids two churns.

## Extend vs replace decision

Chose **extend**. Issue #20's prose and example (salt machine ends up with both the default `/srv/data` AND its own `/home/repos/crow`) describe extend semantics. AC #2 (skip shared-memory args when both lists empty) is also consistent. Same-`mount_tag` per-VM entries override the default, mirroring how the `disks` defaults pattern keys by `name`.

## What changed

- `tkc_lvlab/utils/libvirt.py` — new merge block in `Machine.__init__`, switched `Machine.deploy()` to read from `self.shared_directories`.
- `docs/Lvlab.example.yml` — added a per-VM `shared_directories` entry on `salt.local` showing both halves of the merge with an inline comment.

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] Manual: example manifest renders both default and per-VM entries through cloud-init
- [ ] Verify with empty defaults + per-VM entries
- [ ] Verify with `mount_tag` collision (per-VM should win)

## Risk

- Low. Same merge pattern as existing defaults handling. No schema breakage — manifests without per-VM `shared_directories` see no behavior change.

Closes #20.
Closes #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)