### PR TITLE
chore: add mdformat pre-commit hook with mkdocs + GFM plugins

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,7 @@
 ## Test plan
 
 <!-- How to verify locally. Check what you actually ran. -->
+
 - [ ] `uv sync --group dev`
 - [ ] `uv run pytest` (or note why a test isn't applicable)
 - [ ] `pre-commit run --all-files`

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,11 @@ repos:
     rev: 24.4.2
     hooks:
       - id: black
+  - repo: https://github.com/hukkin/mdformat
+    rev: 0.7.21
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-mkdocs==4.1.2
+          - mdformat-gfm==0.4.1
+          - more_itertools<11

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,10 +7,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 `tkc-lvlab` (binary: `lvlab`) is a Click-based CLI that manages local libvirt+QEMU lab VMs from a single declarative YAML manifest (`Lvlab.yml`). It is meant for end-to-end integration testing of configuration-management code (Salt, Ansible, etc.) on a developer workstation — not for production VM management.
 
 A run of `lvlab init` followed by `lvlab up <vm_name>` will:
+
 1. Download and verify a cloud image (checksum + optional GPG of the checksum file).
-2. Create a qcow2 disk that uses the cloud image as a backing file (via `qemu-img`).
-3. Render cloud-init `meta-data`, `user-data`, and `network-config` from Jinja2 templates, pack them into a `cidata.iso` (built in-process with `pycdlib`), and attach it as a cdrom.
-4. Shell out to `virt-install` to define and launch the domain.
+1. Create a qcow2 disk that uses the cloud image as a backing file (via `qemu-img`).
+1. Render cloud-init `meta-data`, `user-data`, and `network-config` from Jinja2 templates, pack them into a `cidata.iso` (built in-process with `pycdlib`), and attach it as a cdrom.
+1. Shell out to `virt-install` to define and launch the domain.
 
 Because state lives in libvirt + on-disk qcow2 files, **bugs here can damage real VMs the developer cares about.** Treat destructive paths (`destroy`, `down`, snapshot `delete`) with care — there is no separate test hypervisor.
 
@@ -43,6 +44,7 @@ Python floor is `>=3.11` in `pyproject.toml`. The release workflow builds with 3
 The code is organized around the `Lvlab.yml` manifest. Read `parse_config()` first — every command starts there.
 
 `Lvlab.yml` has two top-level sections:
+
 - `environment[0]` — exactly one environment with `name`, `libvirt_uri`, `config_defaults` (cpu/memory/disks/interfaces/cloud_init that apply to every machine), and a list of `machines`.
 - `images` — a dict of named cloud images (URL + checksum + GPG + cloud-init network schema version).
 
@@ -51,11 +53,12 @@ The code is organized around the `Lvlab.yml` manifest. Read `parse_config()` fir
 `tkc_lvlab/cli.py` defines the Click command group. Every command follows the same shape:
 
 1. `parse_config()` returns `(environment, images, config_defaults, machines)`.
-2. `get_machine_by_vm_name(machines, vm_name)` finds the manifest entry.
-3. `Machine(machine_config, environment, config_defaults)` merges defaults into the machine and exposes operations against libvirt.
-4. For `up`, a `CloudImage` + `VirtualDisk` + `CloudInitIso` are constructed alongside the `Machine`.
+1. `get_machine_by_vm_name(machines, vm_name)` finds the manifest entry.
+1. `Machine(machine_config, environment, config_defaults)` merges defaults into the machine and exposes operations against libvirt.
+1. For `up`, a `CloudImage` + `VirtualDisk` + `CloudInitIso` are constructed alongside the `Machine`.
 
 `tkc_lvlab/utils/libvirt.py` — `Machine` is the central object. Key things to know:
+
 - The libvirt domain name is **not** `vm_name`; it's `f"{vm_name}_{environment_name}"` (see `self.libvirt_vm_name`). This namespacing is what lets multiple lvlab environments coexist on one hypervisor. Anything that looks up a domain by name must use `libvirt_vm_name`.
 - `Machine.__init__` merges `config_defaults` into the machine dict (interfaces, disks, and top-level keys). When adding a new configurable field, follow that same pattern instead of reading from `config_defaults` at call sites.
 - `Machine.deploy()` shells out to `virt-install`. The `--os-variant` value is derived by splitting `self.os` on `-` and taking the first segment — this is why custom images must be named `{os_variant}-{anything}` (see `docs/Walkthrough.md` "Image Naming").
@@ -64,6 +67,7 @@ The code is organized around the `Lvlab.yml` manifest. Read `parse_config()` fir
 `tkc_lvlab/utils/cloud_init.py` — three dataclasses (`NetworkConfig`, `MetaData`, `UserData`) each render one Jinja template from `tkc_lvlab/templates/`. `CloudInitIso` uses `pycdlib` to build an ISO9660 + Joliet + Rock Ridge image with the three files at the names cloud-init's NoCloud datasource expects (`meta-data`, `user-data`, `network-config`). `UserData.__post_init__` will read an SSH public key from disk if `cloud_init.pubkey` looks like a path; otherwise it treats the value as a literal key.
 
 `tkc_lvlab/utils/images.py` — `CloudImage` knows how to download, GPG-verify the checksum file, and checksum-verify the image. Two non-obvious bits:
+
 - Debian's `SHA512SUMS` file is the **same filename** across releases, so Debian images get a per-image-prefix checksum filename to avoid clobber when multiple Debian versions are configured. The detector is a regex on `debian-(\d+)` in the image filename.
 - The checksum file parser handles both Fedora's `SHA256 (file) = hash` format and Debian's `hash  file` format.
 - When GPG verification succeeds, the verified plaintext is written to `<checksum>.verified` and subsequent operations prefer that file.
@@ -110,12 +114,12 @@ are out-of-nav until the legacy docs conversion lands (see `TODO.md`).
 ### For new code — required
 
 - **Type hints on every public function, method, parameter, and return value.**
-  mkdocstrings reads the signature as the source of truth; do not restate types
-  in the docstring body.
+    mkdocstrings reads the signature as the source of truth; do not restate types
+    in the docstring body.
 - **Google-style docstrings on every public symbol** (module, class, function,
-  method). Section order: one-line summary → blank line → optional longer
-  description → `Args:` → `Returns:` (or `Yields:`) → `Raises:` → `Example:`.
-  Skip sections that don't apply.
+    method). Section order: one-line summary → blank line → optional longer
+    description → `Args:` → `Returns:` (or `Yields:`) → `Raises:` → `Example:`.
+    Skip sections that don't apply.
 
 Example shape:
 
