### PR TITLE
refactor(cli): adopt snapshot return-shape changes from step 3B (Phase 2 step 3C)

### DIFF
--- a/tests/test_cli_snapshots.py
+++ b/tests/test_cli_snapshots.py
@@ -1,0 +1,231 @@
+"""Unit tests for the ``lvlab snapshot {list,create,delete}`` CLI commands.
+
+These tests lock in the Phase 2 step 3C touch-ups: cli.py must consume the
+new return contracts from :class:`tkc_lvlab.utils.libvirt.Machine` snapshot
+methods (``list_snapshots`` returns ``list[str]``, ``create_snapshot``
+returns ``True`` or raises ``VirshError``, ``delete_snapshot`` returns
+``None`` or raises ``VirshError``).
+
+Strategy: stub ``parse_config``, ``get_machine_by_vm_name`` and ``Machine``
+at the ``tkc_lvlab.cli`` import boundary so nothing here ever reads a
+manifest, builds a Machine, or invokes ``virsh``.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest import mock
+
+from click.testing import CliRunner
+
+from tkc_lvlab import cli
+from tkc_lvlab.cli import snapshot
+from tkc_lvlab.utils.virsh import VirshError
+
+
+URI = "qemu:///session"
+
+
+def _stub_parse_config() -> tuple[dict, dict, dict, list]:
+    """Return a minimal ``parse_config`` tuple that the snapshot commands
+    accept. Real values don't matter because :class:`Machine` is patched."""
+    environment = {"name": "lab", "libvirt_uri": URI}
+    images: dict = {}
+    config_defaults: dict = {}
+    machines = [{"vm_name": "web01"}]
+    return environment, images, config_defaults, machines
+
+
+def _make_machine_stub(**overrides) -> mock.MagicMock:
+    """Build a MagicMock that looks enough like a Machine for the snapshot
+    commands. The truthy ``exists_in_libvirt`` tuple lets the command pass
+    its guard and reach the method under test."""
+    machine = mock.MagicMock()
+    machine.vm_name = "web01"
+    machine.libvirt_vm_name = "web01_lab"
+    machine.exists_in_libvirt.return_value = (True, "running", "booted")
+    for key, value in overrides.items():
+        setattr(machine, key, value)
+    return machine
+
+
+# ---------------------------------------------------------------------------
+# snapshot list
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_list_renders_string_names_with_bullet_prefix() -> None:
+    """Each name from ``list_snapshots`` lands in stdout with the bullet prefix."""
+    machine = _make_machine_stub()
+    machine.list_snapshots.return_value = ["snap1", "snap2"]
+
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", return_value=_stub_parse_config()),
+        mock.patch.object(
+            cli, "get_machine_by_vm_name", return_value={"vm_name": "web01"}
+        ),
+        mock.patch.object(cli, "Machine", return_value=machine),
+    ):
+        result = runner.invoke(snapshot, ["list", "web01"])
+
+    assert result.exit_code == 0, result.output
+    assert "Listing snapshots for web01" in result.output
+    assert "  - snap1" in result.output
+    assert "  - snap2" in result.output
+
+
+def test_snapshot_list_empty_prints_no_snapshots_message() -> None:
+    """An empty ``list_snapshots`` result triggers the "No snapshots" branch."""
+    machine = _make_machine_stub()
+    machine.list_snapshots.return_value = []
+
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", return_value=_stub_parse_config()),
+        mock.patch.object(
+            cli, "get_machine_by_vm_name", return_value={"vm_name": "web01"}
+        ),
+        mock.patch.object(cli, "Machine", return_value=machine),
+    ):
+        result = runner.invoke(snapshot, ["list", "web01"])
+
+    assert result.exit_code == 0, result.output
+    assert "No snapshots found for web01" in result.output
+
+
+def test_snapshot_list_does_not_call_getName_on_string() -> None:
+    """Regression guard for the step 3C contract change.
+
+    Before 3B, list_snapshots returned libvirt virDomainSnapshot objects
+    and cli.py called ``.getName()``. After 3B the return type is
+    ``list[str]``. If cli.py still called ``.getName()`` on a string, the
+    output would contain a ``<MagicMock`` repr or an ``AttributeError``
+    crash. This test asserts the rendered output is exactly the bullet
+    plus the name — no ``getName`` artifacts.
+    """
+    machine = _make_machine_stub()
+    machine.list_snapshots.return_value = ["only-snap"]
+
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", return_value=_stub_parse_config()),
+        mock.patch.object(
+            cli, "get_machine_by_vm_name", return_value={"vm_name": "web01"}
+        ),
+        mock.patch.object(cli, "Machine", return_value=machine),
+    ):
+        result = runner.invoke(snapshot, ["list", "web01"])
+
+    assert result.exit_code == 0, result.output
+    assert "getName" not in result.output
+    assert "MagicMock" not in result.output
+    assert "  - only-snap" in result.output
+
+
+# ---------------------------------------------------------------------------
+# snapshot create
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_create_happy_path_prints_success_using_snapshot_name() -> None:
+    """``create_snapshot`` returning ``True`` produces a success line containing
+    the user-supplied snapshot name (the return value no longer carries it)."""
+    machine = _make_machine_stub()
+    machine.create_snapshot.return_value = True
+
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", return_value=_stub_parse_config()),
+        mock.patch.object(
+            cli, "get_machine_by_vm_name", return_value={"vm_name": "web01"}
+        ),
+        mock.patch.object(cli, "Machine", return_value=machine),
+    ):
+        result = runner.invoke(snapshot, ["create", "web01", "pre-upgrade"])
+
+    assert result.exit_code == 0, result.output
+    assert "Snapshot pre-upgrade created for web01" in result.output
+    machine.create_snapshot.assert_called_once_with(URI, "pre-upgrade", None)
+
+
+def test_snapshot_create_virsh_error_is_logged_and_does_not_crash(
+    caplog,
+) -> None:
+    """When ``create_snapshot`` raises ``VirshError`` the CLI logs and exits
+    cleanly (no traceback escaping to the user)."""
+    machine = _make_machine_stub()
+    machine.create_snapshot.side_effect = VirshError(
+        1, "operation failed", ["snapshot-create", "web01_lab"]
+    )
+
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", return_value=_stub_parse_config()),
+        mock.patch.object(
+            cli, "get_machine_by_vm_name", return_value={"vm_name": "web01"}
+        ),
+        mock.patch.object(cli, "Machine", return_value=machine),
+        caplog.at_level(logging.ERROR, logger="tkc_lvlab.cli"),
+    ):
+        result = runner.invoke(snapshot, ["create", "web01", "pre-upgrade"])
+
+    assert result.exit_code == 0, result.output
+    assert "Snapshot pre-upgrade created" not in result.output
+    assert any(
+        "Failed to create snapshot pre-upgrade for web01" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# snapshot delete
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_delete_happy_path_prints_success_message() -> None:
+    """``delete_snapshot`` returning ``None`` produces the success line."""
+    machine = _make_machine_stub()
+    machine.delete_snapshot.return_value = None
+
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", return_value=_stub_parse_config()),
+        mock.patch.object(
+            cli, "get_machine_by_vm_name", return_value={"vm_name": "web01"}
+        ),
+        mock.patch.object(cli, "Machine", return_value=machine),
+    ):
+        result = runner.invoke(snapshot, ["delete", "web01", "pre-upgrade", "--force"])
+
+    assert result.exit_code == 0, result.output
+    assert "Snapshot pre-upgrade deleted from web01" in result.output
+    machine.delete_snapshot.assert_called_once_with(URI, "pre-upgrade")
+
+
+def test_snapshot_delete_virsh_error_is_logged_and_does_not_crash(
+    caplog,
+) -> None:
+    """When ``delete_snapshot`` raises ``VirshError`` the CLI logs and exits 0."""
+    machine = _make_machine_stub()
+    machine.delete_snapshot.side_effect = VirshError(
+        1, "snapshot not found", ["snapshot-delete", "web01_lab", "ghost"]
+    )
+
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", return_value=_stub_parse_config()),
+        mock.patch.object(
+            cli, "get_machine_by_vm_name", return_value={"vm_name": "web01"}
+        ),
+        mock.patch.object(cli, "Machine", return_value=machine),
+        caplog.at_level(logging.ERROR, logger="tkc_lvlab.cli"),
+    ):
+        result = runner.invoke(snapshot, ["delete", "web01", "ghost", "--force"])
+
+    assert result.exit_code == 0, result.output
+    assert "Snapshot ghost deleted" not in result.output
+    assert any(
+        "Failed to delete snapshot ghost from web01" in record.getMessage()
+        for record in caplog.records
+    )

