### PR TITLE
refactor(libvirt): port Machine snapshot methods to virsh (Phase 2 step 3B)

### DIFF
--- a/tests/test_libvirt_machine.py
+++ b/tests/test_libvirt_machine.py
@@ -1,0 +1,112 @@
+"""Unit tests for :class:`tkc_lvlab.utils.libvirt.Machine` methods that have
+been ported to ``virsh`` (Phase 2).
+
+These tests patch the ``virsh_*`` collaborators at the
+``tkc_lvlab.utils.libvirt`` import boundary so nothing here actually shells
+out. The ``Machine`` object is constructed without running ``__init__`` —
+the methods under test depend only on ``libvirt_vm_name``, and the real
+constructor has unrelated filesystem side effects.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from tkc_lvlab.utils.libvirt import Machine
+from tkc_lvlab.utils.virsh import VirshError
+
+
+@pytest.fixture
+def machine() -> Machine:
+    """A Machine stub whose only populated attribute is libvirt_vm_name."""
+    m = object.__new__(Machine)
+    m.libvirt_vm_name = "web01_lab"
+    m.vm_name = "web01"
+    return m
+
+
+URI = "qemu:///session"
+
+
+# ---------------------------------------------------------------------------
+# exists_in_libvirt — return-shape and lookup behavior
+# ---------------------------------------------------------------------------
+
+
+def test_exists_in_libvirt_absent_returns_empty_strings(machine: Machine) -> None:
+    """When the domain isn't in the list, return (False, "", "") — not the
+    old (False, 0, 0) tuple — and don't call domstate at all."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names", return_value=["other_lab"]
+        ) as list_mock,
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate_reason") as state_mock,
+    ):
+        result = machine.exists_in_libvirt(URI)
+
+    assert result == (False, "", "")
+    list_mock.assert_called_once_with(URI)
+    state_mock.assert_not_called()
+
+
+def test_exists_in_libvirt_present_returns_state_and_reason(machine: Machine) -> None:
+    """When the domain is present, surface the lowercase virsh state strings
+    cli.py now compares against (``running``, ``shut off``, etc.)."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab", "other_lab"],
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_domstate_reason",
+            return_value=("running", "booted"),
+        ) as state_mock,
+    ):
+        result = machine.exists_in_libvirt(URI)
+
+    assert result == (True, "running", "booted")
+    state_mock.assert_called_once_with(URI, "web01_lab")
+
+
+def test_exists_in_libvirt_namespacing_uses_libvirt_vm_name(machine: Machine) -> None:
+    """The lookup must use the env-namespaced name, not the bare vm_name.
+    Regression guard: ``machines[].vm_name`` of ``web01`` in two environments
+    must not collide; only ``web01_<env>`` is the real domain name."""
+    machine.libvirt_vm_name = "web01_prod"
+    with mock.patch(
+        "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+        return_value=["web01_dev"],  # the dev namespaced name, not prod
+    ):
+        exists, _, _ = machine.exists_in_libvirt(URI)
+    assert exists is False
+
+
+def test_exists_in_libvirt_domstate_race_treated_as_absent(machine: Machine) -> None:
+    """If the domain vanishes between the list and the lookup, ``virsh``
+    raises ``VirshError`` for the second call. The method should treat that
+    as 'no longer present' rather than crashing the caller."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names", return_value=["web01_lab"]
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_domstate_reason",
+            side_effect=VirshError(1, "domain not found", ["domstate"]),
+        ),
+    ):
+        result = machine.exists_in_libvirt(URI)
+
+    assert result == (False, "", "")
+
+
+def test_exists_in_libvirt_list_failure_propagates(machine: Machine) -> None:
+    """A failure of the initial ``virsh list`` (URI unreachable, virsh
+    missing, etc.) is an environmental problem — surface it, don't swallow."""
+    with mock.patch(
+        "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+        side_effect=VirshError(127, "virsh not found", ["list"]),
+    ):
+        with pytest.raises(VirshError):
+            machine.exists_in_libvirt(URI)

