### PR TITLE
refactor(cli): port capabilities command to virsh (Phase 2 step 4)

### DIFF
--- a/tests/test_cli_capabilities.py
+++ b/tests/test_cli_capabilities.py
@@ -1,0 +1,69 @@
+"""Unit tests for the ``lvlab capabilities`` CLI command.
+
+These tests stub :func:`tkc_lvlab.cli.virsh_capabilities` at the import
+boundary so nothing here ever invokes ``virsh`` or the libvirt-python
+binding. They lock in the Phase 2 port: ``capabilities`` must go through
+the virsh wrapper, never through :func:`connect_to_libvirt`.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from click.testing import CliRunner
+
+from tkc_lvlab import cli
+from tkc_lvlab.cli import capabilities
+from tkc_lvlab.utils.virsh import VirshError
+
+
+SAMPLE_CAPS_XML = (
+    "<capabilities>\n"
+    "  <host>\n"
+    "    <uuid>00000000-0000-0000-0000-000000000000</uuid>\n"
+    "  </host>\n"
+    "</capabilities>\n"
+)
+
+
+def test_capabilities_prints_xml_from_virsh_capabilities() -> None:
+    """Happy path: stdout contains the banner and the XML from virsh."""
+    runner = CliRunner()
+    with mock.patch.object(
+        cli, "virsh_capabilities", return_value=SAMPLE_CAPS_XML
+    ) as mocked:
+        result = runner.invoke(capabilities, [])
+
+    assert result.exit_code == 0, result.output
+    assert "Capabilities:" in result.output
+    assert "<capabilities>" in result.output
+    assert "00000000-0000-0000-0000-000000000000" in result.output
+    # Locks in the Phase 2 design decision: default URI is qemu:///session.
+    mocked.assert_called_once_with("qemu:///session")
+
+
+def test_capabilities_does_not_reach_libvirt_python() -> None:
+    """Regression guard: command must not call connect_to_libvirt."""
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "virsh_capabilities", return_value=SAMPLE_CAPS_XML),
+        mock.patch.object(cli, "connect_to_libvirt") as connect_mock,
+    ):
+        result = runner.invoke(capabilities, [])
+
+    assert result.exit_code == 0, result.output
+    connect_mock.assert_not_called()
+
+
+def test_capabilities_virsh_error_exits_nonzero_with_stderr_message() -> None:
+    """When virsh fails, the CLI exits nonzero and surfaces the error."""
+    err = VirshError(1, "error: failed to connect to the hypervisor", ["capabilities"])
+    runner = CliRunner()
+    with mock.patch.object(cli, "virsh_capabilities", side_effect=err):
+        result = runner.invoke(capabilities, [])
+
+    assert result.exit_code == 1
+    # The error message goes to stderr, not stdout, and the success banner
+    # must not have been printed. Click 8.2+ always separates stderr.
+    assert "Capabilities:" not in result.stdout
+    assert "failed to connect to the hypervisor" in result.stderr

--- a/tests/test_libvirt_machine.py
+++ b/tests/test_libvirt_machine.py
@@ -1,0 +1,112 @@
+"""Unit tests for :class:`tkc_lvlab.utils.libvirt.Machine` methods that have
+been ported to ``virsh`` (Phase 2).
+
+These tests patch the ``virsh_*`` collaborators at the
+``tkc_lvlab.utils.libvirt`` import boundary so nothing here actually shells
+out. The ``Machine`` object is constructed without running ``__init__`` —
+the methods under test depend only on ``libvirt_vm_name``, and the real
+constructor has unrelated filesystem side effects.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from tkc_lvlab.utils.libvirt import Machine
+from tkc_lvlab.utils.virsh import VirshError
+
+
+@pytest.fixture
+def machine() -> Machine:
+    """A Machine stub whose only populated attribute is libvirt_vm_name."""
+    m = object.__new__(Machine)
+    m.libvirt_vm_name = "web01_lab"
+    m.vm_name = "web01"
+    return m
+
+
+URI = "qemu:///session"
+
+
+# ---------------------------------------------------------------------------
+# exists_in_libvirt — return-shape and lookup behavior
+# ---------------------------------------------------------------------------
+
+
+def test_exists_in_libvirt_absent_returns_empty_strings(machine: Machine) -> None:
+    """When the domain isn't in the list, return (False, "", "") — not the
+    old (False, 0, 0) tuple — and don't call domstate at all."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names", return_value=["other_lab"]
+        ) as list_mock,
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate_reason") as state_mock,
+    ):
+        result = machine.exists_in_libvirt(URI)
+
+    assert result == (False, "", "")
+    list_mock.assert_called_once_with(URI)
+    state_mock.assert_not_called()
+
+
+def test_exists_in_libvirt_present_returns_state_and_reason(machine: Machine) -> None:
+    """When the domain is present, surface the lowercase virsh state strings
+    cli.py now compares against (``running``, ``shut off``, etc.)."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab", "other_lab"],
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_domstate_reason",
+            return_value=("running", "booted"),
+        ) as state_mock,
+    ):
+        result = machine.exists_in_libvirt(URI)
+
+    assert result == (True, "running", "booted")
+    state_mock.assert_called_once_with(URI, "web01_lab")
+
+
+def test_exists_in_libvirt_namespacing_uses_libvirt_vm_name(machine: Machine) -> None:
+    """The lookup must use the env-namespaced name, not the bare vm_name.
+    Regression guard: ``machines[].vm_name`` of ``web01`` in two environments
+    must not collide; only ``web01_<env>`` is the real domain name."""
+    machine.libvirt_vm_name = "web01_prod"
+    with mock.patch(
+        "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+        return_value=["web01_dev"],  # the dev namespaced name, not prod
+    ):
+        exists, _, _ = machine.exists_in_libvirt(URI)
+    assert exists is False
+
+
+def test_exists_in_libvirt_domstate_race_treated_as_absent(machine: Machine) -> None:
+    """If the domain vanishes between the list and the lookup, ``virsh``
+    raises ``VirshError`` for the second call. The method should treat that
+    as 'no longer present' rather than crashing the caller."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names", return_value=["web01_lab"]
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_domstate_reason",
+            side_effect=VirshError(1, "domain not found", ["domstate"]),
+        ),
+    ):
+        result = machine.exists_in_libvirt(URI)
+
+    assert result == (False, "", "")
+
+
+def test_exists_in_libvirt_list_failure_propagates(machine: Machine) -> None:
+    """A failure of the initial ``virsh list`` (URI unreachable, virsh
+    missing, etc.) is an environmental problem — surface it, don't swallow."""
+    with mock.patch(
+        "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+        side_effect=VirshError(127, "virsh not found", ["list"]),
+    ):
+        with pytest.raises(VirshError):
+            machine.exists_in_libvirt(URI)