--- a/tkc_lvlab/cli.py
+++ b/tkc_lvlab/cli.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 import click
-import libvirt
 
 from ._logging import configure_logging, get_logger
 from .config import (
@@ -425,7 +424,7 @@ def list(vm_name):
                 snapshots = machine.list_snapshots(libvirt_endpoint)
                 if snapshots:
                     for snapshot in snapshots:
-                        click.echo(f"  - {snapshot.getName()}")
+                        click.echo(f"  - {snapshot}")
                 else:
                     click.echo(f"No snapshots found for {machine.vm_name}")
             else:
@@ -461,15 +460,20 @@ def create(vm_name, snapshot_name, snapshot_description=None):
         if machine:
             exists, _, _ = machine.exists_in_libvirt(libvirt_endpoint)
             if exists:
-                snapshot_status = machine.create_snapshot(
-                    libvirt_endpoint, snapshot_name, snapshot_description
-                )
-                if type(snapshot_status) == libvirt.virDomainSnapshot:
-                    click.echo(
-                        f"Snapshot {snapshot_status.getName()} created for {machine.vm_name}"
+                try:
+                    machine.create_snapshot(
+                        libvirt_endpoint, snapshot_name, snapshot_description
                     )
-                else:
-                    logger.error("Snapshot creation failed for %s", machine.vm_name)
+                    click.echo(
+                        f"Snapshot {snapshot_name} created for {machine.vm_name}"
+                    )
+                except VirshError as e:
+                    logger.error(
+                        "Failed to create snapshot %s for %s: %s",
+                        snapshot_name,
+                        machine.vm_name,
+                        e,
+                    )
             else:
                 logger.warning(
                     "Machine %s is not deployed to the configured in %s.",
@@ -512,16 +516,17 @@ def delete(vm_name, snapshot_name, force=False):
                     click.echo(f"Snapshot deletion aborted for {machine.vm_name}.")
                     return
 
-                snapshot_status = machine.delete_snapshot(
-                    libvirt_endpoint, snapshot_name
-                )
-                if snapshot_status == 0:
-                    click.echo(f"Snapshot deleted for {machine.vm_name}")
-                else:
+                try:
+                    machine.delete_snapshot(libvirt_endpoint, snapshot_name)
+                    click.echo(
+                        f"Snapshot {snapshot_name} deleted from {machine.vm_name}"
+                    )
+                except VirshError as e:
                     logger.error(
-                        "Snapshot deletion failed for %s: %s",
+                        "Failed to delete snapshot %s from %s: %s",
+                        snapshot_name,
                         machine.vm_name,
-                        snapshot_status,
+                        e,
                     )
             else:
                 logger.warning(


### PR DESCRIPTION
## Summary

Completes the cli.py side of #79's contract changes (Phase 2 step 3C).

Step 3B (#79) flipped three `Machine` snapshot methods to a new return contract; this PR updates the three call sites in `tkc_lvlab/cli.py` to match:

- `snapshot list` — `list_snapshots` now returns `list[str]`. Iterate name strings directly instead of calling `.getName()` on each element.
- `snapshot create` — `create_snapshot` now returns `True` on success or raises `VirshError`. Replaced the `type(...) == libvirt.virDomainSnapshot` check with a `try/except VirshError` pattern. Success message reuses the user-supplied `snapshot_name` argument since the return value no longer carries it.
- `snapshot delete` — `delete_snapshot` now returns `None` on success or raises `VirshError`. Same `try/except` pattern; both branches mirror the existing logger-based error style elsewhere in cli.py.

The `virDomainSnapshot` type check was the only remaining user of `import libvirt` in `cli.py`, so **that import is also removed**. `VirshError` was already imported via the `.utils.virsh` line that step 4 (#78) established — no new import statement needed.

Per the Phase 2 design (§4 step 3C), the `connect_to_libvirt` / `get_machine_state` imports stay until step 5 rewrites the `status` command.

### New tests

`tests/test_cli_snapshots.py` — 7 tests using `CliRunner`, stubbing `parse_config` / `get_machine_by_vm_name` / `Machine` at the cli import boundary so nothing touches `virsh` or the libvirt daemon:

- Happy paths for `list`, `create`, `delete`.
- Empty `list_snapshots` returns the "No snapshots found" branch.
- `VirshError` from `create_snapshot` / `delete_snapshot` is logged and the CLI exits cleanly (no traceback escapes).
- Regression guard: rendered `list` output contains neither `getName` nor `MagicMock`, so cli.py provably stopped calling `.getName()` on strings.

## Test plan

- [x] `uv run pytest` — 92 passed (85 existing + 7 new).
- [x] `uv run lvlab --help` and `uv run lvlab snapshot --help` render without import errors.
- [x] `pre-commit run --files tkc_lvlab/cli.py tests/test_cli_snapshots.py` — clean.
- [ ] Reviewer: confirm the `try/except VirshError` style here matches the convention you want for the rest of the step 5 rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)