--- a/tests/test_libvirt_snapshots.py
+++ b/tests/test_libvirt_snapshots.py
@@ -1,0 +1,287 @@
+"""Unit tests for :class:`tkc_lvlab.utils.libvirt.Machine` snapshot methods
+ported to ``virsh`` (Phase 2 step 3B).
+
+These tests patch the ``virsh_*`` collaborators at the
+``tkc_lvlab.utils.libvirt`` import boundary so nothing here actually shells
+out. The ``Machine`` object is constructed without running ``__init__`` —
+the methods under test depend only on ``libvirt_vm_name`` (and ``vm_name``
+for the "absent" warning log), and the real constructor has unrelated
+filesystem side effects.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from unittest import mock
+
+import pytest
+
+from tkc_lvlab.utils.libvirt import Machine
+from tkc_lvlab.utils.virsh import VirshError
+
+
+URI = "qemu:///session"
+
+
+@pytest.fixture
+def machine() -> Machine:
+    """A Machine stub whose only populated attributes are the two names the
+    snapshot methods read."""
+    m = object.__new__(Machine)
+    m.libvirt_vm_name = "web01_lab"
+    m.vm_name = "web01"
+    return m
+
+
+@contextlib.contextmanager
+def _fake_xml_tempfile(xml: str):
+    """Mock replacement for ``_xml_tempfile`` that records the XML and yields
+    a predictable path. The real helper is itself unit-tested in
+    ``test_virsh.py``; here we only care that the right XML reached it and
+    the right path reached ``run_virsh``."""
+    _fake_xml_tempfile.captured_xml = xml
+    yield "/tmp/lvlab-snapshot-FAKE.xml"
+
+
+# ---------------------------------------------------------------------------
+# list_snapshots
+# ---------------------------------------------------------------------------
+
+
+def test_list_snapshots_present_with_snapshots_preserves_order(
+    machine: Machine,
+) -> None:
+    """When the domain exists, return the names ``virsh snapshot-list --name``
+    emits, in order. Order matters because callers display them to a human
+    and the libvirt-python implementation preserved creation order."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab", "other_lab"],
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_snapshot_names",
+            return_value=["snap-a", "snap-b", "snap-c"],
+        ) as snap_mock,
+    ):
+        result = machine.list_snapshots(URI)
+
+    assert result == ["snap-a", "snap-b", "snap-c"]
+    snap_mock.assert_called_once_with(URI, "web01_lab")
+
+
+def test_list_snapshots_present_no_snapshots_returns_empty(machine: Machine) -> None:
+    """A defined domain with zero snapshots: ``[]``, not ``None`` and not a
+    crash. Regression guard: a wrong-shape return here breaks the for-loop
+    in the cli.py snapshot command."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_snapshot_names",
+            return_value=[],
+        ),
+    ):
+        assert machine.list_snapshots(URI) == []
+
+
+def test_list_snapshots_absent_domain_returns_empty(machine: Machine) -> None:
+    """If the domain isn't defined at the URI, return ``[]`` and don't
+    call ``virsh snapshot-list``. This mirrors the previous libvirt-python
+    behavior (the conn was opened but no lookup happened)."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["other_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_snapshot_names") as snap_mock,
+    ):
+        assert machine.list_snapshots(URI) == []
+
+    snap_mock.assert_not_called()
+
+
+def test_list_snapshots_race_treated_as_absent(machine: Machine) -> None:
+    """If the domain disappears between the list and the snapshot-list
+    call, treat that as 'no snapshots' rather than crashing. The previous
+    libvirt-python code would have raised; the port should not regress to
+    that behavior."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_snapshot_names",
+            side_effect=VirshError(1, "domain not found", ["snapshot-list"]),
+        ),
+    ):
+        assert machine.list_snapshots(URI) == []
+
+
+# ---------------------------------------------------------------------------
+# create_snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_create_snapshot_happy_path_uses_xmlfile_and_timeout(
+    machine: Machine,
+) -> None:
+    """Default-description path: writes XML via ``_xml_tempfile``, calls
+    ``virsh snapshot-create --xmlfile <path>`` with ``timeout=120.0``, and
+    returns ``True``. The XML must carry the snapshot name and the
+    auto-generated description ``Snapshot of <libvirt_vm_name>`` so a
+    reviewer scanning libvirt later can see what each snapshot was for."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt._xml_tempfile",
+            side_effect=_fake_xml_tempfile,
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+    ):
+        result = machine.create_snapshot(URI, "snap-1")
+
+    assert result is True
+
+    captured_xml = _fake_xml_tempfile.captured_xml
+    assert "<name>snap-1</name>" in captured_xml
+    # Default-description branch — must use libvirt_vm_name, not vm_name.
+    assert "<description>Snapshot of web01_lab</description>" in captured_xml
+    assert "<domainsnapshot>" in captured_xml
+
+    run_mock.assert_called_once_with(
+        URI,
+        ["snapshot-create", "web01_lab", "--xmlfile", "/tmp/lvlab-snapshot-FAKE.xml"],
+        timeout=120.0,
+    )
+
+
+def test_create_snapshot_custom_description(machine: Machine) -> None:
+    """When the caller supplies a description, that string lands in the
+    rendered XML verbatim — not the default-fallback text."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt._xml_tempfile",
+            side_effect=_fake_xml_tempfile,
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh"),
+    ):
+        machine.create_snapshot(URI, "snap-2", "pre-upgrade baseline")
+
+    captured_xml = _fake_xml_tempfile.captured_xml
+    assert "<name>snap-2</name>" in captured_xml
+    assert "<description>pre-upgrade baseline</description>" in captured_xml
+    # No leak of the default text.
+    assert "Snapshot of web01_lab" not in captured_xml
+
+
+def test_create_snapshot_propagates_virsh_error(machine: Machine) -> None:
+    """A ``virsh snapshot-create`` failure must propagate ``VirshError``.
+    Regression guard for the historical ``return inside finally`` bug that
+    silently turned exceptions into return values — see Phase 2 design
+    §6.7."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt._xml_tempfile",
+            side_effect=_fake_xml_tempfile,
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.run_virsh",
+            side_effect=VirshError(1, "snapshot already exists", ["snapshot-create"]),
+        ),
+    ):
+        with pytest.raises(VirshError):
+            machine.create_snapshot(URI, "snap-dup")
+
+
+def test_create_snapshot_absent_domain_raises(machine: Machine) -> None:
+    """The previous implementation silently returned ``0`` (= "success") when
+    the domain wasn't defined, which is misleading. The port raises so the
+    caller gets a clean failure signal."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["other_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt._xml_tempfile") as tempfile_mock,
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+    ):
+        with pytest.raises(VirshError):
+            machine.create_snapshot(URI, "snap-1")
+
+    tempfile_mock.assert_not_called()
+    run_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# delete_snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_delete_snapshot_happy_path_returns_none(machine: Machine) -> None:
+    """Build the right argv (``snapshot-delete <name> <snap>``), pass
+    ``timeout=120.0``, and return ``None`` on success."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+    ):
+        result = machine.delete_snapshot(URI, "snap-1")
+
+    assert result is None
+    run_mock.assert_called_once_with(
+        URI,
+        ["snapshot-delete", "web01_lab", "snap-1"],
+        timeout=120.0,
+    )
+
+
+def test_delete_snapshot_propagates_virsh_error(machine: Machine) -> None:
+    """A ``virsh snapshot-delete`` failure (e.g. snapshot doesn't exist)
+    must propagate. Regression guard for the historical ``return inside
+    finally`` bug — see Phase 2 design §6.7."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.run_virsh",
+            side_effect=VirshError(1, "snapshot not found", ["snapshot-delete"]),
+        ),
+    ):
+        with pytest.raises(VirshError):
+            machine.delete_snapshot(URI, "missing-snap")
+
+
+def test_delete_snapshot_absent_domain_raises(machine: Machine) -> None:
+    """The previous implementation silently returned ``0`` when the domain
+    wasn't defined. The port raises so the caller knows nothing got
+    deleted — destructive paths must never lie about success."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["other_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+    ):
+        with pytest.raises(VirshError):
+            machine.delete_snapshot(URI, "snap-1")
+
+    run_mock.assert_not_called()

