### PR TITLE
refactor(libvirt): port Machine.exists_in_libvirt to virsh (Phase 2 step 2)

### DIFF
--- a/tests/test_libvirt_machine.py
+++ b/tests/test_libvirt_machine.py
@@ -1,0 +1,112 @@
+"""Unit tests for :class:`tkc_lvlab.utils.libvirt.Machine` methods that have
+been ported to ``virsh`` (Phase 2).
+
+These tests patch the ``virsh_*`` collaborators at the
+``tkc_lvlab.utils.libvirt`` import boundary so nothing here actually shells
+out. The ``Machine`` object is constructed without running ``__init__`` —
+the methods under test depend only on ``libvirt_vm_name``, and the real
+constructor has unrelated filesystem side effects.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from tkc_lvlab.utils.libvirt import Machine
+from tkc_lvlab.utils.virsh import VirshError
+
+
+@pytest.fixture
+def machine() -> Machine:
+    """A Machine stub whose only populated attribute is libvirt_vm_name."""
+    m = object.__new__(Machine)
+    m.libvirt_vm_name = "web01_lab"
+    m.vm_name = "web01"
+    return m
+
+
+URI = "qemu:///session"
+
+
+# ---------------------------------------------------------------------------
+# exists_in_libvirt — return-shape and lookup behavior
+# ---------------------------------------------------------------------------
+
+
+def test_exists_in_libvirt_absent_returns_empty_strings(machine: Machine) -> None:
+    """When the domain isn't in the list, return (False, "", "") — not the
+    old (False, 0, 0) tuple — and don't call domstate at all."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names", return_value=["other_lab"]
+        ) as list_mock,
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate_reason") as state_mock,
+    ):
+        result = machine.exists_in_libvirt(URI)
+
+    assert result == (False, "", "")
+    list_mock.assert_called_once_with(URI)
+    state_mock.assert_not_called()
+
+
+def test_exists_in_libvirt_present_returns_state_and_reason(machine: Machine) -> None:
+    """When the domain is present, surface the lowercase virsh state strings
+    cli.py now compares against (``running``, ``shut off``, etc.)."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab", "other_lab"],
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_domstate_reason",
+            return_value=("running", "booted"),
+        ) as state_mock,
+    ):
+        result = machine.exists_in_libvirt(URI)
+
+    assert result == (True, "running", "booted")
+    state_mock.assert_called_once_with(URI, "web01_lab")
+
+
+def test_exists_in_libvirt_namespacing_uses_libvirt_vm_name(machine: Machine) -> None:
+    """The lookup must use the env-namespaced name, not the bare vm_name.
+    Regression guard: ``machines[].vm_name`` of ``web01`` in two environments
+    must not collide; only ``web01_<env>`` is the real domain name."""
+    machine.libvirt_vm_name = "web01_prod"
+    with mock.patch(
+        "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+        return_value=["web01_dev"],  # the dev namespaced name, not prod
+    ):
+        exists, _, _ = machine.exists_in_libvirt(URI)
+    assert exists is False
+
+
+def test_exists_in_libvirt_domstate_race_treated_as_absent(machine: Machine) -> None:
+    """If the domain vanishes between the list and the lookup, ``virsh``
+    raises ``VirshError`` for the second call. The method should treat that
+    as 'no longer present' rather than crashing the caller."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names", return_value=["web01_lab"]
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_domstate_reason",
+            side_effect=VirshError(1, "domain not found", ["domstate"]),
+        ),
+    ):
+        result = machine.exists_in_libvirt(URI)
+
+    assert result == (False, "", "")
+
+
+def test_exists_in_libvirt_list_failure_propagates(machine: Machine) -> None:
+    """A failure of the initial ``virsh list`` (URI unreachable, virsh
+    missing, etc.) is an environmental problem — surface it, don't swallow."""
+    with mock.patch(
+        "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+        side_effect=VirshError(127, "virsh not found", ["list"]),
+    ):
+        with pytest.raises(VirshError):
+            machine.exists_in_libvirt(URI)

--- a/tkc_lvlab/cli.py
+++ b/tkc_lvlab/cli.py
@@ -148,7 +148,7 @@ def down(vm_name):
         )
 
         if exists:
-            if state in ["VIR_DOMAIN_RUNNING", "VIR_DOMAIN_PAUSED"]:
+            if state in {"running", "paused"}:
                 click.echo(f"Shutting down virtual machine {vm_name}.")
                 if (
                     machine.shutdown(environment.get("libvirt_uri", "qemu:///session"))
@@ -591,11 +591,11 @@ def up(vm_name):
         )
 
         if exists:
-            if status in ["VIR_DOMAIN_SHUTOFF", "VIR_DOMAIN_CRASHED"]:
+            if status in {"shut off", "crashed"}:
                 click.echo(f"Starting virtual machine {machine.vm_name}")
                 if machine.poweron(environment.get("libvirt_uri", None)) > 0:
                     logger.error("Problem powering on VM %s", machine.vm_name)