@@ -138,9 +142,9 @@ def parse_checksum_file(path: Path) -> dict[str, str]:
     """
 ```
 
-For classes, document the class itself (one-liner plus an ``Attributes:`` block
+For classes, document the class itself (one-liner plus an `Attributes:` block
 if useful), and document each method separately. `__init__` parameters go in
-the **class-level** docstring's ``Args:`` section, not in `__init__`'s own
+the **class-level** docstring's `Args:` section, not in `__init__`'s own
 docstring — mkdocstrings renders them under the class.
 
 For modules, put a docstring at the top of the file describing what the module
@@ -165,10 +169,12 @@ to the new convention. Don't touch neighbors.
 **Pushes via `gh`'s authenticated PAT are allowed when the user has asked for them**, scoped to the PAT's `contents:write` + `pull-requests:write`. That means `git push` of feature/topic branches and `gh pr create` against `main` are fine in those cases.
 
 The remote `origin` is configured for SSH (`git@github.com:...`) but the gh PAT only authenticates HTTPS. Two consequences:
+
 - For pushes, push to the HTTPS URL explicitly (`git push -u https://github.com/memblin/tkc-lvlab-py.git <branch>`) — `gh auth git-credential` is wired into the global gitconfig and supplies the token. Don't rewrite `origin`; the user uses SSH from their own terminal.
 - Fetches in this environment will also need the HTTPS URL (e.g. `git pull https://github.com/memblin/tkc-lvlab-py.git main`) because no SSH key here has read access.
 
 **Still off-limits without an explicit, scoped request:**
+
 - Force-push of any kind (`--force`, `--force-with-lease`).
 - Pushing tags — tag pushes on `main` trigger `.github/workflows/build-release.yml` and cut a real GitHub release. See "Releasing".
 - Pushes directly to `main` (the "Branching" rule still applies — work goes through PRs).

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ Commands:
 - Libvirt w/ QEMU configured and functional
 - The user should be a member of the `libvirt` group on the system
 - Utilities: virt-install, qemu-img (For now until we can implement these
-              parts via libvirt-python)
+    parts via libvirt-python)
 - `cloud_image_basedir` and `disk_image_basedir` configuration paths need
-  to be writable by the user to run w/o sudo.
-  - I usually create these directories in advance and chown them for my
-    user.
+    to be writable by the user to run w/o sudo.
+    - I usually create these directories in advance and chown them for my
+        user.
 
 ### Ubuntu 22.04
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ Roadmap for the next few sessions. Phases are ordered by dependency, not strict
 calendar. Phase 5 onward is blocked until the Claude session is restarted so
 the `.claude/settings.local.json` grant for `lvscripts-py` takes effect.
 
----
+______________________________________________________________________
 
 ## Phase 1 — Migrate Poetry → uv, refresh deps, add Python matrix ✅ COMPLETE
 
@@ -16,36 +16,36 @@ its own Phase 3 — it depends on Phase 2 landing first so the conftest
 doesn't have to mock around `libvirt-python`.
 
 - [x] Use `uv_build` as the PEP 517 build backend.
-      `requires = ["uv_build>=0.5,<0.12"]` with `build-backend = "uv_build"`.
+    `requires = ["uv_build>=0.5,<0.12"]` with `build-backend = "uv_build"`.
 - [x] Rewrite `pyproject.toml` to PEP 621:
-  - [x] `[project]` with name/version/description/authors/readme and
+    - [x] `[project]` with name/version/description/authors/readme and
         `requires-python = ">=3.11"`. License/classifiers skipped (no
         `LICENSE` file in repo yet — revisit later).
-  - [x] `[project.dependencies]` and `[project.scripts]` populated.
-  - [x] Poetry-only `include = [...]` dropped. Templates verified shipping
+    - [x] `[project.dependencies]` and `[project.scripts]` populated.
+    - [x] Poetry-only `include = [...]` dropped. Templates verified shipping
         via `unzip -l dist/*.whl | grep templates`. Layout config set
         under `[tool.uv.build-backend]` (`module-root = ""`,
         `module-name = "tkc_lvlab"`).
-  - [x] `[dependency-groups]` `dev` table with `pytest`, `pytest-cov`,
+    - [x] `[dependency-groups]` `dev` table with `pytest`, `pytest-cov`,
         `pysonar`. Installed via `uv sync --group dev`.
 - [x] `poetry.lock` removed, `uv.lock` generated and committed.
 - [x] `requirements.txt` removed.
 - [x] Dep floors refreshed; post-migration hardening raised
-      `requests>=2.33` and `jinja2>=3.1.6` to lock in the Dependabot fixes
-      against future fresh resolves. `libvirt-python` kept pinned (drops
-      entirely in Phase 2).
+    `requests>=2.33` and `jinja2>=3.1.6` to lock in the Dependabot fixes
+    against future fresh resolves. `libvirt-python` kept pinned (drops
+    entirely in Phase 2).
 - [x] `.github/workflows/build-release.yml` rewritten:
-  - [x] `astral-sh/setup-uv@v3` + `uv build` replaces poetry install +
+    - [x] `astral-sh/setup-uv@v3` + `uv build` replaces poetry install +
         `poetry build`.
-  - [x] Dropped the `apt install libvirt-dev` step — `uv build` does not
+    - [x] Dropped the `apt install libvirt-dev` step — `uv build` does not
         install runtime deps. Developers still need it until Phase 2 lands.
 - [x] `README.md` install instructions updated to `uv tool install`
-      (release path) and `uv sync && uv run lvlab` (dev path).
+    (release path) and `uv sync && uv run lvlab` (dev path).
 - [x] `CLAUDE.md` "Build / dev / lint commands" section updated to uv.
 - [x] `pre-commit` verified working after migration.
 - [x] `.github/dependabot.yml` added — uv weekly, github-actions monthly.
 
----
+______________________________________________________________________
 
 ## Phase 2 — Replace `libvirt-python` with `virsh` subprocess calls
 
@@ -63,55 +63,55 @@ plus one stray `conn.getCapabilities()` in `tkc_lvlab/cli.py`.
 ### Implementation
 
 - [ ] Build a small subprocess wrapper at `tkc_lvlab/utils/virsh.py`:
-  - [ ] `run_virsh(uri, args, check=True, capture=True) -> CompletedProcess`
+    - [ ] `run_virsh(uri, args, check=True, capture=True) -> CompletedProcess`
         — wraps `subprocess.run(["virsh", "-c", uri, *args], env={..., "LC_ALL": "C"})`
         so output is locale-stable.
-  - [ ] Custom `VirshError(returncode, stderr)` so callers can `except VirshError`
+    - [ ] Custom `VirshError(returncode, stderr)` so callers can `except VirshError`
         without leaking `subprocess.CalledProcessError` everywhere.
 - [ ] Port the `Machine` methods in `tkc_lvlab/utils/libvirt.py`:
-  - [ ] `Machine.exists_in_libvirt` → `virsh list --all --name`, exact match.
-  - [ ] `Machine.destroy` / `Machine.shutdown` / `Machine.poweron` →
+    - [ ] `Machine.exists_in_libvirt` → `virsh list --all --name`, exact match.
+    - [ ] `Machine.destroy` / `Machine.shutdown` / `Machine.poweron` →
         `virsh destroy|shutdown|start <name>`.
-  - [ ] `Machine.list_snapshots` → `virsh snapshot-list <name> --name`.
-  - [ ] `Machine.create_snapshot` → `virsh snapshot-create <name> --xmlfile <path>`.
+    - [ ] `Machine.list_snapshots` → `virsh snapshot-list <name> --name`.
+    - [ ] `Machine.create_snapshot` → `virsh snapshot-create <name> --xmlfile <path>`.
         **Sharp edge:** `--xmlfile` needs a real path. Use `tempfile.NamedTemporaryFile`
         (delete after) rather than relying on stdin redirection — virsh's stdin
         handling for `--xmlfile -` varies by version.
-  - [ ] `Machine.delete_snapshot` → `virsh snapshot-delete <name> <snapshot_name>`.
-  - [ ] `Machine.hasCurrentSnapshot` equivalent — `virsh snapshot-list <name> --name`
+    - [ ] `Machine.delete_snapshot` → `virsh snapshot-delete <name> <snapshot_name>`.
+    - [ ] `Machine.hasCurrentSnapshot` equivalent — `virsh snapshot-list <name> --name`
         and check non-empty (used in `destroy()` cleanup path).
-  - [ ] `capabilities` command (`cli.py:30-35`) → `virsh capabilities` stdout.
-  - [ ] `status` command (`cli.py:385-422`) → single `virsh list --all` parse,
+    - [ ] `capabilities` command (`cli.py:30-35`) → `virsh capabilities` stdout.
+    - [ ] `status` command (`cli.py:385-422`) → single `virsh list --all` parse,
         not one `domstate` call per declared VM (cuts startup overhead).
 - [ ] Replace dynamic state-constant reflection. Drop `get_machine_state`
-      (libvirt.py:546) and `_humanize_machine_status` (libvirt.py:493) in
-      their current form:
-  - [ ] `virsh domstate <name>` returns a human string: `running`, `idle`,
+    (libvirt.py:546) and `_humanize_machine_status` (libvirt.py:493) in
+    their current form:
+    - [ ] `virsh domstate <name>` returns a human string: `running`, `idle`,
         `paused`, `in shutdown`, `shut off`, `crashed`, `pmsuspended`.
         Replace the integer-keyed dynamic dict with a hardcoded `str → human`
         map keyed on those exact strings.
-  - [ ] Use `virsh domstate <name> --reason` for the reason string. Build the
+    - [ ] Use `virsh domstate <name> --reason` for the reason string. Build the
         analogous reason map.
-  - [ ] Audit every caller that compares against `"VIR_DOMAIN_*"` strings
+    - [ ] Audit every caller that compares against `"VIR_DOMAIN_*"` strings
         (`cli.py:126`, `cli.py:137`, `cli.py:443`, `cli.py:447`,
         `libvirt.py:301`, `libvirt.py:307`, `libvirt.py:440`, `libvirt.py:463`)
         and switch them to the new lowercase virsh state strings.
 - [ ] Drop `libvirt-python` from `[project.dependencies]` in `pyproject.toml`.
-      Regenerate `uv.lock`. Update `CLAUDE.md`'s "Install deps" note — at
-      build time we no longer need `libvirt-dev` / `pkg-config`, only
-      `libvirt-clients` (or distro equivalent) at runtime.
+    Regenerate `uv.lock`. Update `CLAUDE.md`'s "Install deps" note — at
+    build time we no longer need `libvirt-dev` / `pkg-config`, only
+    `libvirt-clients` (or distro equivalent) at runtime.
 - [ ] After regenerating `uv.lock`, diff it against the previous lock and
-      confirm the only changes are `libvirt-python` removal plus any
-      transitives uniquely brought in by it. Surprise shifts in
-      `requests` / `urllib3` / `idna` / `jinja2` / `cryptography` resolved
-      versions should be investigated before merging — those are the
-      packages Dependabot has historically flagged.
+    confirm the only changes are `libvirt-python` removal plus any
+    transitives uniquely brought in by it. Surprise shifts in
+    `requests` / `urllib3` / `idna` / `jinja2` / `cryptography` resolved
+    versions should be investigated before merging — those are the
+    packages Dependabot has historically flagged.
 - [ ] Update `CLAUDE.md` Architecture section: remove `libvirt-python` API
-      references, document the `virsh` subprocess pattern and the
-      `tkc_lvlab/utils/virsh.py` helper.
+    references, document the `virsh` subprocess pattern and the
+    `tkc_lvlab/utils/virsh.py` helper.
 - [ ] Remove `continue-on-error: true` for Python 3.14 in the test workflow
-      (Phase 3); 3.14 should be a first-class matrix entry once libvirt-python
-      is gone.
+    (Phase 3); 3.14 should be a first-class matrix entry once libvirt-python
+    is gone.
 
 ### Standardize destructive-path UX (do it here, not as a separate pass)
 
@@ -119,30 +119,30 @@ We're rewriting all destructive code paths in this phase anyway. Land the
 hardening at the same time so we don't churn these files twice.
 
 - [ ] `snapshot delete` gets a `--force` flag + confirmation prompt, mirroring
-      `destroy` (already done in the Phase 0 incidentals commit, but verify
-      consistency once the underlying call is virsh-based).
+    `destroy` (already done in the Phase 0 incidentals commit, but verify
+    consistency once the underlying call is virsh-based).
 - [ ] Every destructive command surfaces the actual `virsh` stderr on failure
-      paths — no more silent "deletion failed" with no detail.
+    paths — no more silent "deletion failed" with no detail.
 - [ ] Audit `down` for whether it should consume the same `--force` semantics
-      as `destroy` (decision pending).
+    as `destroy` (decision pending).
 
 ### Phase 2 risks / sharp edges
 
 - **Snapshot XML handoff:** confirm tempfile approach works on all target
-  distros' `virsh` versions. Backup plan: keep XML as a Python heredoc string
-  and write to a temp file inside `run_virsh`.
+    distros' `virsh` versions. Backup plan: keep XML as a Python heredoc string
+    and write to a temp file inside `run_virsh`.
 - **Locale:** force `LC_ALL=C` for every `virsh` invocation; output parsing
-  depends on it.
+    depends on it.
 - **Performance:** each `virsh` call pays subprocess startup overhead
-  (~50ms). Fine for interactive CLI use; `status` should batch via a single
-  `virsh list --all` rather than N `domstate` calls.
+    (~50ms). Fine for interactive CLI use; `status` should batch via a single
+    `virsh list --all` rather than N `domstate` calls.
 - **Error surface change:** existing code catches `libvirt.libvirtError`.
-  After the port it catches `VirshError`. Don't broaden to bare `except Exception`.
+    After the port it catches `VirshError`. Don't broaden to bare `except Exception`.
 - **Pre-port incidentals already landed:** dead `delete_vdisks()` removed,
-  unused snapshot params cleaned, `snapshot delete` confirm/`--force` added
-  in the pre-Phase-1 housekeeping commit. Don't re-do these.
+    unused snapshot params cleaned, `snapshot delete` confirm/`--force` added
+    in the pre-Phase-1 housekeeping commit. Don't re-do these.
 
----
+______________________________________________________________________
 
 ## Phase 3 — Test infrastructure (depends on Phase 1 matrix + Phase 2 port)
 
@@ -150,39 +150,39 @@ Land after Phase 2 — the conftest is dramatically simpler with no
 `libvirt-python` C extension to mock around.
 
 - [ ] Add `.github/workflows/test.yml`:
-  - [ ] Matrix: `python-version: ['3.11', '3.12', '3.13', '3.14']`.
-  - [ ] Job step: `uv sync --all-extras && uv run pytest -m "not integration"`.
-  - [ ] 3.14 is a first-class entry, **not** `continue-on-error` (libvirt-python
+    - [ ] Matrix: `python-version: ['3.11', '3.12', '3.13', '3.14']`.
+    - [ ] Job step: `uv sync --all-extras && uv run pytest -m "not integration"`.
+    - [ ] 3.14 is a first-class entry, **not** `continue-on-error` (libvirt-python
         is gone by now).
 - [ ] Create `tests/conftest.py` with the safety scaffolding (see
-      "Cross-cutting safety rules" below).
+    "Cross-cutting safety rules" below).
 - [ ] Seed a small set of pure-unit tests (no libvirt, no qemu-img) to prove
-      the matrix runs end-to-end before we start writing real coverage:
-  - [ ] `parse_config()` happy / missing-file / bad-yaml cases.
-  - [ ] `parse_file_from_url()`.
-  - [ ] `CloudImage._parse_checksum_file()` — both Fedora and Debian formats,
+    the matrix runs end-to-end before we start writing real coverage:
+    - [ ] `parse_config()` happy / missing-file / bad-yaml cases.
+    - [ ] `parse_file_from_url()`.
+    - [ ] `CloudImage._parse_checksum_file()` — both Fedora and Debian formats,
         including the `.verified` swap.
-  - [ ] `UserData._is_valid_ssh_public_key()`.
-  - [ ] `Machine.libvirt_vm_name` construction (`vm_name_environment`).
-  - [ ] `run_virsh()` wrapper — stub `subprocess.run`, verify args / env /
+    - [ ] `UserData._is_valid_ssh_public_key()`.
+    - [ ] `Machine.libvirt_vm_name` construction (`vm_name_environment`).
+    - [ ] `run_virsh()` wrapper — stub `subprocess.run`, verify args / env /
         error translation.
 - [ ] Mark anything that touches `virsh` for real, `qemu-img`, or libvirt
-      with `@pytest.mark.integration`; require `LVLAB_INTEGRATION=1` to opt
-      in and never enable it in CI.
+    with `@pytest.mark.integration`; require `LVLAB_INTEGRATION=1` to opt
+    in and never enable it in CI.
 
----
+______________________________________________________________________
 
 ## Phase 4 — Documentation pass after uv + virsh migrations
 
 - [ ] `docs/Walkthrough.md` — replace any `poetry build` / pip-install lines
-      with uv equivalents. Remove any "needs libvirt-dev" notes that no
-      longer apply.
+    with uv equivalents. Remove any "needs libvirt-dev" notes that no
+    longer apply.
 - [ ] `docs/CONTRIBUTING.md` (if it references Poetry — verify).
 - [ ] `README.md` Requirements section: replace `libvirt-python` build
-      requirements with the runtime `libvirt-clients` requirement. Confirm
-      no Poetry remnants.
+    requirements with the runtime `libvirt-clients` requirement. Confirm
+    no Poetry remnants.
 
----
+______________________________________________________________________
 
 ## Phase 5 — Survey `lvscripts-py` (blocked on session restart)
 
@@ -192,22 +192,22 @@ just added).
 
 - [ ] Read `lvscripts-py/CLAUDE.md` and `README.md` to understand intent.
 - [ ] Inventory the public surface: what scripts ship, what flags they take,
-      what they do top-to-bottom.
+    what they do top-to-bottom.
 - [ ] Map functional overlap with `tkc-lvlab`:
-  - cloud-image download/verify
-  - cloud-init ISO build
-  - qcow2 backing-disk creation
-  - virt-install invocation
-  - libvirt domain lifecycle (define / start / shutdown / destroy / undefine)
+    - cloud-image download/verify
+    - cloud-init ISO build
+    - qcow2 backing-disk creation
+    - virt-install invocation
+    - libvirt domain lifecycle (define / start / shutdown / destroy / undefine)
 - [ ] Identify capabilities lvlab does **not** have today, especially:
-  - [ ] One-off `createvm <name> --os ... --memory ... --disk ...` style entry
+    - [ ] One-off `createvm <name> --os ... --memory ... --disk ...` style entry
         without needing an `Lvlab.yml`.
-  - [ ] Anything around image building / customization, NAT/bridge wiring,
+    - [ ] Anything around image building / customization, NAT/bridge wiring,
         or post-create provisioning.
 - [ ] Decide on per-feature disposition: **port**, **adapt**, **skip**, or
-      **leave to lvscripts**.
+    **leave to lvscripts**.
 
----
+______________________________________________________________________
 
 ## Phase 6 — Merge `createvm` / `destroyvm` into `lvlab`
 
@@ -216,26 +216,26 @@ creation, sharing the same `Machine` / `CloudImage` / `VirtualDisk` /
 `CloudInitIso` machinery.
 
 - [ ] CLI shape:
-  - [ ] `lvlab vm create <name> [--os …] [--memory …] [--cpu …] [--disk …] [--network …] [--pubkey …]` — manifest-less one-off.
-  - [ ] `lvlab vm destroy <name>` — one-off teardown (no Lvlab.yml lookup).
-  - [ ] Existing `lvlab up` / `lvlab destroy` / `lvlab status` continue to be
+    - [ ] `lvlab vm create <name> [--os …] [--memory …] [--cpu …] [--disk …] [--network …] [--pubkey …]` — manifest-less one-off.
+    - [ ] `lvlab vm destroy <name>` — one-off teardown (no Lvlab.yml lookup).
+    - [ ] Existing `lvlab up` / `lvlab destroy` / `lvlab status` continue to be
         manifest-driven and unchanged.
-  - [ ] Expose `createvm` and `destroyvm` as additional `[project.scripts]`
+    - [ ] Expose `createvm` and `destroyvm` as additional `[project.scripts]`
         thin shims to the same Click commands (for muscle memory from users
         coming from lvscripts).
 - [ ] Refactor where the merge exposes duplication:
-  - [ ] If lvscripts has a cleaner abstraction we want, port it and make
+    - [ ] If lvscripts has a cleaner abstraction we want, port it and make
         manifest-driven commands use it too — don't keep two implementations.
 - [ ] Naming guard: one-off VMs should still be namespaced. Either reuse
-      `{vm_name}_{environment}` with a sentinel environment like `_oneoff`,
-      or introduce a distinct prefix like `oneoff-{vm_name}`. **Decide
-      explicitly** — this affects how `status`/listing finds them.
+    `{vm_name}_{environment}` with a sentinel environment like `_oneoff`,
+    or introduce a distinct prefix like `oneoff-{vm_name}`. **Decide
+    explicitly** — this affects how `status`/listing finds them.
 - [ ] Tests for both code paths (manifest and one-off) share the same safety
-      fixture (see below).
+    fixture (see below).
 - [ ] Docs: extend `README.md` and `docs/Walkthrough.md` with the one-off
-      workflow. Add a section explaining when to use which.
+    workflow. Add a section explaining when to use which.
 
----
+______________________________________________________________________
 
 ## Cross-cutting safety rules (apply to every phase that writes tests)
 
@@ -245,28 +245,28 @@ prefix.** Existing developer VMs on the same hypervisor must be invisible to
 the test suite.
 
 - [ ] `tests/conftest.py` exports:
-  - [ ] `LVLAB_TEST_PREFIX` — generated once per session:
+    - [ ] `LVLAB_TEST_PREFIX` — generated once per session:
         `f"lvlab-test-{epoch_ms}-{random4}-"` (epoch + short random to avoid
         collisions across parallel runs).
-  - [ ] `make_test_name(base) -> str` — the only sanctioned way for tests to
+    - [ ] `make_test_name(base) -> str` — the only sanctioned way for tests to
         name a resource. Returns `f"{LVLAB_TEST_PREFIX}{base}"`.
-  - [ ] `assert_owned_by_test(name) -> None` — raises if `name` does not
+    - [ ] `assert_owned_by_test(name) -> None` — raises if `name` does not
         start with `LVLAB_TEST_PREFIX`. Called before every destructive op
         in test helpers.
-  - [ ] A session-scoped teardown that runs `virsh list --all --name`
+    - [ ] A session-scoped teardown that runs `virsh list --all --name`
         *filtered by the prefix* and reaps any that survived a crashing test.
         **Never list all domains; only ones matching the prefix.**
 - [ ] Same prefix applies to:
-  - [ ] On-disk paths (`disk_image_basedir` for tests must be a temp dir,
+    - [ ] On-disk paths (`disk_image_basedir` for tests must be a temp dir,
         not the developer's shared `~/.local/lvlab/...`).
-  - [ ] Cloud-init ISOs and the per-VM config directory.
+    - [ ] Cloud-init ISOs and the per-VM config directory.
 - [ ] Add a lint/grep check (or pytest plugin) that fails CI if a test calls
-      `virsh destroy` / `virsh undefine` / `os.remove()` on a name that
-      didn't come from `make_test_name`.
+    `virsh destroy` / `virsh undefine` / `os.remove()` on a name that
+    didn't come from `make_test_name`.
 - [ ] Integration tests **must** use a dedicated `libvirt_uri` or at least a
-      dedicated network and storage pool so cleanup can be scoped further.
+    dedicated network and storage pool so cleanup can be scoped further.
 
----
+______________________________________________________________________
 
 ## Phase 7 — Legacy docstring + type-hint conversion
 
@@ -280,17 +280,17 @@ Modules to convert (one PR per module is fine; one PR for the whole sweep is
 also fine — pick what reviews cleanly):
 
 - [ ] `tkc_lvlab/cli.py` — biggest surface, Click commands and docstrings
-      become the `--help` output. Mind that black-formatted Click decorator
-      output and Google `Args:` headings interact awkwardly; verify with
-      `uv run lvlab --help` after conversion.
+    become the `--help` output. Mind that black-formatted Click decorator
+    output and Google `Args:` headings interact awkwardly; verify with
+    `uv run lvlab --help` after conversion.
 - [ ] `tkc_lvlab/config.py` — `parse_config`, `generate_hosts`,
-      `generate_hosts_entries`, `parse_hosts_file`.
+    `generate_hosts_entries`, `parse_hosts_file`.
 - [ ] `tkc_lvlab/_logging.py` — `get_logger`, `configure_logging`.
 - [ ] `tkc_lvlab/utils/cloud_init.py` — three dataclasses and `CloudInitIso`.
 - [ ] `tkc_lvlab/utils/images.py` — `CloudImage` and its parsers.
 - [ ] `tkc_lvlab/utils/libvirt.py` — `Machine` and its methods. **Wait until
-      Phase 2 ports finish** — the methods change shape and types in Phase 2,
-      so converting here too early just creates rework.
+    Phase 2 ports finish** — the methods change shape and types in Phase 2,
+    so converting here too early just creates rework.
 - [ ] `tkc_lvlab/utils/vdisk.py` — `VirtualDisk` (small).
 
 After each module is converted, remove its name from the "Modules pending
@@ -305,20 +305,19 @@ The legacy user-facing docs (`docs/Walkthrough.md`, `Design.md`, `Why.md`,
 out of `exclude_docs`) as each one gets its turn at modernization. That's a
 separate effort from the docstring conversion.
 
----
+______________________________________________________________________
 
 ## Decisions still open (call these out before Phase 6 lands)
 
 1. ~~Build backend~~ — decided: `uv_build`. No hatchling, no setuptools.
-2. ~~Python floor~~ — decided: drop 3.10, `requires-python = ">=3.11"`.
-   Phase 2 makes this consequence-free since libvirt-python is gone.
-3. ~~One-off VM namespacing~~ — decided in Phase 2 design doc
-   (`/tmp/phase2-design.md` §5): sentinel environment `_oneoff`.
-4. Whether to keep `createvm` / `destroyvm` as separate console_scripts, or
-   only expose `lvlab vm create` / `lvlab vm destroy`.
-5. ~~Phase 2: snapshot XML handoff~~ — decided: tempfile. Stdin path
-   reserved for future use.
-6. ~~Phase 2: `down --force`~~ — decided: yes, with **different** semantics
-   than `destroy --force` (force-off without undefine; calls `virsh destroy
-   <name>`). Documented asymmetry in command help text at implementation
-   time.
+1. ~~Python floor~~ — decided: drop 3.10, `requires-python = ">=3.11"`.
+    Phase 2 makes this consequence-free since libvirt-python is gone.
+1. ~~One-off VM namespacing~~ — decided in Phase 2 design doc
+    (`/tmp/phase2-design.md` §5): sentinel environment `_oneoff`.
+1. Whether to keep `createvm` / `destroyvm` as separate console_scripts, or
+    only expose `lvlab vm create` / `lvlab vm destroy`.
+1. ~~Phase 2: snapshot XML handoff~~ — decided: tempfile. Stdin path
+    reserved for future use.
+1. ~~Phase 2: `down --force`~~ — decided: yes, with **different** semantics
+    than `destroy --force` (force-off without undefine; calls `virsh destroy <name>`). Documented asymmetry in command help text at implementation
+    time.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -42,7 +42,7 @@ pre-commit run --all-files
 The project uses..
 
 - [Poetry](https://python-poetry.org/docs/) for dependency management and
-  packaging. Poetry install directions are in the docs linked here.
+    packaging. Poetry install directions are in the docs linked here.
 
 These are some common poetry commands:
 
@@ -62,11 +62,11 @@ poetry build
 ```
 
 - [pre-commit](https://pre-commit.com/)
-  - hooks
-      - id: check-yaml
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
-      - id: black
+    - hooks
+        - id: check-yaml
+        - id: end-of-file-fixer
+        - id: trailing-whitespace
+        - id: black
 
 ```bash
 # Install our pre-commit hooks in the repo after cloning

--- a/docs/Design.md
+++ b/docs/Design.md
@@ -34,7 +34,7 @@ about proper use.
 ## Goals
 
 - First, and foremost; A functional tool that is safe and easy to use for
-  local libvirt+qemu based integration testing of systems management code.
+    local libvirt+qemu based integration testing of systems management code.
 
-  Think full end-to-end environmental testing of Salt, Ansible, Chef, or
-  Puppet environments.
+    Think full end-to-end environmental testing of Salt, Ansible, Chef, or
+    Puppet environments.

--- a/docs/WIP.md
+++ b/docs/WIP.md
@@ -27,5 +27,5 @@ sudo chown -R $user:$group /var/lib/libvirt/images/lvlab
 ```
 
 - With `/var/lib/libvirt/images/lvlab` writeable we can create the subdirs
-  ourselves without root privileges.
+    ourselves without root privileges.
 - Libvirt will sometimes change the uid/gid on a image file or iso

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,11 +10,11 @@ workstation — not for production VM management.
 `lvlab init` followed by `lvlab up <vm_name>` will:
 
 1. Download and verify a cloud image (checksum + optional GPG of the checksum file).
-2. Create a qcow2 disk that uses the cloud image as a backing file (via `qemu-img`).
-3. Render cloud-init `meta-data`, `user-data`, and `network-config` from Jinja2
-   templates, pack them into a `cidata.iso` (built in-process with `pycdlib`),
-   and attach it as a cdrom.
-4. Shell out to `virt-install` to define and launch the domain.
+1. Create a qcow2 disk that uses the cloud image as a backing file (via `qemu-img`).
+1. Render cloud-init `meta-data`, `user-data`, and `network-config` from Jinja2
+    templates, pack them into a `cidata.iso` (built in-process with `pycdlib`),
+    and attach it as a cdrom.
+1. Shell out to `virt-install` to define and launch the domain.
 
 ## Install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ dev = [
     "mkdocs>=1.6",
     "mkdocs-material>=9.5",
     "mkdocstrings[python]>=0.27",
+    "mdformat>=0.7",
+    "mdformat-mkdocs>=4.0",
+    "mdformat-gfm>=0.4",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -326,6 +326,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -397,6 +409,69 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdformat"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/05/32b5e14b192b0a8a309f32232c580aefedd9d06017cb8fe8fce34bec654c/mdformat-1.0.0.tar.gz", hash = "sha256:4954045fcae797c29f86d4ad879e43bb151fa55dbaf74ac6eaeacf1d45bb3928", size = 56953, upload-time = "2025-10-16T12:05:03.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/9a/8fe71b95985ca7a4001effbcc58e5a07a1f2a2884203f74dcf48a3b08315/mdformat-1.0.0-py3-none-any.whl", hash = "sha256:bca015d65a1d063a02e885a91daee303057bc7829c2cd37b2075a50dbb65944b", size = 53288, upload-time = "2025-10-16T12:05:02.607Z" },
+]
+
+[[package]]
+name = "mdformat-gfm"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "mdformat" },
+    { name = "mdit-py-plugins" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/6f/a626ebb142a290474401b67e2d61e73ce096bf7798ee22dfe6270f924b3f/mdformat_gfm-1.0.0.tar.gz", hash = "sha256:d1d49a409a6acb774ce7635c72d69178df7dce1dc8cdd10e19f78e8e57b72623", size = 10112, upload-time = "2025-10-16T09:12:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/18/6bc2189b744dd383cad03764f41f30352b1278d2205096f77a29c0b327ad/mdformat_gfm-1.0.0-py3-none-any.whl", hash = "sha256:7305a50efd2a140d7c83505b58e3ac5df2b09e293f9bbe72f6c7bee8c678b005", size = 10970, upload-time = "2025-10-16T09:12:21.276Z" },
+]
+
+[[package]]
+name = "mdformat-mkdocs"
+version = "5.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "mdformat-gfm" },
+    { name = "mdit-py-plugins" },
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/25/df38de72a291b96fb7af7549c5285e934267f8f0b269d3ccacda84ef764c/mdformat_mkdocs-5.1.4.tar.gz", hash = "sha256:d3ecf035100328c5ff2b3bd7de87a16ee0484e5c317add9c70022598d15af6a1", size = 28160, upload-time = "2026-01-26T12:12:41.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/bf/00ba31df7cd955eb0dbb1b8b0eb388bc6f717f033f807656a12eb8f12a5b/mdformat_mkdocs-5.1.4-py3-none-any.whl", hash = "sha256:6ff339c1023926077c0c598533768433b38981a9eb792ebfe02d2438ba71514d", size = 38377, upload-time = "2026-01-26T12:12:40.326Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -525,6 +600,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/29/33/c225eaf898634bdda489a6766fc35d1683c640bffe0e0acd10646b13536d/mkdocstrings_python-2.0.3.tar.gz", hash = "sha256:c518632751cc869439b31c9d3177678ad2bfa5c21b79b863956ad68fc92c13b8", size = 199083, upload-time = "2026-02-20T10:38:36.368Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/28/79f0f8de97cce916d5ae88a7bee1ad724855e83e6019c0b4d5b3fabc80f3/mkdocstrings_python-2.0.3-py3-none-any.whl", hash = "sha256:0b83513478bdfd803ff05aa43e9b1fca9dd22bcd9471f09ca6257f009bc5ee12", size = 104779, upload-time = "2026-02-20T10:38:34.517Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -776,6 +860,9 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "mdformat" },
+    { name = "mdformat-gfm" },
+    { name = "mdformat-mkdocs" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
@@ -798,6 +885,9 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "mdformat", specifier = ">=0.7" },
+    { name = "mdformat-gfm", specifier = ">=0.4" },
+    { name = "mdformat-mkdocs", specifier = ">=4.0" },
     { name = "mkdocs", specifier = ">=1.6" },
     { name = "mkdocs-material", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.27" },
@@ -906,4 +996,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ee/afaf0f85a9a18fe47a67f1e4422ed6cf1fe642f0ae0a2f81166231303c52/wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0", size = 182132, upload-time = "2026-05-02T16:04:12.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/52/e465037f5375f43533d1a80b6923955201596a99142ed524d77b571a1418/wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2", size = 110825, upload-time = "2026-05-02T16:04:11.033Z" },
 ]


### PR DESCRIPTION
## Summary

- Adds Python-native markdown formatting via [mdformat](https://github.com/hukkin/mdformat) as a pre-commit hook.
- Plugins: \`mdformat-mkdocs\` preserves Material admonitions, content tabs, and mkdocstrings directives; \`mdformat-gfm\` covers GitHub-Flavored Markdown.
- Includes the one-time formatting churn across existing markdown.

## Why

Follow-up to #71. The mkdocs convention work generated a lot of new markdown and we'll keep producing more (docs/api/* per module, PR templates, etc.). mdformat is the markdown equivalent of black — set-and-forget formatting so we don't churn over cosmetics in review.

Python-native (no Node) so it fits the existing toolchain. Without the \`-mkdocs\` plugin, a vanilla markdown formatter would mangle mkdocstrings \`:::\` directives and Material admonitions — the plugin is the reason this is worth doing.

## What changed

- **\`.pre-commit-config.yaml\`** — new mdformat hook. \`additional_dependencies\` are version-pinned to dodge an incompatibility between \`mdformat-mkdocs\` 4.x and \`more_itertools\` 11+ (\`zip_equal\` was removed). Pins: \`mdformat-mkdocs==4.1.2\`, \`mdformat-gfm==0.4.1\`, \`more_itertools<11\`.
- **\`pyproject.toml\`** — dev deps gain the same three packages so \`uv run mdformat ...\` works outside pre-commit too.
- **Markdown reformat** — \`CLAUDE.md\`, \`README.md\`, \`TODO.md\`, \`docs/CONTRIBUTING.md\`, \`docs/Design.md\`, \`docs/WIP.md\`, \`docs/index.md\`, \`.github/pull_request_template.md\` reformatted. No semantic changes; mostly list indentation, fence styles, table padding, line-wrap. The legacy docs that are \`exclude_docs\` in mkdocs.yml (\`Walkthrough.md\`, \`Why.md\`, \`Libvirt.md\`, \`releases.md\`) had no changes — they were already conforming or only stylistically minor.

## Test plan

- [x] \`pre-commit run mdformat --all-files\` runs idempotently (second run \`Passed\`)
- [x] \`pre-commit run --all-files\` passes all hooks
- [x] \`uv run mkdocs build --strict\` clean after the reformat

## Risk

- Low. Cosmetic churn only. mdformat's GFM plugin treats tables and task lists correctly; the mkdocs plugin preserves admonitions/directives. A grep for \`!!!\` / \`:::\` confirms those survived.
- One-time diff. Future PRs touching markdown will see clean diffs.
- The dep-version pinning will eventually need bumping when upstream resolves the more_itertools issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)