--- a/tkc_lvlab/cli.py
+++ b/tkc_lvlab/cli.py
@@ -148,7 +148,7 @@ def down(vm_name):
         )
 
         if exists:
-            if state in ["VIR_DOMAIN_RUNNING", "VIR_DOMAIN_PAUSED"]:
+            if state in {"running", "paused"}:
                 click.echo(f"Shutting down virtual machine {vm_name}.")
                 if (
                     machine.shutdown(environment.get("libvirt_uri", "qemu:///session"))
@@ -591,11 +591,11 @@ def up(vm_name):
         )
 
         if exists:
-            if status in ["VIR_DOMAIN_SHUTOFF", "VIR_DOMAIN_CRASHED"]:
+            if status in {"shut off", "crashed"}:
                 click.echo(f"Starting virtual machine {machine.vm_name}")
                 if machine.poweron(environment.get("libvirt_uri", None)) > 0:
                     logger.error("Problem powering on VM %s", machine.vm_name)
-            elif status in ["VIR_DOMAIN_RUNNING"]:
+            elif status == "running":
                 click.echo(f"The virtual machine {machine.vm_name} is running already")
 
         else:

--- a/tkc_lvlab/utils/libvirt.py
+++ b/tkc_lvlab/utils/libvirt.py
@@ -11,6 +11,7 @@ from .._logging import get_logger
 from ..config import parse_config, generate_hosts
 from .vdisk import VirtualDisk
 from .cloud_init import MetaData, NetworkConfig, UserData