-            elif status in ["VIR_DOMAIN_RUNNING"]:
+            elif status == "running":
                 click.echo(f"The virtual machine {machine.vm_name} is running already")
 
         else:

--- a/tkc_lvlab/utils/libvirt.py
+++ b/tkc_lvlab/utils/libvirt.py
@@ -11,6 +11,7 @@ from .._logging import get_logger
 from ..config import parse_config, generate_hosts
 from .vdisk import VirtualDisk
 from .cloud_init import MetaData, NetworkConfig, UserData
+from .virsh import VirshError, virsh_domstate_reason, virsh_list_all_names
 
 
 logger = get_logger(__name__)
@@ -350,20 +351,35 @@ class Machine:
 
         return True
 
-    def exists_in_libvirt(self, uri):
-        """Virtual machine existance and status"""
-        exists, state, state_reason = (False, 0, 0)
+    def exists_in_libvirt(self, uri: str) -> tuple[bool, str, str]:
+        """Check whether this machine is defined in libvirt and report its state.
 
-        conn = connect_to_libvirt(uri)
-        current_vms = [dom.name() for dom in conn.listAllDomains()]
+        Looks the domain up by ``self.libvirt_vm_name`` against the list of
+        domains known to ``uri`` and, if found, queries its state and reason.
 
-        if self.libvirt_vm_name in current_vms:
-            vm = conn.lookupByName(self.libvirt_vm_name)
-            state, state_reason, _, _ = get_machine_state(vm.state())
-            exists = True
+        Args:
+            uri: A libvirt connection URI (e.g. ``qemu:///session``).
 
-        conn.close()
-        return exists, state, state_reason
+        Returns:
+            A 3-tuple ``(exists, state, state_reason)``. ``state`` and
+            ``state_reason`` are the lowercase virsh strings (``running``,
+            ``shut off``, ``shutdown user``, etc.). Both are ``""`` when the
+            domain is not defined.
+
+        Raises:
+            VirshError: If ``virsh`` itself fails (e.g. cannot reach the URI).
+        """
+        if self.libvirt_vm_name not in virsh_list_all_names(uri):
+            return False, "", ""
+
+        try:
+            state, reason = virsh_domstate_reason(uri, self.libvirt_vm_name)
+        except VirshError:
+            # The domain disappeared between the list and the lookup. Treat as
+            # absent rather than propagating a transient race.
+            return False, "", ""
+
+        return True, state, reason
 
     def list_snapshots(self, uri):
         """List snapshots for a virtual machine"""


### PR DESCRIPTION
## Summary

Phase 2 step 2 of the libvirt-python → virsh port. Builds on the `virsh.py` foundation from #72.

- `Machine.exists_in_libvirt` now calls `virsh_list_all_names` + `virsh_domstate_reason` instead of `connect_to_libvirt` + `vm.state()`.
- Return shape changes from `(bool, int, int)` to `(bool, str, str)` — the strings are the lowercase forms virsh emits (`running`, `shut off`, `crashed`, `shutdown user`, ...).
- The three `cli.py` callers that compared the returned state against old `VIR_DOMAIN_*` constants are flipped to the new strings in the same PR (down command + up command paths).
- Race handling: if a domain is listed but `virsh domstate` then fails for that name, the method treats it as absent rather than propagating `VirshError`. Avoids transient flakes from undefine-while-running checks.

## What remains on libvirt-python (intentionally)

`connect_to_libvirt`, `_humanize_machine_status`, `get_machine_state`, and the `import libvirt` / `import re` lines all stay for now — they're still called by `Machine.destroy/shutdown/poweron/list_snapshots/create_snapshot/delete_snapshot` (step 3) and by `cli.py` `capabilities` and `status` (steps 4-5). They'll be deleted in step 6 once orphaned. Mixing the two backends in `libvirt.py` is deliberate during the port.

## Test plan

- [x] `uv run pytest` — 52 tests pass (47 existing virsh + 5 new for `Machine.exists_in_libvirt`).
- [x] New tests cover: present / absent / env-namespacing / domstate race / list failure propagation.
- [x] `uv run lvlab --help` still loads cleanly (no broken imports).
- [x] `pre-commit run --files ...` clean.
- [ ] Manual smoke against a real `qemu:///session` libvirt (will run locally before/after merge).

## Phase 2 progress

| Step | Status | PR |
|------|--------|----|
| 1 — `virsh.py` foundation | ✅ merged | #72 |
| 2 — `Machine.exists_in_libvirt` port | this PR | — |
| 3 — Lifecycle + snapshots + cli state flips (parallel pod) | next | — |
| 4 — `capabilities` rewrite | after 2 | — |
| 5 — `status` rewrite | after 3 | — |
| 6 — drop `libvirt-python` from `pyproject.toml` | after 5 | — |
| 7 — CLAUDE.md Architecture update | after 5 | — |
| 8 — drop `continue-on-error: true` for 3.14 in CI | after 6 | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)