--- a/tkc_lvlab/cli.py
+++ b/tkc_lvlab/cli.py
@@ -148,7 +148,7 @@ def down(vm_name):
         )
 
         if exists:
-            if state in ["VIR_DOMAIN_RUNNING", "VIR_DOMAIN_PAUSED"]:
+            if state in {"running", "paused"}:
                 click.echo(f"Shutting down virtual machine {vm_name}.")
                 if (
                     machine.shutdown(environment.get("libvirt_uri", "qemu:///session"))
@@ -591,11 +591,11 @@ def up(vm_name):
         )
 
         if exists:
-            if status in ["VIR_DOMAIN_SHUTOFF", "VIR_DOMAIN_CRASHED"]:
+            if status in {"shut off", "crashed"}:
                 click.echo(f"Starting virtual machine {machine.vm_name}")
                 if machine.poweron(environment.get("libvirt_uri", None)) > 0:
                     logger.error("Problem powering on VM %s", machine.vm_name)
-            elif status in ["VIR_DOMAIN_RUNNING"]:
+            elif status == "running":
                 click.echo(f"The virtual machine {machine.vm_name} is running already")
 
         else:

--- a/tkc_lvlab/cli.py
+++ b/tkc_lvlab/cli.py
@@ -22,6 +22,7 @@ from .utils.libvirt import (
 )
 from .utils.vdisk import VirtualDisk
 from .utils.images import CloudImage
+from .utils.virsh import VirshError, virsh_capabilities
 
 
 logger = get_logger(__name__)
@@ -47,14 +48,14 @@ def run(verbose, quiet):
 
 
 @click.command()
-def capabilities():
-    """Hypervisor Capabilities"""
-    conn = connect_to_libvirt()
-
-    caps = conn.getCapabilities()
+def capabilities() -> None:
+    """Print the raw hypervisor capabilities XML for qemu:///session."""
+    try:
+        caps = virsh_capabilities("qemu:///session")
+    except VirshError as exc:
+        click.echo(f"Error: {exc}", err=True)
+        sys.exit(1)
     click.echo("Capabilities:\n" + caps)