+from .virsh import VirshError, virsh_domstate_reason, virsh_list_all_names
 
 
 logger = get_logger(__name__)
@@ -350,20 +351,35 @@ class Machine:
 
         return True
 
-    def exists_in_libvirt(self, uri):
-        """Virtual machine existance and status"""
-        exists, state, state_reason = (False, 0, 0)
+    def exists_in_libvirt(self, uri: str) -> tuple[bool, str, str]:
+        """Check whether this machine is defined in libvirt and report its state.
 
-        conn = connect_to_libvirt(uri)
-        current_vms = [dom.name() for dom in conn.listAllDomains()]
+        Looks the domain up by ``self.libvirt_vm_name`` against the list of
+        domains known to ``uri`` and, if found, queries its state and reason.
 
-        if self.libvirt_vm_name in current_vms:
-            vm = conn.lookupByName(self.libvirt_vm_name)
-            state, state_reason, _, _ = get_machine_state(vm.state())
-            exists = True
+        Args:
+            uri: A libvirt connection URI (e.g. ``qemu:///session``).
 
-        conn.close()
-        return exists, state, state_reason
+        Returns:
+            A 3-tuple ``(exists, state, state_reason)``. ``state`` and
+            ``state_reason`` are the lowercase virsh strings (``running``,
+            ``shut off``, ``shutdown user``, etc.). Both are ``""`` when the
+            domain is not defined.
+
+        Raises:
+            VirshError: If ``virsh`` itself fails (e.g. cannot reach the URI).
+        """
+        if self.libvirt_vm_name not in virsh_list_all_names(uri):
+            return False, "", ""
+
+        try:
+            state, reason = virsh_domstate_reason(uri, self.libvirt_vm_name)
+        except VirshError:
+            # The domain disappeared between the list and the lookup. Treat as
+            # absent rather than propagating a transient race.
+            return False, "", ""
+
+        return True, state, reason
 
     def list_snapshots(self, uri):
         """List snapshots for a virtual machine"""

--- a/tkc_lvlab/utils/libvirt.py
+++ b/tkc_lvlab/utils/libvirt.py
@@ -11,7 +11,14 @@ from .._logging import get_logger
 from ..config import parse_config, generate_hosts
 from .vdisk import VirtualDisk
 from .cloud_init import MetaData, NetworkConfig, UserData
-from .virsh import VirshError, virsh_domstate_reason, virsh_list_all_names
+from .virsh import (
+    VirshError,
+    _xml_tempfile,
+    run_virsh,
+    virsh_domstate_reason,
+    virsh_list_all_names,
+    virsh_snapshot_names,
+)
 
 
 logger = get_logger(__name__)
@@ -381,64 +388,126 @@ class Machine:
 
         return True, state, reason
 
-    def list_snapshots(self, uri):
-        """List snapshots for a virtual machine"""
-        snapshots = []
-        conn = connect_to_libvirt(uri)
-        current_vms = [dom.name() for dom in conn.listAllDomains()]
+    def list_snapshots(self, uri: str) -> list[str]:
+        """Return the snapshot names defined for this machine's domain.
 
-        if self.libvirt_vm_name in current_vms:
-            vm = conn.lookupByName(self.libvirt_vm_name)
-            snapshots = vm.listAllSnapshots()
+        Uses ``virsh snapshot-list --name`` so the result is a flat list of
+        snapshot names in creation order. When the domain isn't defined at
+        ``uri`` the list is empty — callers can treat "no domain" and
+        "no snapshots" identically (the previous libvirt-python
+        implementation did the same).
 
-        conn.close()
-        return snapshots
+        Args:
+            uri: A libvirt connection URI (e.g. ``qemu:///session``).
 
-    def create_snapshot(self, uri, snapshot_name, snapshot_description=None):
-        """Create a snapshot of a virtual machine with optional description"""
-        snapshot_status = 0
-        conn = connect_to_libvirt(uri)
-        current_vms = [dom.name() for dom in conn.listAllDomains()]
+        Returns:
+            Snapshot names in creation order. ``[]`` when the domain isn't
+            defined or has no snapshots.
 
-        if self.libvirt_vm_name in current_vms:
-            vm = conn.lookupByName(self.libvirt_vm_name)
+        Raises:
+            VirshError: If ``virsh`` itself fails for a reason other than
+                "domain not defined" (e.g. cannot reach the URI).
+        """
+        if self.libvirt_vm_name not in virsh_list_all_names(uri):
+            return []
 
