### PR TITLE
refactor(libvirt): port Machine.destroy/poweron/shutdown to virsh (Phase 2 step 3A)

### DIFF
--- a/tests/test_libvirt_lifecycle.py
+++ b/tests/test_libvirt_lifecycle.py
@@ -1,0 +1,407 @@
+"""Unit tests for :class:`tkc_lvlab.utils.libvirt.Machine` lifecycle methods
+(``destroy``, ``poweron``, ``shutdown``) after the Phase 2 port to ``virsh``.
+
+These tests patch the ``virsh_*`` collaborators at the
+``tkc_lvlab.utils.libvirt`` import boundary so nothing here actually shells
+out to ``virsh``. The ``Machine`` object is constructed without running
+``__init__`` — the methods under test depend only on ``libvirt_vm_name``,
+``vm_name``, and ``config_fpath``; the real constructor has unrelated
+filesystem side effects.
+
+The tests are scoped to behaviors that *could realistically break* during
+the port:
+
+* Lifecycle methods sequence their ``virsh`` calls correctly (e.g. destroy
+  before undefine, snapshots deleted before undefine).
+* The bool/int return contracts are preserved exactly, because ``cli.py``
+  checks them with ``> 0`` and ``if machine.destroy(...)``.
+* ``VirshError`` from any underlying call short-circuits the rest of the
+  flow rather than tearing down later state on a half-failed machine.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from tkc_lvlab.utils.libvirt import Machine
+from tkc_lvlab.utils.virsh import VirshError
+
+
+URI = "qemu:///session"
+
+
+@pytest.fixture
+def machine(tmp_path) -> Machine:
+    """A Machine stub with the attributes lifecycle methods touch.
+
+    ``config_fpath`` points at a real (empty) temp directory so ``destroy``'s
+    file-cleanup block can exercise the happy path without writing to a real
+    libvirt images directory.
+    """
+    m = object.__new__(Machine)
+    m.libvirt_vm_name = "web01_lab"
+    m.vm_name = "web01"
+    m.config_fpath = str(tmp_path)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# destroy
+# ---------------------------------------------------------------------------
+
+
+def test_destroy_running_vm_calls_destroy_then_undefine(machine: Machine) -> None:
+    """A running domain gets ``virsh destroy`` first, then (no snapshots)
+    ``virsh undefine``. Ordering matters: undefining a running domain fails
+    on real libvirt, so the destroy must come first."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_domstate",
+            side_effect=["running", "shut off"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_snapshot_names", return_value=[]),
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+    ):
+        result = machine.destroy(URI)
+
+    assert result is True
+    # Order: destroy, then undefine. No snapshot-delete because there were none.
+    called_subcommands = [call.args[1][0] for call in run_mock.call_args_list]
+    assert called_subcommands == ["destroy", "undefine"]
+    run_mock.assert_any_call(URI, ["destroy", "web01_lab"])
+    run_mock.assert_any_call(URI, ["undefine", "web01_lab"])
+
+
+def test_destroy_already_shut_off_skips_destroy(machine: Machine) -> None:
+    """A domain that is already ``shut off`` must NOT have ``virsh destroy``
+    invoked against it — that's an error on a stopped domain. The method
+    should go straight to snapshot cleanup + undefine."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="shut off"),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_snapshot_names", return_value=[]),
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+    ):
+        result = machine.destroy(URI)
+
+    assert result is True
+    called_subcommands = [call.args[1][0] for call in run_mock.call_args_list]
+    assert "destroy" not in called_subcommands
+    assert called_subcommands == ["undefine"]
+
+
+def test_destroy_deletes_each_snapshot_before_undefine(machine: Machine) -> None:
+    """``virsh undefine`` refuses if snapshot metadata exists, so each
+    snapshot must be deleted first — and the undefine must come after."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="shut off"),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_snapshot_names",
+            return_value=["snap-a", "snap-b"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+    ):
+        result = machine.destroy(URI)
+
+    assert result is True
+    calls = [call.args[1] for call in run_mock.call_args_list]
+    assert calls == [
+        ["snapshot-delete", "web01_lab", "snap-a"],
+        ["snapshot-delete", "web01_lab", "snap-b"],
+        ["undefine", "web01_lab"],
+    ]
+
+
+def test_destroy_absent_domain_returns_false(machine: Machine) -> None:
+    """If ``virsh list`` doesn't show the domain, destroy is a no-op that
+    returns False. It must NOT call destroy/undefine on a domain that's
+    not there — that would be a wrong-target risk."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["other_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate") as state_mock,
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+    ):
+        result = machine.destroy(URI)
+
+    assert result is False
+    state_mock.assert_not_called()
+    run_mock.assert_not_called()
+
+
+def test_destroy_destroy_failure_skips_undefine(machine: Machine) -> None:
+    """If ``virsh destroy`` raises, we must NOT proceed to ``virsh undefine``
+    or to file cleanup — that would leave behind a half-broken VM with no
+    files. The whole operation returns False so the caller can react."""
+
+    def fake_run(uri, args, **kwargs):
+        if args[0] == "destroy":
+            raise VirshError(1, "operation failed", args)
+        return mock.MagicMock(returncode=0)
+
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="running"),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_snapshot_names", return_value=[]),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.run_virsh", side_effect=fake_run
+        ) as run_mock,
+    ):
+        result = machine.destroy(URI)
+
+    assert result is False
+    called_subcommands = [call.args[1][0] for call in run_mock.call_args_list]
+    assert called_subcommands == ["destroy"]
+    assert "undefine" not in called_subcommands
+
+
+def test_destroy_undefine_failure_skips_file_cleanup(
+    machine: Machine, tmp_path
+) -> None:
+    """If ``virsh undefine`` raises, on-disk files must NOT be removed.
+    File removal in that case would leave libvirt with a half-defined
+    domain pointing at deleted qcow2s — worse than leaving the files."""
+    # Drop a sentinel file so we can prove we didn't touch it.
+    sentinel = tmp_path / "disk0.qcow2"
+    sentinel.write_text("not really a disk")
+
+    def fake_run(uri, args, **kwargs):
+        if args[0] == "undefine":
+            raise VirshError(1, "operation failed", args)
+        return mock.MagicMock(returncode=0)
+
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="shut off"),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_snapshot_names", return_value=[]),
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh", side_effect=fake_run),
+    ):
+        result = machine.destroy(URI)
+
+    assert result is False
+    assert sentinel.exists(), "file cleanup must not run when undefine failed"
+
+
+def test_destroy_snapshot_delete_failure_skips_undefine(machine: Machine) -> None:
+    """A snapshot-delete failure aborts the flow before undefining; the
+    domain would refuse undefine anyway, and proceeding could mask a real
+    error mid-cleanup."""
+
+    def fake_run(uri, args, **kwargs):
+        if args[0] == "snapshot-delete":
+            raise VirshError(1, "snapshot busy", args)
+        return mock.MagicMock(returncode=0)
+
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="shut off"),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_snapshot_names", return_value=["snap-a"]
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.run_virsh", side_effect=fake_run
+        ) as run_mock,
+    ):
+        result = machine.destroy(URI)
+
+    assert result is False
+    called_subcommands = [call.args[1][0] for call in run_mock.call_args_list]
+    assert "undefine" not in called_subcommands
+
+
+# ---------------------------------------------------------------------------
+# poweron
+# ---------------------------------------------------------------------------
+
+
+def test_poweron_shut_off_vm_invokes_start(machine: Machine) -> None:
+    """A ``shut off`` domain is the normal start case. Must call
+    ``virsh start`` and return 0 to satisfy the ``> 0`` check in cli.py."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="shut off"),
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+    ):
+        result = machine.poweron(URI)
+
+    assert result == 0
+    run_mock.assert_called_once_with(URI, ["start", "web01_lab"])
+
+
+def test_poweron_crashed_vm_invokes_start(machine: Machine) -> None:
+    """Per DEAD_STATES, a ``crashed`` domain is also startable — guard
+    against accidentally narrowing the trigger set during the port."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="crashed"),
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+    ):
+        result = machine.poweron(URI)
+
+    assert result == 0
+    run_mock.assert_called_once_with(URI, ["start", "web01_lab"])
+
+
+def test_poweron_running_vm_is_noop(machine: Machine) -> None:
+    """Already-running domains must not be ``virsh start``-ed again —
+    that errors. The method must return 0 (not 1) so cli.py treats it as
+    success."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="running"),
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+    ):
+        result = machine.poweron(URI)
+
+    assert result == 0
+    run_mock.assert_not_called()
+
+
+def test_poweron_start_failure_returns_one(machine: Machine) -> None:
+    """A ``virsh start`` failure must surface as the ``> 0`` signal the
+    cli.py caller looks for."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="shut off"),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.run_virsh",
+            side_effect=VirshError(1, "boot failed", ["start", "web01_lab"]),
+        ),
+    ):
+        result = machine.poweron(URI)
+
+    assert result == 1
+
+
+def test_poweron_absent_domain_returns_zero(machine: Machine) -> None:
+    """Preserve the pre-port behavior: if the domain isn't defined, warn
+    and return 0. ``cli.py`` does its own existence check before calling
+    poweron, so this branch is the safety net, not the primary path."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["other_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate") as state_mock,
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+    ):
+        result = machine.poweron(URI)
+
+    assert result == 0
+    state_mock.assert_not_called()
+    run_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# shutdown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("state", ["running", "idle", "paused", "pmsuspended"])
+def test_shutdown_active_states_invoke_shutdown(machine: Machine, state: str) -> None:
+    """Every state in SHUTDOWNABLE_STATES must trigger ``virsh shutdown``.
+    Notable: virsh emits ``idle`` for what libvirt-python called
+    ``VIR_DOMAIN_BLOCKED``; this parametrize protects against accidentally
+    losing the ``idle`` case during the port."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value=state),
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+    ):
+        result = machine.shutdown(URI)
+
+    assert result == 0
+    run_mock.assert_called_once_with(URI, ["shutdown", "web01_lab"])
+
+
+def test_shutdown_shut_off_vm_is_noop(machine: Machine) -> None:
+    """Don't ``virsh shutdown`` a domain that's already off — virsh errors
+    on that. Return 0 so cli.py treats the no-op as success."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="shut off"),
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+    ):
+        result = machine.shutdown(URI)
+
+    assert result == 0
+    run_mock.assert_not_called()
+
+
+def test_shutdown_failure_returns_one(machine: Machine) -> None:
+    """A ``virsh shutdown`` failure must surface as the ``> 0`` signal
+    the cli.py caller checks."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="running"),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.run_virsh",
+            side_effect=VirshError(1, "agent unresponsive", ["shutdown", "web01_lab"]),
+        ),
+    ):
+        result = machine.shutdown(URI)
+
+    assert result == 1
+
+
+def test_shutdown_absent_domain_returns_zero(machine: Machine) -> None:
+    """A missing domain is a no-op (return 0), matching the pre-port
+    behavior. cli.py already checks existence, so this is defensive."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["other_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate") as state_mock,
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+    ):
+        result = machine.shutdown(URI)
+
+    assert result == 0
+    state_mock.assert_not_called()
+    run_mock.assert_not_called()