-
-    conn.close()
 
 
 @click.command()

--- a/tkc_lvlab/utils/libvirt.py
+++ b/tkc_lvlab/utils/libvirt.py
@@ -11,6 +11,7 @@ from .._logging import get_logger
 from ..config import parse_config, generate_hosts
 from .vdisk import VirtualDisk
 from .cloud_init import MetaData, NetworkConfig, UserData
+from .virsh import VirshError, virsh_domstate_reason, virsh_list_all_names
 
 
 logger = get_logger(__name__)
@@ -350,20 +351,35 @@ class Machine:
 
         return True
 
-    def exists_in_libvirt(self, uri):
-        """Virtual machine existance and status"""
-        exists, state, state_reason = (False, 0, 0)
+    def exists_in_libvirt(self, uri: str) -> tuple[bool, str, str]:
+        """Check whether this machine is defined in libvirt and report its state.
 
-        conn = connect_to_libvirt(uri)
-        current_vms = [dom.name() for dom in conn.listAllDomains()]
+        Looks the domain up by ``self.libvirt_vm_name`` against the list of
+        domains known to ``uri`` and, if found, queries its state and reason.
 
-        if self.libvirt_vm_name in current_vms:
-            vm = conn.lookupByName(self.libvirt_vm_name)
-            state, state_reason, _, _ = get_machine_state(vm.state())
-            exists = True
+        Args:
+            uri: A libvirt connection URI (e.g. ``qemu:///session``).
 
-        conn.close()
-        return exists, state, state_reason
+        Returns:
+            A 3-tuple ``(exists, state, state_reason)``. ``state`` and
+            ``state_reason`` are the lowercase virsh strings (``running``,
+            ``shut off``, ``shutdown user``, etc.). Both are ``""`` when the
+            domain is not defined.
+
+        Raises:
+            VirshError: If ``virsh`` itself fails (e.g. cannot reach the URI).
+        """
+        if self.libvirt_vm_name not in virsh_list_all_names(uri):
+            return False, "", ""
+
+        try:
+            state, reason = virsh_domstate_reason(uri, self.libvirt_vm_name)
+        except VirshError:
+            # The domain disappeared between the list and the lookup. Treat as
+            # absent rather than propagating a transient race.
+            return False, "", ""
+
+        return True, state, reason
 
     def list_snapshots(self, uri):
         """List snapshots for a virtual machine"""


### PR DESCRIPTION
## Summary

Step 4 of the Phase 2 port (see `/tmp/phase2-design.md` §4.4). Replaces
the `capabilities` Click command's `libvirt-python` round-trip with a
single call to `virsh_capabilities("qemu:///session")` from the Phase 1
wrapper landed in #72.

- Adds `from tkc_lvlab.utils.virsh import VirshError, virsh_capabilities`
  — the first virsh import on the cli.py side.
- Wraps the call in `try/except VirshError` so an unreachable hypervisor
  produces a one-line stderr message + nonzero exit, instead of a Python
  traceback. Mirrors the existing `parse_config()` → `logger.error` +
  `sys.exit(1)` pattern in cli.py for friendliness.
- Hardcodes `qemu:///session` per the locked design decision. Threading
  the URI through `parse_config()` is a future scope item.
- Leaves `connect_to_libvirt` / `get_machine_state` imports intact — the
  `status` command (step 5) and other commands still depend on them.

### Scope

cli.py-only. Does not touch `utils/libvirt.py` (#77's territory),
`utils/virsh.py` (Phase 1), or any other command.

### Parallelism

Independent of step 3 (Agents A — lifecycle, B — snapshots) per the
design's conflict-free parallelism summary. Builds on #77
(`phase2/02-exists-in-libvirt`), which only added the virsh imports to
`libvirt.py`.

## Test plan

- [x] `uv run pytest` — 55 passed (3 new in `tests/test_cli_capabilities.py`).
- [x] `uv run lvlab --help` — `capabilities` still listed.
- [x] `uv run lvlab capabilities --help` — new docstring rendered.
- [x] `pre-commit run --files tkc_lvlab/cli.py tests/test_cli_capabilities.py` — clean.
- [ ] Local smoke: `uv run lvlab capabilities` against a real `qemu:///session`.
- [ ] Local smoke: confirm friendly error when `virsh` is missing (`PATH=/dev/null uv run lvlab capabilities`).