-            if not snapshot_description:
-                snapshot_description = f"Snapshot of {vm.name()}"
+        try:
+            return virsh_snapshot_names(uri, self.libvirt_vm_name)
+        except VirshError:
+            # The domain disappeared between the list and the snapshot-list
+            # call. Treat as absent — caller wanted snapshot names, there
+            # are none to report.
+            return []
 
-            snapshot_xml = f"""
-            <domainsnapshot>
-                <name>{snapshot_name}</name>
-                <description>Snapshot of {vm.name()}</description>
-            </domainsnapshot>
-            """
+    def create_snapshot(
+        self,
+        uri: str,
+        snapshot_name: str,
+        snapshot_description: str | None = None,
+    ) -> bool:
+        """Create a snapshot of this machine's domain.
 
-            try:
-                snapshot_status = vm.snapshotCreateXML(snapshot_xml, 0)
-            except libvirt.libvirtError as e:
-                snapshot_status = e
-            finally:
-                conn.close()
-                return snapshot_status
+        Builds a minimal ``<domainsnapshot>`` XML document, writes it to a
+        tempfile, and hands it to ``virsh snapshot-create --xmlfile``. The
+        tempfile is removed after the call (or on exception) by
+        :func:`tkc_lvlab.utils.virsh._xml_tempfile`.
 
-    def delete_snapshot(self, uri, snapshot_name):
-        """Create a snapshot of a virtual machine with optional description"""
-        snapshot_status = 0
-        conn = connect_to_libvirt(uri)
-        current_vms = [dom.name() for dom in conn.listAllDomains()]
+        Args:
+            uri: A libvirt connection URI (e.g. ``qemu:///session``).
+            snapshot_name: Name to assign to the new snapshot.
+            snapshot_description: Optional human-readable description.
+                Defaults to ``"Snapshot of <libvirt_vm_name>"``.
 
-        if self.libvirt_vm_name in current_vms:
-            try:
-                vm = conn.lookupByName(self.libvirt_vm_name)
-                snapshot = vm.snapshotLookupByName(snapshot_name)
+        Returns:
+            ``True`` on success. Failures raise rather than returning a
+            sentinel — the previous libvirt-python implementation returned
+            the exception instance from a ``finally`` block, which silently
+            swallowed errors.
 
-                if snapshot:
-                    snapshot_status = snapshot.delete()
-            except libvirt.libvirtError as e:
-                snapshot_status = e
-            finally:
-                conn.close()
-                return snapshot_status
+        Raises:
+            VirshError: When the domain isn't defined at ``uri`` or when
+                ``virsh snapshot-create`` itself fails (timeout, malformed
+                XML, libvirt error, etc.).
+        """
+        if self.libvirt_vm_name not in virsh_list_all_names(uri):
+            logger.warning(
+                "The virtual machine %s does not exist in this Libvirt URI",
+                self.vm_name,
+            )
+            raise VirshError(
+                1,
+                f"domain {self.libvirt_vm_name} is not defined at {uri}",
+                ["snapshot-create", self.libvirt_vm_name],
+            )
+
+        if not snapshot_description:
+            snapshot_description = f"Snapshot of {self.libvirt_vm_name}"
+
+        snapshot_xml = (
+            "<domainsnapshot>\n"
+            f"    <name>{snapshot_name}</name>\n"
+            f"    <description>{snapshot_description}</description>\n"
+            "</domainsnapshot>\n"
+        )
+
+        with _xml_tempfile(snapshot_xml) as xml_path:
+            run_virsh(
+                uri,
+                ["snapshot-create", self.libvirt_vm_name, "--xmlfile", xml_path],
+                timeout=120.0,
+            )
+        return True
+
+    def delete_snapshot(self, uri: str, snapshot_name: str) -> None:
+        """Delete a named snapshot from this machine's domain.
+
+        Args:
+            uri: A libvirt connection URI (e.g. ``qemu:///session``).
+            snapshot_name: Name of the snapshot to delete.
+
+        Raises:
+            VirshError: When the domain isn't defined at ``uri``, when the
+                named snapshot doesn't exist, or when ``virsh
+                snapshot-delete`` itself fails. The previous libvirt-python
+                implementation swallowed errors in a ``finally`` block; this
+                port propagates them so callers get a clean signal.
+        """
+        if self.libvirt_vm_name not in virsh_list_all_names(uri):
+            logger.warning(
+                "The virtual machine %s does not exist in this Libvirt URI",
+                self.vm_name,
+            )
+            raise VirshError(
+                1,
+                f"domain {self.libvirt_vm_name} is not defined at {uri}",
+                ["snapshot-delete", self.libvirt_vm_name, snapshot_name],
+            )
+
+        run_virsh(
+            uri,
+            ["snapshot-delete", self.libvirt_vm_name, snapshot_name],
+            timeout=120.0,
+        )
 
     def poweron(self, uri):
         """Powreon a virtual machine"""