--- a/tests/test_libvirt_machine.py
+++ b/tests/test_libvirt_machine.py
@@ -1,0 +1,112 @@
+"""Unit tests for :class:`tkc_lvlab.utils.libvirt.Machine` methods that have
+been ported to ``virsh`` (Phase 2).
+
+These tests patch the ``virsh_*`` collaborators at the
+``tkc_lvlab.utils.libvirt`` import boundary so nothing here actually shells
+out. The ``Machine`` object is constructed without running ``__init__`` —
+the methods under test depend only on ``libvirt_vm_name``, and the real
+constructor has unrelated filesystem side effects.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+from tkc_lvlab.utils.libvirt import Machine
+from tkc_lvlab.utils.virsh import VirshError
+
+
+@pytest.fixture
+def machine() -> Machine:
+    """A Machine stub whose only populated attribute is libvirt_vm_name."""
+    m = object.__new__(Machine)
+    m.libvirt_vm_name = "web01_lab"
+    m.vm_name = "web01"
+    return m
+
+
+URI = "qemu:///session"
+
+
+# ---------------------------------------------------------------------------
+# exists_in_libvirt — return-shape and lookup behavior
+# ---------------------------------------------------------------------------
+
+
+def test_exists_in_libvirt_absent_returns_empty_strings(machine: Machine) -> None:
+    """When the domain isn't in the list, return (False, "", "") — not the
+    old (False, 0, 0) tuple — and don't call domstate at all."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names", return_value=["other_lab"]
+        ) as list_mock,
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate_reason") as state_mock,
+    ):
+        result = machine.exists_in_libvirt(URI)
+
+    assert result == (False, "", "")
+    list_mock.assert_called_once_with(URI)
+    state_mock.assert_not_called()
+
+
+def test_exists_in_libvirt_present_returns_state_and_reason(machine: Machine) -> None:
+    """When the domain is present, surface the lowercase virsh state strings
+    cli.py now compares against (``running``, ``shut off``, etc.)."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab", "other_lab"],
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_domstate_reason",
+            return_value=("running", "booted"),
+        ) as state_mock,
+    ):
+        result = machine.exists_in_libvirt(URI)
+
+    assert result == (True, "running", "booted")
+    state_mock.assert_called_once_with(URI, "web01_lab")
+
+
+def test_exists_in_libvirt_namespacing_uses_libvirt_vm_name(machine: Machine) -> None:
+    """The lookup must use the env-namespaced name, not the bare vm_name.
+    Regression guard: ``machines[].vm_name`` of ``web01`` in two environments
+    must not collide; only ``web01_<env>`` is the real domain name."""
+    machine.libvirt_vm_name = "web01_prod"
+    with mock.patch(
+        "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+        return_value=["web01_dev"],  # the dev namespaced name, not prod
+    ):
+        exists, _, _ = machine.exists_in_libvirt(URI)
+    assert exists is False
+
+
+def test_exists_in_libvirt_domstate_race_treated_as_absent(machine: Machine) -> None:
+    """If the domain vanishes between the list and the lookup, ``virsh``
+    raises ``VirshError`` for the second call. The method should treat that
+    as 'no longer present' rather than crashing the caller."""
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names", return_value=["web01_lab"]
+        ),
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_domstate_reason",
+            side_effect=VirshError(1, "domain not found", ["domstate"]),
+        ),
+    ):
+        result = machine.exists_in_libvirt(URI)
+
+    assert result == (False, "", "")
+
+
+def test_exists_in_libvirt_list_failure_propagates(machine: Machine) -> None:
+    """A failure of the initial ``virsh list`` (URI unreachable, virsh
+    missing, etc.) is an environmental problem — surface it, don't swallow."""
+    with mock.patch(
+        "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+        side_effect=VirshError(127, "virsh not found", ["list"]),
+    ):
+        with pytest.raises(VirshError):
+            machine.exists_in_libvirt(URI)

