### PR TITLE
feat(virsh): add subprocess wrapper foundation for Phase 2 port

### DIFF
--- a/tests/test_virsh.py
+++ b/tests/test_virsh.py
@@ -1,0 +1,448 @@
+"""Unit tests for :mod:`tkc_lvlab.utils.virsh`.
+
+These tests mock ``subprocess.run`` at the boundary; nothing here ever
+actually invokes ``virsh``. They lock in the contract subsequent Phase 2
+agents will build on.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from unittest import mock
+
+import pytest
+
+from tkc_lvlab.utils import virsh
+from tkc_lvlab.utils.virsh import (
+    DEAD_STATES,
+    DESTROYABLE_STATES,
+    DOMSTATE_HUMAN,
+    RUNNING_STATES,
+    SHUTDOWNABLE_STATES,
+    VirshError,
+    _xml_tempfile,
+    humanize_state,
+    run_virsh,
+    virsh_capabilities,
+    virsh_domstate,
+    virsh_domstate_reason,
+    virsh_list_all_names,
+    virsh_snapshot_names,
+)
+
+
+URI = "qemu:///session"
+
+
+def _completed(
+    stdout: str = "", stderr: str = "", returncode: int = 0
+) -> subprocess.CompletedProcess:
+    """Build a CompletedProcess stub mirroring what subprocess.run returns."""
+    return subprocess.CompletedProcess(
+        args=["virsh"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+# ---------------------------------------------------------------------------
+# run_virsh — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_run_virsh_builds_correct_argv_and_env():
+    """argv is ``virsh -c <uri> <args...>`` and env forces LC_ALL=C + LANG=C."""
+    with mock.patch(
+        "tkc_lvlab.utils.virsh.subprocess.run", return_value=_completed(stdout="ok\n")
+    ) as run:
+        result = run_virsh(URI, ["list", "--all", "--name"])
+
+    assert result.stdout == "ok\n"
+    run.assert_called_once()
+    call_args, call_kwargs = run.call_args
+    assert call_args[0] == ["virsh", "-c", URI, "list", "--all", "--name"]
+    env = call_kwargs["env"]
+    assert env["LC_ALL"] == "C"
+    assert env["LANG"] == "C"
+    # env should be derived from os.environ — keys present in os.environ are present here.
+    for key in os.environ:
+        assert key in env
+
+
+def test_run_virsh_capture_true_sets_text_mode_and_pipes():
+    """capture=True passes stdout/stderr pipes and text-mode encoding kwargs."""
+    with mock.patch(
+        "tkc_lvlab.utils.virsh.subprocess.run", return_value=_completed()
+    ) as run:
+        run_virsh(URI, ["domstate", "foo"])
+
+    _, kwargs = run.call_args
+    assert kwargs["stdout"] is subprocess.PIPE
+    assert kwargs["stderr"] is subprocess.PIPE
+    assert kwargs["text"] is True
+    assert kwargs["encoding"] == "utf-8"
+    assert kwargs["errors"] == "replace"
+    assert kwargs["timeout"] == 30.0
+    assert kwargs["input"] is None
+
+
+def test_run_virsh_capture_false_does_not_pipe():
+    """capture=False omits the stdout/stderr/text plumbing for passthrough."""
+    with mock.patch(
+        "tkc_lvlab.utils.virsh.subprocess.run", return_value=_completed()
+    ) as run:
+        run_virsh(URI, ["console", "foo"], capture=False)
+
+    _, kwargs = run.call_args
+    assert "stdout" not in kwargs
+    assert "stderr" not in kwargs
+    assert "text" not in kwargs
+
+
+def test_run_virsh_custom_timeout_is_forwarded():
+    with mock.patch(
+        "tkc_lvlab.utils.virsh.subprocess.run", return_value=_completed()
+    ) as run:
+        run_virsh(
+            URI, ["snapshot-create", "vm", "--xmlfile", "/tmp/x.xml"], timeout=120.0
+        )
+    _, kwargs = run.call_args
+    assert kwargs["timeout"] == 120.0
+
+
+def test_run_virsh_input_text_is_forwarded():
+    with mock.patch(
+        "tkc_lvlab.utils.virsh.subprocess.run", return_value=_completed()
+    ) as run:
+        run_virsh(URI, ["foo"], input_text="hello\n")
+    _, kwargs = run.call_args
+    assert kwargs["input"] == "hello\n"
+
+
+# ---------------------------------------------------------------------------
+# run_virsh — error paths
+# ---------------------------------------------------------------------------
+
+
+def test_run_virsh_nonzero_rc_raises_virsh_error():
+    """Nonzero returncode raises VirshError carrying rc, stderr, and args."""
+    with mock.patch(
+        "tkc_lvlab.utils.virsh.subprocess.run",
+        return_value=_completed(
+            stderr="error: Failed to get domain 'nope'\n", returncode=1
+        ),
+    ):
+        with pytest.raises(VirshError) as excinfo:
+            run_virsh(URI, ["domstate", "nope"])
+
+    err = excinfo.value
+    assert err.returncode == 1
+    assert err.stderr == "error: Failed to get domain 'nope'"
+    # ``BaseException.args`` is always coerced to a tuple by the runtime,
+    # regardless of what __init__ assigns. We compare as a sequence.
+    assert tuple(err.args) == ("domstate", "nope")
+    assert "domstate nope" in str(err)
+    assert "rc=1" in str(err)
+    assert "Failed to get domain" in str(err)
+
+
+def test_run_virsh_check_false_returns_failed_result():
+    """check=False suppresses the exception and returns the process object."""
+    with mock.patch(
+        "tkc_lvlab.utils.virsh.subprocess.run",
+        return_value=_completed(stderr="boom", returncode=5),
+    ):
+        result = run_virsh(URI, ["foo"], check=False)
+    assert result.returncode == 5
+    assert result.stderr == "boom"
+
+
+def test_run_virsh_file_not_found_raises_virsh_error_127():
+    """Missing virsh binary surfaces as VirshError(127, documented-msg, ...)."""
+    with mock.patch(
+        "tkc_lvlab.utils.virsh.subprocess.run", side_effect=FileNotFoundError()
+    ):
+        with pytest.raises(VirshError) as excinfo:
+            run_virsh(URI, ["list"])
+    err = excinfo.value
+    assert err.returncode == 127
+    assert err.stderr == "virsh binary not found in PATH; install libvirt-clients"
+    assert tuple(err.args) == ("list",)
+
+
+def test_run_virsh_timeout_raises_virsh_error_minus_one():
+    """Subprocess TimeoutExpired surfaces as VirshError(-1, timed-out-msg, ...)."""
+    with mock.patch(
+        "tkc_lvlab.utils.virsh.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd=["virsh"], timeout=30.0),
+    ):
+        with pytest.raises(VirshError) as excinfo:
+            run_virsh(URI, ["list", "--all"])
+    err = excinfo.value
+    assert err.returncode == -1
+    assert "virsh timed out after 30.0s" in err.stderr
+    assert "list --all" in err.stderr
+    assert tuple(err.args) == ("list", "--all")
+
+
+def test_virsh_error_empty_stderr_uses_placeholder():
+    """An empty stderr still produces a readable str(err)."""
+    err = VirshError(2, "", ["foo"])
+    assert "<no stderr>" in str(err)
+    assert err.stderr == ""
+    assert tuple(err.args) == ("foo",)
+    assert err.returncode == 2
+
+
+# ---------------------------------------------------------------------------
+# State strings & humanize_state
+# ---------------------------------------------------------------------------
+
+
+def test_state_sets_contents():
+    """The four state-membership sets stay exactly as the design spec dictates."""
+    assert RUNNING_STATES == {"running", "paused"}
+    assert DEAD_STATES == {"shut off", "crashed"}
+    assert SHUTDOWNABLE_STATES == {"running", "idle", "paused", "pmsuspended"}
+    assert DESTROYABLE_STATES == {"running", "paused"}
+
+
+@pytest.mark.parametrize(
+    "state,expected",
+    [
+        ("no state", "no state"),
+        ("running", "the machine is running"),
+        ("idle", "the machine is blocked on resource"),
+        ("paused", "the machine is paused by user"),
+        ("in shutdown", "the machine is being shut down"),
+        ("shut off", "the machine is shut off"),
+        ("crashed", "the machine is crashed"),
+        ("pmsuspended", "the machine is suspended by guest power management"),
+    ],
+)
+def test_humanize_state_known_states(state, expected):
+    """Every key in DOMSTATE_HUMAN maps to its documented human string."""
+    status, _reason = humanize_state(state, "unknown")
+    assert status == expected
+
+
+def test_humanize_state_covers_every_domstate_key():
+    """Sanity: the parametrized list above stays in sync with DOMSTATE_HUMAN."""
+    parametrized = {
+        "no state",
+        "running",
+        "idle",
+        "paused",
+        "in shutdown",
+        "shut off",
+        "crashed",
+        "pmsuspended",
+    }
+    assert parametrized == set(DOMSTATE_HUMAN.keys())
+
+
+def test_humanize_state_unknown_state_falls_back_to_raw():
+    """An unknown state string is returned verbatim, no KeyError."""
+    status, reason = humanize_state("hypothetical", "unknown")
+    assert status == "hypothetical"
+    # unknown reason for unknown state also falls back
+    assert reason == "unknown"
+
+
+def test_humanize_state_known_state_unknown_reason_falls_back():
+    """Unknown reason falls back to the raw reason; no KeyError."""
+    status, reason = humanize_state("running", "made-up-reason")
+    assert status == "the machine is running"
+    assert reason == "made-up-reason"
+
+
+def test_humanize_state_known_state_known_reason_maps():
+    """A known (state, reason) pair maps to the documented human string."""
+    status, reason = humanize_state("running", "booted")
+    assert status == "the machine is running"
+    assert reason == "normal startup from boot"
+
+    status, reason = humanize_state("shut off", "destroyed")
+    assert status == "the machine is shut off"
+    assert reason == "forced poweroff"
+
+
+# ---------------------------------------------------------------------------
+# _xml_tempfile
+# ---------------------------------------------------------------------------
+
+
+def test_xml_tempfile_writes_contents_and_cleans_up():
+    """Body sees the file with the right contents; cleanup happens on exit."""
+    payload = "<domainsnapshot><name>snap1</name></domainsnapshot>"
+    seen_path = None
+    with _xml_tempfile(payload) as path:
+        seen_path = path
+        assert os.path.exists(path)
+        basename = os.path.basename(path)
+        assert basename.startswith("lvlab-snapshot-")
+        assert basename.endswith(".xml")
+        with open(path, "r", encoding="utf-8") as fh:
+            assert fh.read() == payload
+    assert seen_path is not None
+    assert not os.path.exists(seen_path)
+
+
+def test_xml_tempfile_cleans_up_on_exception():
+    """Cleanup also runs when the body raises."""
+    seen_path = None
+    with pytest.raises(RuntimeError, match="boom"):
+        with _xml_tempfile("<x/>") as path:
+            seen_path = path
+            assert os.path.exists(path)
+            raise RuntimeError("boom")
+    assert seen_path is not None
+    assert not os.path.exists(seen_path)
+
+
+def test_xml_tempfile_handles_already_gone_file():
+    """If the file disappears before cleanup, the context manager still exits cleanly."""
+    seen_path: str | None = None
+    with _xml_tempfile("<x/>") as path:
+        seen_path = path
+        # Simulate a racing unlink — file is gone before the finally-block
+        # gets to it. The context manager must not raise.
+        os.unlink(path)
+        assert not os.path.exists(path)
+    assert seen_path is not None
+    assert not os.path.exists(seen_path)
+
+
+def test_xml_tempfile_unlink_oserror_is_swallowed():
+    """Cleanup never propagates OSError from a racing unlink."""
+    seen_path: str | None = None
+    with mock.patch(
+        "tkc_lvlab.utils.virsh.os.unlink", side_effect=OSError("simulated race")
+    ):
+        with _xml_tempfile("<x/>") as path:
+            seen_path = path
+            assert os.path.exists(path)
+        # Cleanup must not propagate the OSError. (If it did, this line
+        # would never execute.)
+    # Real cleanup never happened (we patched it out); clean it up ourselves
+    # outside the mock so the real os.unlink is used.
+    assert seen_path is not None
+    if os.path.exists(seen_path):
+        os.unlink(seen_path)
+
+
+# ---------------------------------------------------------------------------
+# Convenience parsers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "stdout,expected",
+    [
+        ("", []),
+        ("\n", []),
+        ("vm1\n", ["vm1"]),
+        ("vm1\nvm2\nvm3\n", ["vm1", "vm2", "vm3"]),
+        ("   vm1   \n  vm2\n", ["vm1", "vm2"]),
+        ("vm1\n\nvm2\n", ["vm1", "vm2"]),
+        # no trailing newline
+        ("vm1\nvm2", ["vm1", "vm2"]),
+    ],
+)
+def test_virsh_list_all_names_parses_one_per_line(stdout, expected):
+    with mock.patch(
+        "tkc_lvlab.utils.virsh.subprocess.run", return_value=_completed(stdout=stdout)
+    ) as run:
+        names = virsh_list_all_names(URI)
+    assert names == expected
+    call_args, _ = run.call_args
+    assert call_args[0] == ["virsh", "-c", URI, "list", "--all", "--name"]
+
+
+def test_virsh_domstate_strips_and_lowercases():
+    with mock.patch(
+        "tkc_lvlab.utils.virsh.subprocess.run",
+        return_value=_completed(stdout="  Running  \n"),
+    ) as run:
+        state = virsh_domstate(URI, "vm1")
+    assert state == "running"
+    call_args, _ = run.call_args
+    assert call_args[0] == ["virsh", "-c", URI, "domstate", "vm1"]
+
+
+@pytest.mark.parametrize(
+    "stdout,expected",
+    [
+        ("running (booted)\n", ("running", "booted")),
+        ("shut off (destroyed)\n", ("shut off", "destroyed")),
+        ("paused (user)\n", ("paused", "user")),
+        # virsh sometimes reports multi-word reasons
+        ("running (migration canceled)\n", ("running", "migration canceled")),
+        # Empty output → empty pair (defensive)
+        ("\n", ("", "")),
+        # Output without parens → state only
+        ("shut off\n", ("shut off", "")),
+    ],
+)
+def test_virsh_domstate_reason_parses(stdout, expected):
+    with mock.patch(
+        "tkc_lvlab.utils.virsh.subprocess.run", return_value=_completed(stdout=stdout)
+    ) as run:
+        result = virsh_domstate_reason(URI, "vm1")
+    assert result == expected
+    call_args, _ = run.call_args
+    assert call_args[0] == ["virsh", "-c", URI, "domstate", "--reason", "vm1"]
+
+
+@pytest.mark.parametrize(
+    "stdout,expected",
+    [
+        ("", []),
+        ("snap1\n", ["snap1"]),
+        ("snap1\nsnap2\nsnap3\n", ["snap1", "snap2", "snap3"]),
+        ("   snap1\n  snap2  \n", ["snap1", "snap2"]),
+    ],
+)
+def test_virsh_snapshot_names_parses(stdout, expected):
+    with mock.patch(
+        "tkc_lvlab.utils.virsh.subprocess.run", return_value=_completed(stdout=stdout)
+    ) as run:
+        names = virsh_snapshot_names(URI, "vm1")
+    assert names == expected
+    call_args, _ = run.call_args
+    assert call_args[0] == ["virsh", "-c", URI, "snapshot-list", "vm1", "--name"]
+
+
+def test_virsh_capabilities_returns_raw_stdout():
+    xml = "<capabilities>\n  <host/>\n</capabilities>\n"
+    with mock.patch(
+        "tkc_lvlab.utils.virsh.subprocess.run", return_value=_completed(stdout=xml)
+    ) as run:
+        result = virsh_capabilities(URI)
+    assert result == xml
+    call_args, _ = run.call_args
+    assert call_args[0] == ["virsh", "-c", URI, "capabilities"]
+
+
+# ---------------------------------------------------------------------------
+# Module-level re-exports — smoke check so future refactors don't quietly
+# rename the public constants used by callers.
+# ---------------------------------------------------------------------------
+
+
+def test_module_exports_public_names():
+    for name in [
+        "run_virsh",
+        "VirshError",
+        "DOMSTATE_HUMAN",
+        "RUNNING_STATES",
+        "DEAD_STATES",
+        "SHUTDOWNABLE_STATES",
+        "DESTROYABLE_STATES",
+        "humanize_state",
+        "virsh_list_all_names",
+        "virsh_domstate",
+        "virsh_domstate_reason",
+        "virsh_snapshot_names",
+        "virsh_capabilities",
+    ]:
+        assert hasattr(virsh, name), f"virsh module missing public name {name!r}"

--- a/tkc_lvlab/utils/virsh.py
+++ b/tkc_lvlab/utils/virsh.py
@@ -1,0 +1,291 @@
+"""Thin wrapper around the ``virsh`` CLI.
+
+This module is the foundation for replacing the ``libvirt-python`` C-extension
+dependency with subprocess calls to ``virsh``. Callers in
+``tkc_lvlab/utils/libvirt.py`` and ``tkc_lvlab/cli.py`` will be ported to use
+the helpers in this module in subsequent Phase 2 steps.
+
+All helpers force the ``virsh`` locale to ``C`` so output parsing is stable
+across host locales.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import subprocess
+import tempfile
+from typing import Iterator
+
+
+class VirshError(RuntimeError):
+    """Raised when a ``virsh`` invocation fails.
+
+    Attributes:
+        returncode: Exit code from ``virsh`` (or ``-1`` for timeouts, ``127``
+            when the binary is missing).
+        stderr: Captured stderr text (stripped). Empty if not available.
+        args: The argument list passed to ``virsh`` (without the leading
+            ``virsh -c <uri>``).
+    """
+
+    def __init__(self, returncode: int, stderr: str, args: list[str]):
+        self.returncode = returncode
+        self.stderr = (stderr or "").strip()
+        # NB: ``BaseException.__init__`` would overwrite ``self.args`` with
+        # the tuple of positional args passed to it. We want ``self.args`` to
+        # expose the failing virsh argv (per Phase 2 design §1), so we
+        # bypass super().__init__'s args-handling by passing nothing and then
+        # storing our own value. ``__str__`` is overridden to build the
+        # formatted message lazily.
+        super().__init__()
+        self.args = list(args)
+
+    def __str__(self) -> str:
+        return (
+            f"virsh {' '.join(self.args)} failed (rc={self.returncode}): "
+            f"{self.stderr or '<no stderr>'}"
+        )
+
+
+def run_virsh(
+    uri: str,
+    args: list[str],
+    *,
+    check: bool = True,
+    capture: bool = True,
+    timeout: float | None = 30.0,
+    input_text: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run ``virsh -c <uri> <args...>`` and return the completed process.
+
+    The locale is forced to ``C`` via both ``LC_ALL`` and ``LANG``; some
+    distros' ``virsh`` honors ``LANG`` even when ``LC_ALL`` is set, so both
+    overrides are required to guarantee stable output parsing.
+
+    Args:
+        uri: libvirt connection URI (e.g. ``qemu:///session``).
+        args: ``virsh`` subcommand and flags (no leading ``virsh -c <uri>``).
+        check: If ``True``, raise :class:`VirshError` on nonzero exit.
+        capture: If ``True``, capture stdout/stderr as text. If ``False``,
+            inherit the parent's stdio (used for interactive subcommands).
+        timeout: Wall-clock seconds before raising :class:`VirshError`. The
+            default is 30s; long-running ops (snapshots) should pass a larger
+            value explicitly.
+        input_text: Optional stdin text. Reserved for future interactive use;
+            no current Phase 2 caller passes this.
+
+    Returns:
+        The :class:`subprocess.CompletedProcess` from the invocation.
+
+    Raises:
+        VirshError: On nonzero exit (when ``check=True``), on missing
+            ``virsh`` binary, or on timeout.
+    """
+    argv = ["virsh", "-c", uri, *args]
+    env = os.environ.copy()
+    env["LC_ALL"] = "C"
+    env["LANG"] = "C"
+
+    run_kwargs: dict = {
+        "env": env,
+        "timeout": timeout,
+        "input": input_text,
+    }
+    if capture:
+        run_kwargs.update(
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+        )
+
+    try:
+        result = subprocess.run(
+            argv, **run_kwargs
+        )  # noqa: S603 (args are constructed in-process)
+    except FileNotFoundError as exc:
+        raise VirshError(
+            127,
+            "virsh binary not found in PATH; install libvirt-clients",
+            args,
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise VirshError(
+            -1,
+            f"virsh timed out after {timeout}s: {' '.join(args)}",
+            args,
+        ) from exc
+
+    if check and result.returncode != 0:
+        stderr = result.stderr if capture else ""
+        raise VirshError(result.returncode, stderr or "", args)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# State strings — what ``virsh domstate`` actually emits.
+# ---------------------------------------------------------------------------
+
+DOMSTATE_HUMAN: dict[str, str] = {
+    # https://libvirt.org/html/libvirt-libvirt-domain.html#virDomainState
+    "no state": "no state",
+    "running": "the machine is running",
+    "idle": "the machine is blocked on resource",
+    "paused": "the machine is paused by user",
+    "in shutdown": "the machine is being shut down",
+    "shut off": "the machine is shut off",
+    "crashed": "the machine is crashed",
+    "pmsuspended": "the machine is suspended by guest power management",
+}
+
+RUNNING_STATES: set[str] = {"running", "paused"}
+DEAD_STATES: set[str] = {"shut off", "crashed"}
+SHUTDOWNABLE_STATES: set[str] = {"running", "idle", "paused", "pmsuspended"}
+DESTROYABLE_STATES: set[str] = {"running", "paused"}
+
+# Reason map keyed on ``(state, reason)`` as ``virsh domstate --reason`` emits
+# them. Missing keys fall back to the raw reason string.
+#
+# ``virsh`` emits the reason as a lowercase short word (e.g. ``booted``,
+# ``user``, ``destroyed``) — the same suffix that libvirt's
+# ``VIR_DOMAIN_<STATE>_<REASON>`` constants use. The values mirror the human
+# strings the previous ``_humanize_machine_status`` returned so user-facing
+# output is preserved across the port.
+_REASON_HUMAN: dict[tuple[str, str], str] = {
+    # virDomainRunningReason
+    ("running", "unknown"): "Unknown",
+    ("running", "booted"): "normal startup from boot",
+    ("running", "migrated"): "migrated from another host",
+    ("running", "restored"): "restored from a state file",
+    ("running", "from snapshot"): "restored from snapshot",
+    ("running", "unpaused"): "returned from paused state",
+    ("running", "migration canceled"): "returned from migration",
+    ("running", "save canceled"): "returned from failed save process",
+    ("running", "wakeup"): "returned from pmsuspended due to wakeup event",
+    ("running", "crashed"): "resumed from crashed",
+    ("running", "post-copy"): "running in post-copy migration mode",
+    ("running", "post-copy failed"): "running in failed post-copy migration",
+    # virDomainShutdownReason
+    ("in shutdown", "unknown"): "the reason is unknown",
+    ("in shutdown", "user"): "shutting down on user request",
+    # virDomainShutoffReason
+    ("shut off", "unknown"): "the reason is unknown",
+    ("shut off", "shutdown"): "normal shutdown",
+    ("shut off", "destroyed"): "forced poweroff",
+    ("shut off", "crashed"): "machine crashed",
+    ("shut off", "migrated"): "migrated to another host",
+    ("shut off", "saved"): "saved to a file",
+    ("shut off", "failed"): "machine failed to start",
+    (
+        "shut off",
+        "from snapshot",
+    ): "restored from a snapshot which was taken while machine was shutoff",
+    (
+        "shut off",
+        "daemon",
+    ): "daemon decided to kill machine during reconnection processing",
+}
+
+
+def humanize_state(state: str, reason: str) -> tuple[str, str]:
+    """Convert a ``virsh`` state/reason pair into human-friendly strings.
+
+    Unknown states/reasons fall back to the raw input — no ``KeyError`` is
+    raised. The contract matches the old ``_humanize_machine_status`` helper
+    so caller-visible output is preserved across the libvirt-python -> virsh
+    port.
+    """
+    status = DOMSTATE_HUMAN.get(state, state)
+    human_reason = _REASON_HUMAN.get((state, reason), reason)
+    return status, human_reason
+
+
+# ---------------------------------------------------------------------------
+# Convenience parsers around individual ``virsh`` subcommands.
+# ---------------------------------------------------------------------------
+
+
+def virsh_list_all_names(uri: str) -> list[str]:
+    """Return all domain names known to libvirt at ``uri`` (running or not).
+
+    Uses ``virsh list --all --name`` which prints one bare domain name per
+    line. Blank lines (including the trailing newline) are stripped.
+    """
+    result = run_virsh(uri, ["list", "--all", "--name"])
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def virsh_domstate(uri: str, name: str) -> str:
+    """Return the raw lowercase state string for ``name`` (e.g. ``running``)."""
+    result = run_virsh(uri, ["domstate", name])
+    return result.stdout.strip().lower()
+
+
+def virsh_domstate_reason(uri: str, name: str) -> tuple[str, str]:
+    """Return ``(state, reason)`` for ``name``.
+
+    ``virsh domstate --reason`` emits a single line of the form
+    ``<state> (<reason words>)``. Returns ``("", "")``-style empty strings if
+    the output cannot be parsed, but in practice virsh always emits both.
+    """
+    result = run_virsh(uri, ["domstate", "--reason", name])
+    text = result.stdout.strip().lower()
+    if not text:
+        return "", ""
+    if "(" in text and text.endswith(")"):
+        state_part, _, reason_part = text.partition("(")
+        return state_part.strip(), reason_part[:-1].strip()
+    return text, ""
+
+
+def virsh_snapshot_names(uri: str, name: str) -> list[str]:
+    """Return snapshot names for domain ``name`` in creation order.
+
+    Uses ``virsh snapshot-list <name> --name`` which prints one snapshot name
+    per line in creation order.
+    """
+    result = run_virsh(uri, ["snapshot-list", name, "--name"])
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def virsh_capabilities(uri: str) -> str:
+    """Return the raw XML output of ``virsh capabilities``."""
+    result = run_virsh(uri, ["capabilities"])
+    return result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Tempfile helper for XML handoff to ``virsh snapshot-create --xmlfile``.
+# ---------------------------------------------------------------------------
+
+
+@contextlib.contextmanager
+def _xml_tempfile(xml: str) -> Iterator[str]:
+    """Yield a path to a tempfile containing ``xml``; clean up on exit.
+
+    ``virsh snapshot-create --xmlfile -`` (stdin) is unreliable on RHEL 7-era
+    ``virsh``. Using an on-disk tempfile is consistent across distros. The
+    file is deleted even when the body raises; cleanup errors are swallowed
+    silently because best-effort unlink is good enough for a temp file.
+    """
+    path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            suffix=".xml",
+            prefix="lvlab-snapshot-",
+            delete=False,
+        ) as fh:
+            fh.write(xml)
+            path = fh.name
+        yield path
+    finally:
+        if path and os.path.exists(path):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass


### PR DESCRIPTION
## Summary

- Adds \`tkc_lvlab/utils/virsh.py\` — the foundation for replacing the \`libvirt-python\` C-extension dependency with \`virsh\` subprocess calls in subsequent Phase 2 steps.
- Adds \`tests/test_virsh.py\` — 47 unit tests with 100% coverage of the new module.

This is **step 1 of 8** in the Phase 2 sequence laid out in \`/tmp/phase2-design.md\` §4. Steps 2+ port \`Machine\` methods and \`cli.py\` callers onto this foundation; they belong to separate PRs.

## What the module provides

- \`run_virsh(uri, args, *, check=True, capture=True, timeout=30.0, input_text=None)\` — main wrapper. Forces \`LC_ALL=C\` and \`LANG=C\` for stable output parsing. Custom \`VirshError(returncode, stderr, args)\` exception.
- \`VirshError\` translation for \`FileNotFoundError\` (missing \`virsh\` binary → rc=127) and \`TimeoutExpired\` (→ rc=-1).
- State-string remap: \`DOMSTATE_HUMAN\` + \`RUNNING_STATES\` / \`DEAD_STATES\` / \`SHUTDOWNABLE_STATES\` / \`DESTROYABLE_STATES\` sets. \`humanize_state(state, reason)\` for CLI output.
- \`_xml_tempfile\` context manager for snapshot XML handoff (default \`tempfile\` dir).
- Convenience parsers: \`virsh_list_all_names\`, \`virsh_domstate\`, \`virsh_domstate_reason\`, \`virsh_snapshot_names\`, \`virsh_capabilities\`.

## Locked-in design decisions

Per user resolution of the open items in \`/tmp/phase2-design.md\` §8:

- 30s default timeout (callers like \`Machine.create_snapshot\` will pass \`timeout=120.0\` explicitly in step 3).
- Default \`tempfile\` directory (\`\$TMPDIR\`/\`/tmp\`).

The other two locked decisions (\`down --force\` semantics; dropping reason from \`lvlab status\`) belong to step 3 and 5 of the sequence.

## Implementation notes

- \`VirshError.args\` is restored after \`super().__init__()\` clobbering — \`BaseException\` coerces \`args\` to a tuple, so we bypass that and override \`__str__\` to build the message lazily.
- Reason-string keys (\`_REASON_HUMAN\` dict) derived from libvirt's \`virDomainRunningReason\` / \`virDomainShutdownReason\` / \`virDomainShutoffReason\` enums. Unknown reasons fall back to the raw string — no \`KeyError\`. Human strings preserved verbatim from the existing \`_humanize_machine_status\` so CLI output is identical across the port.

## Test plan

- [x] \`uv run pytest -v\` → 47 passed, 0 failed
- [x] Coverage of \`tkc_lvlab/utils/virsh.py\` is **100%** (76 stmts, 10 branches, 0 missing, 0 partial)
- [x] \`pre-commit run --all-files\` passes
- [ ] After merge: step 2 begins (Machine.exists_in_libvirt port + state-string callers in \`libvirt.py\` and \`cli.py\`)

## Risk

- Low. New module with no callers yet — nothing in the existing codebase depends on it. The \`libvirt-python\` import in \`tkc_lvlab/utils/libvirt.py\` is untouched in this step; lvlab still uses the C extension for everything. Step 2+ port callers onto this foundation.

## Follow-up (after #71 lands)

The new module follows the Google-style + type-hint convention from PR #71. After #71 merges, a small follow-up will:
- Add \`docs/api/utils/virsh.md\` with \`::: tkc_lvlab.utils.virsh\` for mkdocstrings.
- Move \`tkc_lvlab.utils.virsh\` from "pending migration" to "migrated" in \`docs/api/index.md\`.
- Add the page to \`mkdocs.yml\` nav.

That follow-up can land in this PR via rebase if #71 merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)