### PR DESCRIPTION
## Summary

Port the three snapshot methods on `Machine` from `libvirt-python` to
`virsh` subprocess calls via helpers in `tkc_lvlab.utils.virsh`:

- `list_snapshots` → `virsh snapshot-list --name`
- `create_snapshot` → `virsh snapshot-create --xmlfile <tempfile>`
- `delete_snapshot` → `virsh snapshot-delete`

Also fix two latent bugs flagged in the Phase 2 design doc (§6.7):

1. **`return` inside `finally`** in `create_snapshot` / `delete_snapshot`
   silently swallowed exceptions and turned them into return values. The
   ported methods raise `VirshError` on failure instead.
2. **Absent-domain branch** previously returned `0` (= "success") when
   the domain wasn't defined at the URI — misleading for a destructive
   path. The ported methods now raise `VirshError` so callers get an
   honest signal.

This is **Phase 2 step 3B** in the libvirt-python → virsh port, layered
on top of `phase2/02-exists-in-libvirt` (PR #77). The lifecycle methods
(`destroy`, `shutdown`, `poweron`) are step 3A, owned by a sibling agent.

## Breaking changes for callers

`cli.py` callers of these three methods will fail at runtime until a
follow-up PR updates them. Test suite still passes because `cli.py` is
not exercised by the unit tests yet (it will be in Phase 3).

| Method | Old return | New return |
|---|---|---|
| `list_snapshots` | `list[virDomainSnapshot]` | `list[str]` |
| `create_snapshot` | `0` (success) / `libvirtError` instance (failure) | `True` / raises `VirshError` |
| `delete_snapshot` | `0` (success) / `libvirtError` instance (failure) | `None` / raises `VirshError` |

Required follow-up edits in `cli.py` (the sibling Agent C / follow-up PR
will handle these):

- `cli.py:295-296` — replace `[s.getName() for s in machine.list_snapshots(...)]`
  with the bare list (snapshots are already strings).
- `cli.py:333` — handle `True` return + catch `VirshError` (was `if rc == 0`).
- `cli.py:382` — handle `None` return + catch `VirshError` (was `if rc == 0`).

## Conformance with Phase 2 design

- §1 — `run_virsh` and `VirshError` reused; no module-level changes.
- §3 — snapshot XML handed off via `_xml_tempfile` context manager.
- §6.6 — return-type changes applied; callers updated by Agent C.
- §6.7 — `return inside finally` removed; regression test added.
- §7 — conformance surface for `Machine.list_snapshots` /
  `create_snapshot` / `delete_snapshot` covered by
  `tests/test_libvirt_snapshots.py` (11 new tests).

## Hard constraints preserved

- `connect_to_libvirt`, `_humanize_machine_status`, `get_machine_state`,
  `import libvirt`, `import re` — **not touched** (Agent A still uses
  them; step 6 removes them once 3A and 3B both land).
- `Machine.exists_in_libvirt`, `Machine.destroy`, `Machine.shutdown`,
  `Machine.poweron` — **not touched** (PR #77 + Agent A territory).
- `tkc_lvlab/utils/virsh.py` — **not modified** (foundation is frozen).
- `cli.py` — **not modified** (Agent C / follow-up PR).

## Test plan

- [x] `uv run pytest` — 63 passed, 0 failed (47 virsh + 5 exists + 11 new
      snapshot tests). No pre-existing test broke.
- [x] `uv run lvlab --help` — CLI still loads.
- [x] `pre-commit run --files tkc_lvlab/utils/libvirt.py tests/test_libvirt_snapshots.py` — passes.
- [ ] (Follow-up) Real `virsh snapshot-create/delete` exercised via
      Phase 3 integration tests once they land (`LVLAB_INTEGRATION=1`).
- [ ] (Follow-up) `cli.py` snapshot command handlers updated by Agent C.