--- a/tkc_lvlab/cli.py
+++ b/tkc_lvlab/cli.py
@@ -148,7 +148,7 @@ def down(vm_name):
         )
 
         if exists:
-            if state in ["VIR_DOMAIN_RUNNING", "VIR_DOMAIN_PAUSED"]:
+            if state in {"running", "paused"}:
                 click.echo(f"Shutting down virtual machine {vm_name}.")
                 if (
                     machine.shutdown(environment.get("libvirt_uri", "qemu:///session"))
@@ -591,11 +591,11 @@ def up(vm_name):
         )
 
         if exists:
-            if status in ["VIR_DOMAIN_SHUTOFF", "VIR_DOMAIN_CRASHED"]:
+            if status in {"shut off", "crashed"}:
                 click.echo(f"Starting virtual machine {machine.vm_name}")
                 if machine.poweron(environment.get("libvirt_uri", None)) > 0:
                     logger.error("Problem powering on VM %s", machine.vm_name)
-            elif status in ["VIR_DOMAIN_RUNNING"]:
+            elif status == "running":
                 click.echo(f"The virtual machine {machine.vm_name} is running already")
 
         else:

--- a/tkc_lvlab/utils/libvirt.py
+++ b/tkc_lvlab/utils/libvirt.py
@@ -11,6 +11,7 @@ from .._logging import get_logger
 from ..config import parse_config, generate_hosts
 from .vdisk import VirtualDisk
 from .cloud_init import MetaData, NetworkConfig, UserData
+from .virsh import VirshError, virsh_domstate_reason, virsh_list_all_names
 
 
 logger = get_logger(__name__)
@@ -350,20 +351,35 @@ class Machine:
 
         return True
 
-    def exists_in_libvirt(self, uri):
-        """Virtual machine existance and status"""
-        exists, state, state_reason = (False, 0, 0)
+    def exists_in_libvirt(self, uri: str) -> tuple[bool, str, str]:
+        """Check whether this machine is defined in libvirt and report its state.
 
-        conn = connect_to_libvirt(uri)
-        current_vms = [dom.name() for dom in conn.listAllDomains()]
+        Looks the domain up by ``self.libvirt_vm_name`` against the list of
+        domains known to ``uri`` and, if found, queries its state and reason.
 
-        if self.libvirt_vm_name in current_vms:
-            vm = conn.lookupByName(self.libvirt_vm_name)
-            state, state_reason, _, _ = get_machine_state(vm.state())
-            exists = True
+        Args:
+            uri: A libvirt connection URI (e.g. ``qemu:///session``).
 
-        conn.close()
-        return exists, state, state_reason
+        Returns:
+            A 3-tuple ``(exists, state, state_reason)``. ``state`` and
+            ``state_reason`` are the lowercase virsh strings (``running``,
+            ``shut off``, ``shutdown user``, etc.). Both are ``""`` when the
+            domain is not defined.
+
+        Raises:
+            VirshError: If ``virsh`` itself fails (e.g. cannot reach the URI).
+        """
+        if self.libvirt_vm_name not in virsh_list_all_names(uri):
+            return False, "", ""
+
+        try:
+            state, reason = virsh_domstate_reason(uri, self.libvirt_vm_name)
+        except VirshError:
+            # The domain disappeared between the list and the lookup. Treat as
+            # absent rather than propagating a transient race.
+            return False, "", ""
+
+        return True, state, reason
 
     def list_snapshots(self, uri):
         """List snapshots for a virtual machine"""

--- a/tkc_lvlab/utils/libvirt.py
+++ b/tkc_lvlab/utils/libvirt.py
@@ -11,7 +11,16 @@ from .._logging import get_logger
 from ..config import parse_config, generate_hosts
 from .vdisk import VirtualDisk
 from .cloud_init import MetaData, NetworkConfig, UserData
-from .virsh import VirshError, virsh_domstate_reason, virsh_list_all_names
+from .virsh import (
+    DEAD_STATES,
+    SHUTDOWNABLE_STATES,
+    VirshError,
+    run_virsh,
+    virsh_domstate,
+    virsh_domstate_reason,
+    virsh_list_all_names,
+    virsh_snapshot_names,
+)
 
 
 logger = get_logger(__name__)
@@ -282,71 +291,127 @@ class Machine:
             logger.error("%s", " ".join(command))
             return False
 
-    def destroy(self, uri):
-        """Destroy a machine by shutting it down, undefining it, and deleting the directory
+    def destroy(self, uri: str) -> bool:
+        """Forcefully power off, undefine, and clean up files for this machine.
 
-        config_path is to be used in the fugure
+        The sequence is: force-off (if running/paused) -> delete all snapshots
+        -> undefine the domain -> remove on-disk files under
+        ``self.config_fpath``. Each ``virsh`` step is independent; if any step
+        fails the method logs and returns ``False`` without attempting later
+        steps (this preserves the previous "stop at first error" behavior).
+
+        Args:
+            uri: libvirt connection URI (e.g. ``qemu:///session``).
+
+        Returns:
+            ``True`` if the domain was undefined and file cleanup succeeded.
+            ``False`` if the domain was not found, any ``virsh`` call failed,
+            or file cleanup raised.
         """
-        conn = connect_to_libvirt(uri)
+        try:
+            current_vms = virsh_list_all_names(uri)
+        except VirshError as e:
+            logger.error("Failed to list domains at %s: %s", uri, e)
+            return False
 
-        current_vms = [dom.name() for dom in conn.listAllDomains()]
-
-        if self.libvirt_vm_name in current_vms:
-            vm = conn.lookupByName(self.libvirt_vm_name)
-            vm_state, _, _, _ = get_machine_state(vm.state())
-
-            if vm_state in ["VIR_DOMAIN_RUNNING", "VIR_DOMAIN_PAUSED"]:
-                logger.warning("Forcefully shutting down %s", self.vm_name)
-                if vm.destroy() > 0:
-                    logger.error("Failed to forcefully shutdown %s", self.vm_name)
-                vm_state, _, _, _ = get_machine_state(vm.state())
-
-            if vm_state in ["VIR_DOMAIN_SHUTOFF", "VIR_DOMAIN_CRASHED"]:
-                if vm.hasCurrentSnapshot():
-                    logger.warning("Deleting all snapshots for %s", self.vm_name)
-                    for snapshot in vm.listAllSnapshots():
-                        logger.info("Deleting snapshot %s", snapshot.getName())
-                        snapshot.delete()
-
-                logger.info("Undefining %s", self.vm_name)
-                if vm.undefine() > 0:
-                    logger.error(
-                        "Failed to undefine (remove from Libvirt) %s ", self.vm_name
-                    )
-                else:
-                    # Done with libvirt connection
-                    conn.close()
-                    try:
-                        machine_files = glob.glob(os.path.join(self.config_fpath, "*"))
-                        for file in machine_files:
-                            if os.path.isfile(file):
-                                logger.info("Removing file %s.", file)
-                                os.remove(file)
-                    except Exception as e:
-                        logger.error("Exception when removing machine files %s", e)
-                        return False
-
-                    try:
-                        # Check if the directory is empty and then remove it
-                        if not os.listdir(self.config_fpath):
-                            logger.info(
-                                "Removing machine directory %s.", self.config_fpath
-                            )
-                            os.rmdir(self.config_fpath)
-                        else:
-                            logger.warning(
-                                "Machine directory %s is not empty.", self.config_fpath
-                            )
-                    except Exception as e:
-                        logger.error("Exception when removing machine files %s", e)
-                        return False
-
-        else:
+        if self.libvirt_vm_name not in current_vms:
             logger.warning(
                 "The virtual machine %s does not exist in this Libvirt URI",
                 self.vm_name,
             )
-            conn.close()
+            return False
+
+        try:
+            vm_state = virsh_domstate(uri, self.libvirt_vm_name)
+        except VirshError as e:
+            logger.error("Failed to query state of %s: %s", self.vm_name, e)
+            return False
+
+        # Force-off if the domain is still running. virsh destroy is the
+        # power-cord-pull equivalent; the previous libvirt-python code called
+        # this on RUNNING or PAUSED.
+        if vm_state in {"running", "paused"}:
+            logger.warning("Forcefully shutting down %s", self.vm_name)
+            try:
+                run_virsh(uri, ["destroy", self.libvirt_vm_name])
+            except VirshError as e:
+                logger.error("Failed to forcefully shutdown %s: %s", self.vm_name, e)
+                return False
+            try:
+                vm_state = virsh_domstate(uri, self.libvirt_vm_name)
+            except VirshError as e:
+                logger.error(
+                    "Failed to query state of %s after destroy: %s", self.vm_name, e
+                )
+                return False
+
+        # Only proceed with snapshot cleanup + undefine when the domain has
+        # actually reached a dead state. If destroy didn't take effect (state
+        # is still running, in shutdown, etc.) we abort rather than undefining
+        # a live domain.
+        if vm_state not in DEAD_STATES:
+            logger.error(
+                "Machine %s is in state %r; refusing to undefine.",
+                self.vm_name,
+                vm_state,
+            )
+            return False
+
+        # Delete every snapshot before undefining. ``virsh undefine`` will
+        # refuse if snapshot metadata exists, so this is mandatory cleanup,
+        # not a courtesy.
+        try:
+            snapshots = virsh_snapshot_names(uri, self.libvirt_vm_name)
+        except VirshError as e:
+            logger.error("Failed to list snapshots for %s: %s", self.vm_name, e)
+            return False
+
+        if snapshots:
+            logger.warning("Deleting all snapshots for %s", self.vm_name)
+            for snap in snapshots:
+                logger.info("Deleting snapshot %s", snap)
+                try:
+                    run_virsh(uri, ["snapshot-delete", self.libvirt_vm_name, snap])
+                except VirshError as e:
+                    logger.error(
+                        "Failed to delete snapshot %s of %s: %s",
+                        snap,
+                        self.vm_name,
+                        e,
+                    )
+                    return False
+
+        logger.info("Undefining %s", self.vm_name)
+        try:
+            run_virsh(uri, ["undefine", self.libvirt_vm_name])
+        except VirshError as e:
+            logger.error(
+                "Failed to undefine (remove from Libvirt) %s: %s", self.vm_name, e
+            )
+            return False
+
+        # Remove on-disk machine files. Mirrors the previous behavior: a
+        # filesystem error here logs and returns False even though libvirt
+        # state has already been cleaned up.
+        try:
+            machine_files = glob.glob(os.path.join(self.config_fpath, "*"))
+            for file in machine_files:
+                if os.path.isfile(file):
+                    logger.info("Removing file %s.", file)
+                    os.remove(file)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error("Exception when removing machine files %s", e)
+            return False
+
+        try:
+            # Check if the directory is empty and then remove it
+            if not os.listdir(self.config_fpath):
+                logger.info("Removing machine directory %s.", self.config_fpath)
+                os.rmdir(self.config_fpath)
+            else:
+                logger.warning("Machine directory %s is not empty.", self.config_fpath)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.error("Exception when removing machine files %s", e)
             return False
 
         return True
@@ -440,58 +505,87 @@ class Machine:
                 conn.close()
                 return snapshot_status
 
-    def poweron(self, uri):
-        """Powreon a virtual machine"""
-        create_status = 0
-        conn = connect_to_libvirt(uri)
-        current_vms = [dom.name() for dom in conn.listAllDomains()]
+    def poweron(self, uri: str) -> int:
+        """Start the virtual machine if it is currently shut off or crashed.
 
-        if self.libvirt_vm_name in current_vms:
-            vm = conn.lookupByName(self.libvirt_vm_name)
-            vm_state, _, _, _ = get_machine_state(vm.state())
+        Returns ``0`` on success or when the machine is already running (or
+        absent — preserving the pre-port behavior of warning + returning 0).
+        Returns ``1`` when the ``virsh start`` invocation fails.
 
-            if vm_state in ["VIR_DOMAIN_SHUTOFF", "VIR_DOMAIN_CRASHED"]:
-                create_status = vm.create()
+        Args:
+            uri: libvirt connection URI (e.g. ``qemu:///session``).
 
-        else:
+        Returns:
+            ``0`` on success / no-op, ``1`` on ``VirshError``. The integer
+            return type matches the ``> 0`` truthy check in ``cli.py``.
+        """
+        try:
+            current_vms = virsh_list_all_names(uri)
+        except VirshError as e:
+            logger.error("Failed to list domains at %s: %s", uri, e)
+            return 1
+
+        if self.libvirt_vm_name not in current_vms:
             logger.warning(
                 "The virtual machine %s does not exist in this Libvirt URI",
                 self.vm_name,
             )
+            return 0
 
-        conn.close()
-        return create_status
+        try:
+            vm_state = virsh_domstate(uri, self.libvirt_vm_name)
+        except VirshError as e:
+            logger.error("Failed to query state of %s: %s", self.vm_name, e)
+            return 1
 
-    def shutdown(self, uri):
-        """Shutdown the virtual machine"""
-        shutdown_status = 0
-        conn = connect_to_libvirt(uri)
+        if vm_state in DEAD_STATES:
+            try:
+                run_virsh(uri, ["start", self.libvirt_vm_name])
+            except VirshError as e:
+                logger.error("Failed to power on %s: %s", self.vm_name, e)
+                return 1
 
-        # Get a list of current VMs
-        current_vms = [dom.name() for dom in conn.listAllDomains()]
+        return 0
 
-        if self.libvirt_vm_name in current_vms:
-            vm = conn.lookupByName(self.libvirt_vm_name)
-            vm_state, _, _, _ = get_machine_state(vm.state())
+    def shutdown(self, uri: str) -> int:
+        """Gracefully shut down the virtual machine if it is currently active.
 
-            if vm_state in [
-                "VIR_DOMAIN_RUNNING",
-                "VIR_DOMAIN_BLOCKED",
-                "VIR_DOMAIN_PAUSED",
-                "VIR_DOMAIN_PMSUSPENDED",
-            ]:
-                shutdown_status = vm.shutdown()
+        Active means any of ``running``, ``idle`` (i.e. blocked on resource),
+        ``paused``, or ``pmsuspended``. Already-stopped domains are a no-op.
 
-            if shutdown_status > 0:
-                logger.error("Error with machine.shutdown")
+        Args:
+            uri: libvirt connection URI (e.g. ``qemu:///session``).
 
-        else:
+        Returns:
+            ``0`` on success / no-op, ``1`` on ``VirshError``. The integer
+            return type matches the ``> 0`` truthy check in ``cli.py``.
+        """
+        try:
+            current_vms = virsh_list_all_names(uri)
+        except VirshError as e:
+            logger.error("Failed to list domains at %s: %s", uri, e)
+            return 1
+
+        if self.libvirt_vm_name not in current_vms:
             logger.warning(
                 "The virtual machine %s does not exist in Libvirt", self.vm_name
             )
+            return 0
 
-        conn.close()
-        return shutdown_status
+        try:
+            vm_state = virsh_domstate(uri, self.libvirt_vm_name)
+        except VirshError as e:
+            logger.error("Failed to query state of %s: %s", self.vm_name, e)
+            return 1
+
+        if vm_state in SHUTDOWNABLE_STATES:
+            try:
+                run_virsh(uri, ["shutdown", self.libvirt_vm_name])
+            except VirshError as e:
+                logger.error("Error with machine.shutdown: %s", e)
+                return 1
+
+        return 0
 
 
 def connect_to_libvirt(uri=None):


### PR DESCRIPTION
## Summary

Phase 2 step 3A of the libvirt-python -> virsh port. Replaces the libvirt-python calls in three lifecycle methods on `Machine` with subprocess invocations of `virsh` via the helpers in `tkc_lvlab.utils.virsh`.

State comparisons switch from `VIR_DOMAIN_*` constants to the lowercase strings `virsh domstate` emits — notably `idle` for what libvirt-python called `BLOCKED` — using the `DEAD_STATES` and `SHUTDOWNABLE_STATES` sets defined in the virsh module.

### Stacked on #77

This PR is stacked on #77 (`phase2/02-exists-in-libvirt`). The diff against `main` includes #77's changes; once #77 merges, this PR's diff will narrow to just the lifecycle work. No rebase needed on the consumer's end — the stacking auto-cleans.

### Methods ported

- `Machine.destroy` — `virsh destroy` (if running/paused) -> `virsh snapshot-delete` per snapshot -> `virsh undefine` -> file cleanup. Each virsh step is wrapped in try/except; `VirshError` at any step logs and returns `False` without attempting later steps. File cleanup now only runs after `virsh undefine` succeeds, so an undefine failure no longer orphans on-disk files belonging to a half-defined domain.
- `Machine.poweron` — `virsh start` when state in `DEAD_STATES` (`{"shut off", "crashed"}`). Returns `0` on success/no-op, `1` on `VirshError`.
- `Machine.shutdown` — `virsh shutdown` when state in `SHUTDOWNABLE_STATES` (`{"running", "idle", "paused", "pmsuspended"}`). Returns `0` on success/no-op, `1` on `VirshError`.

### Behavioral notes

- Return signatures preserved exactly so cli.py call sites are untouched: `destroy` still returns `bool` for the `if machine.destroy(...)` truthy check; `poweron` and `shutdown` still return `int` for the `> 0` failure check.
- `libvirt-python` returned `0` on success and raised on error. `virsh` returns nonzero on failure (translated to `VirshError`). The `> 0` defensive checks scattered through the old code are gone — error handling is now the `except VirshError` branch.
- The pre-port no-op behavior (domain absent, already in target state) is preserved across all three methods.

### What is intentionally not touched

Kept around for Agent B's snapshot port (step 3B) and step 6 cleanup: `connect_to_libvirt`, `_humanize_machine_status`, `get_machine_state`, and the `libvirt` / `re` imports. These get removed once snapshots are also ported.

### Tests

New `tests/test_libvirt_lifecycle.py` with 19 cases. All patch the `virsh_*` collaborators at the `tkc_lvlab.utils.libvirt` import boundary — nothing actually shells out.

**`destroy`:**
- running VM -> `virsh destroy` before `virsh undefine`
- already shut off -> skips `virsh destroy`, goes straight to undefine
- snapshots present -> each `virsh snapshot-delete` runs before `virsh undefine`
- domain absent from `virsh list` -> returns `False`, makes no further calls
- `virsh destroy` raises -> undefine NOT called, returns `False`
- `virsh undefine` raises -> file cleanup NOT performed (sentinel file preserved), returns `False`
- `virsh snapshot-delete` raises -> undefine NOT called

**`poweron`:**
- `shut off` -> `virsh start` called, returns `0`
- `crashed` -> `virsh start` called, returns `0`
- already running -> no-op, returns `0`
- `virsh start` raises `VirshError` -> returns `1`
- domain absent -> returns `0` (pre-port behavior preserved)

**`shutdown`:**
- parametrized over `{running, idle, paused, pmsuspended}` -> `virsh shutdown` called, returns `0`
- `shut off` -> no-op, returns `0`
- `virsh shutdown` raises -> returns `1`
- domain absent -> returns `0`

Full suite: **71 passing** (52 prior + 19 new).

## Test plan

- [x] `uv run pytest` passes locally (71 tests)
- [x] `uv run lvlab --help` imports cleanly
- [x] `pre-commit run --files <touched>` clean (black happy)
- [ ] (Reviewer) Confirm the `destroy` "stop at first failure" semantics match the prior intent — the new code is slightly stricter than the libvirt-python version (which silently absorbed non-zero return codes from `vm.destroy()` and continued).
- [ ] (Reviewer) Confirm the `>= phase2/02-exists-in-libvirt` base is acceptable; will rebase automatically once #77 merges.