### PR TITLE
refactor(cli): rewrite status command on virsh, drop reason string (Phase 2 step 5)

### DIFF
--- a/tests/test_cli_capabilities.py
+++ b/tests/test_cli_capabilities.py
@@ -43,11 +43,19 @@ def test_capabilities_prints_xml_from_virsh_capabilities() -> None:
 
 
 def test_capabilities_does_not_reach_libvirt_python() -> None:
-    """Regression guard: command must not call connect_to_libvirt."""
+    """Regression guard: command must not call connect_to_libvirt.
+
+    ``cli.py`` stopped importing ``connect_to_libvirt`` as of Phase 2
+    step 5 (status command rewrite), so we patch the helper on the
+    ``tkc_lvlab.utils.libvirt`` module where it still lives (step 6
+    will delete it). The patch will start to AttributeError once that
+    deletion lands — at which point the regression guard has lost its
+    target and this whole test can be retired with the function.
+    """
     runner = CliRunner()
     with (
         mock.patch.object(cli, "virsh_capabilities", return_value=SAMPLE_CAPS_XML),
-        mock.patch.object(cli, "connect_to_libvirt") as connect_mock,
+        mock.patch("tkc_lvlab.utils.libvirt.connect_to_libvirt") as connect_mock,
     ):
         result = runner.invoke(capabilities, [])
 

--- a/tests/test_cli_snapshots.py
+++ b/tests/test_cli_snapshots.py
@@ -1,0 +1,231 @@
+"""Unit tests for the ``lvlab snapshot {list,create,delete}`` CLI commands.
+
+These tests lock in the Phase 2 step 3C touch-ups: cli.py must consume the
+new return contracts from :class:`tkc_lvlab.utils.libvirt.Machine` snapshot
+methods (``list_snapshots`` returns ``list[str]``, ``create_snapshot``
+returns ``True`` or raises ``VirshError``, ``delete_snapshot`` returns
+``None`` or raises ``VirshError``).
+
+Strategy: stub ``parse_config``, ``get_machine_by_vm_name`` and ``Machine``
+at the ``tkc_lvlab.cli`` import boundary so nothing here ever reads a
+manifest, builds a Machine, or invokes ``virsh``.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest import mock
+
+from click.testing import CliRunner
+
+from tkc_lvlab import cli
+from tkc_lvlab.cli import snapshot
+from tkc_lvlab.utils.virsh import VirshError
+
+
+URI = "qemu:///session"
+
+
+def _stub_parse_config() -> tuple[dict, dict, dict, list]:
+    """Return a minimal ``parse_config`` tuple that the snapshot commands
+    accept. Real values don't matter because :class:`Machine` is patched."""
+    environment = {"name": "lab", "libvirt_uri": URI}
+    images: dict = {}
+    config_defaults: dict = {}
+    machines = [{"vm_name": "web01"}]
+    return environment, images, config_defaults, machines
+
+
+def _make_machine_stub(**overrides) -> mock.MagicMock:
+    """Build a MagicMock that looks enough like a Machine for the snapshot
+    commands. The truthy ``exists_in_libvirt`` tuple lets the command pass
+    its guard and reach the method under test."""
+    machine = mock.MagicMock()
+    machine.vm_name = "web01"
+    machine.libvirt_vm_name = "web01_lab"
+    machine.exists_in_libvirt.return_value = (True, "running", "booted")
+    for key, value in overrides.items():
+        setattr(machine, key, value)
+    return machine
+
+
+# ---------------------------------------------------------------------------
+# snapshot list
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_list_renders_string_names_with_bullet_prefix() -> None:
+    """Each name from ``list_snapshots`` lands in stdout with the bullet prefix."""
+    machine = _make_machine_stub()
+    machine.list_snapshots.return_value = ["snap1", "snap2"]
+
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", return_value=_stub_parse_config()),
+        mock.patch.object(
+            cli, "get_machine_by_vm_name", return_value={"vm_name": "web01"}
+        ),
+        mock.patch.object(cli, "Machine", return_value=machine),
+    ):
+        result = runner.invoke(snapshot, ["list", "web01"])
+
+    assert result.exit_code == 0, result.output
+    assert "Listing snapshots for web01" in result.output
+    assert "  - snap1" in result.output
+    assert "  - snap2" in result.output
+
+
+def test_snapshot_list_empty_prints_no_snapshots_message() -> None:
+    """An empty ``list_snapshots`` result triggers the "No snapshots" branch."""
+    machine = _make_machine_stub()
+    machine.list_snapshots.return_value = []
+
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", return_value=_stub_parse_config()),
+        mock.patch.object(
+            cli, "get_machine_by_vm_name", return_value={"vm_name": "web01"}
+        ),
+        mock.patch.object(cli, "Machine", return_value=machine),
+    ):
+        result = runner.invoke(snapshot, ["list", "web01"])
+
+    assert result.exit_code == 0, result.output
+    assert "No snapshots found for web01" in result.output
+
+
+def test_snapshot_list_does_not_call_getName_on_string() -> None:
+    """Regression guard for the step 3C contract change.
+
+    Before 3B, list_snapshots returned libvirt virDomainSnapshot objects
+    and cli.py called ``.getName()``. After 3B the return type is
+    ``list[str]``. If cli.py still called ``.getName()`` on a string, the
+    output would contain a ``<MagicMock`` repr or an ``AttributeError``
+    crash. This test asserts the rendered output is exactly the bullet
+    plus the name — no ``getName`` artifacts.
+    """
+    machine = _make_machine_stub()
+    machine.list_snapshots.return_value = ["only-snap"]
+
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", return_value=_stub_parse_config()),
+        mock.patch.object(
+            cli, "get_machine_by_vm_name", return_value={"vm_name": "web01"}
+        ),
+        mock.patch.object(cli, "Machine", return_value=machine),
+    ):
+        result = runner.invoke(snapshot, ["list", "web01"])
+
+    assert result.exit_code == 0, result.output
+    assert "getName" not in result.output
+    assert "MagicMock" not in result.output
+    assert "  - only-snap" in result.output
+
+
+# ---------------------------------------------------------------------------
+# snapshot create
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_create_happy_path_prints_success_using_snapshot_name() -> None:
+    """``create_snapshot`` returning ``True`` produces a success line containing
+    the user-supplied snapshot name (the return value no longer carries it)."""
+    machine = _make_machine_stub()
+    machine.create_snapshot.return_value = True
+
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", return_value=_stub_parse_config()),
+        mock.patch.object(
+            cli, "get_machine_by_vm_name", return_value={"vm_name": "web01"}
+        ),
+        mock.patch.object(cli, "Machine", return_value=machine),
+    ):
+        result = runner.invoke(snapshot, ["create", "web01", "pre-upgrade"])
+
+    assert result.exit_code == 0, result.output
+    assert "Snapshot pre-upgrade created for web01" in result.output
+    machine.create_snapshot.assert_called_once_with(URI, "pre-upgrade", None)
+
+
+def test_snapshot_create_virsh_error_is_logged_and_does_not_crash(
+    caplog,
+) -> None:
+    """When ``create_snapshot`` raises ``VirshError`` the CLI logs and exits
+    cleanly (no traceback escaping to the user)."""
+    machine = _make_machine_stub()
+    machine.create_snapshot.side_effect = VirshError(
+        1, "operation failed", ["snapshot-create", "web01_lab"]
+    )
+
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", return_value=_stub_parse_config()),
+        mock.patch.object(
+            cli, "get_machine_by_vm_name", return_value={"vm_name": "web01"}
+        ),
+        mock.patch.object(cli, "Machine", return_value=machine),
+        caplog.at_level(logging.ERROR, logger="tkc_lvlab.cli"),
+    ):
+        result = runner.invoke(snapshot, ["create", "web01", "pre-upgrade"])
+
+    assert result.exit_code == 0, result.output
+    assert "Snapshot pre-upgrade created" not in result.output
+    assert any(
+        "Failed to create snapshot pre-upgrade for web01" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# snapshot delete
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_delete_happy_path_prints_success_message() -> None:
+    """``delete_snapshot`` returning ``None`` produces the success line."""
+    machine = _make_machine_stub()
+    machine.delete_snapshot.return_value = None
+
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", return_value=_stub_parse_config()),
+        mock.patch.object(
+            cli, "get_machine_by_vm_name", return_value={"vm_name": "web01"}
+        ),
+        mock.patch.object(cli, "Machine", return_value=machine),
+    ):
+        result = runner.invoke(snapshot, ["delete", "web01", "pre-upgrade", "--force"])
+
+    assert result.exit_code == 0, result.output
+    assert "Snapshot pre-upgrade deleted from web01" in result.output
+    machine.delete_snapshot.assert_called_once_with(URI, "pre-upgrade")
+
+
+def test_snapshot_delete_virsh_error_is_logged_and_does_not_crash(
+    caplog,
+) -> None:
+    """When ``delete_snapshot`` raises ``VirshError`` the CLI logs and exits 0."""
+    machine = _make_machine_stub()
+    machine.delete_snapshot.side_effect = VirshError(
+        1, "snapshot not found", ["snapshot-delete", "web01_lab", "ghost"]
+    )
+
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", return_value=_stub_parse_config()),
+        mock.patch.object(
+            cli, "get_machine_by_vm_name", return_value={"vm_name": "web01"}
+        ),
+        mock.patch.object(cli, "Machine", return_value=machine),
+        caplog.at_level(logging.ERROR, logger="tkc_lvlab.cli"),
+    ):
+        result = runner.invoke(snapshot, ["delete", "web01", "ghost", "--force"])
+
+    assert result.exit_code == 0, result.output
+    assert "Snapshot ghost deleted" not in result.output
+    assert any(
+        "Failed to delete snapshot ghost from web01" in record.getMessage()
+        for record in caplog.records
+    )

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -1,0 +1,226 @@
+"""Unit tests for the ``lvlab status`` CLI command.
+
+These tests stub the virsh helpers and :func:`parse_config` at the
+``tkc_lvlab.cli`` import boundary so nothing here ever invokes ``virsh``
+or libvirt. They lock in the Phase 2 port: ``status`` now uses
+``virsh_list_all_names`` + ``virsh_domstate`` and the user-visible
+output no longer carries a parenthesized state-reason suffix.
+"""
+
+from __future__ import annotations
+
+from unittest import mock
+
+from click.testing import CliRunner
+
+from tkc_lvlab import cli
+from tkc_lvlab.cli import status
+from tkc_lvlab.utils.virsh import VirshError
+
+
+# A representative manifest tuple matching parse_config's return shape:
+# (environment, images, config_defaults, machines).
+SAMPLE_ENV = {"name": "demo", "libvirt_uri": "qemu:///session"}
+SAMPLE_IMAGES = {
+    "fedora-40": {"image_url": "https://example.invalid/fedora.qcow2"},
+    "debian-12": {"image_url": "https://example.invalid/debian.qcow2"},
+}
+SAMPLE_MACHINES = [
+    {"vm_name": "alpha"},
+    {"vm_name": "beta"},
+    {"vm_name": "gamma"},
+]
+
+
+def _patched_config(
+    env: dict | None = None,
+    images: dict | None = None,
+    machines: list | None = None,
+) -> mock._patch:
+    """Patch ``cli.parse_config`` with a deterministic tuple."""
+    return mock.patch.object(
+        cli,
+        "parse_config",
+        return_value=(
+            env if env is not None else SAMPLE_ENV,
+            images if images is not None else SAMPLE_IMAGES,
+            {},
+            machines if machines is not None else SAMPLE_MACHINES,
+        ),
+    )
+
+
+def test_status_happy_path_mixed_states_no_reason_suffix() -> None:
+    """alpha running, beta shut off, gamma undeployed — all rendered humanly."""
+    runner = CliRunner()
+    # Only the two deployed VMs come back from virsh list.
+    listed = ["alpha_demo", "beta_demo"]
+
+    def domstate_side_effect(uri: str, name: str) -> str:
+        assert uri == "qemu:///session"
+        if name == "alpha_demo":
+            return "running"
+        if name == "beta_demo":
+            return "shut off"
+        raise AssertionError(f"unexpected domstate call for {name}")
+
+    with (
+        _patched_config(),
+        mock.patch.object(cli, "virsh_list_all_names", return_value=listed),
+        mock.patch.object(
+            cli, "virsh_domstate", side_effect=domstate_side_effect
+        ) as domstate_mock,
+    ):
+        result = runner.invoke(status, [])
+
+    assert result.exit_code == 0, result.output
+    assert "LvLab Environment Name: demo" in result.output
+    assert "Machines Defined:" in result.output
+    assert "Images Used:" in result.output
+
+    # Per-machine lines, with humanized state and no reason suffix.
+    assert "  - alpha is the machine is running" in result.output
+    assert "  - beta is the machine is shut off" in result.output
+    assert "  - gamma is undeployed" in result.output
+
+    # Regression guard: dropped reason string. None of the successful
+    # state lines may carry a parenthesized reason like ``(normal startup
+    # from boot)``. The natural form to forbid is the substring ``is the
+    # machine is <state> (`` which is exactly what the old output emitted.
+    assert "is the machine is running (" not in result.output
+    assert "is the machine is shut off (" not in result.output
+    # And no successful-state line ends with ``)``.
+    for line in result.output.splitlines():
+        if "is the machine is" in line:
+            assert not line.rstrip().endswith(")"), line
+
+    # Image URLs surface in the Images Used block.
+    assert "fedora-40 from https://example.invalid/fedora.qcow2" in result.output
+    assert "debian-12 from https://example.invalid/debian.qcow2" in result.output
+
+    # Only the two deployed VMs are queried; the undeployed one is not.
+    assert domstate_mock.call_count == 2
+
+
+def test_status_all_undeployed_skips_domstate_entirely() -> None:
+    """No machines present on the hypervisor -> all 'undeployed', zero domstate calls."""
+    runner = CliRunner()
+    with (
+        _patched_config(),
+        mock.patch.object(cli, "virsh_list_all_names", return_value=[]),
+        mock.patch.object(cli, "virsh_domstate") as domstate_mock,
+    ):
+        result = runner.invoke(status, [])
+
+    assert result.exit_code == 0, result.output
+    assert "  - alpha is undeployed" in result.output
+    assert "  - beta is undeployed" in result.output
+    assert "  - gamma is undeployed" in result.output
+    domstate_mock.assert_not_called()
+
+
+def test_status_list_failure_exits_nonzero() -> None:
+    """When virsh list itself fails, the command logs an error and exits 1."""
+    runner = CliRunner()
+    err = VirshError(1, "error: failed to connect to the hypervisor", ["list"])
+    with (
+        _patched_config(),
+        mock.patch.object(cli, "virsh_list_all_names", side_effect=err),
+        mock.patch.object(cli, "virsh_domstate") as domstate_mock,
+    ):
+        result = runner.invoke(status, [])
+
+    assert result.exit_code == 1
+    # We never reach the per-machine loop if listing fails.
+    domstate_mock.assert_not_called()
+    # The "Machines Defined:" banner must not have been printed either —
+    # the failure happens before that section.
+    assert "Machines Defined:" not in result.output
+
+
+def test_status_per_machine_domstate_failure_continues() -> None:
+    """One VM's domstate failing renders an inline fallback; others render normally."""
+    runner = CliRunner()
+    listed = ["alpha_demo", "beta_demo"]
+
+    def domstate_side_effect(uri: str, name: str) -> str:
+        if name == "alpha_demo":
+            raise VirshError(1, "error: Domain not found", ["domstate", name])
+        if name == "beta_demo":
+            return "running"
+        raise AssertionError(f"unexpected domstate call for {name}")
+
+    with (
+        _patched_config(),
+        mock.patch.object(cli, "virsh_list_all_names", return_value=listed),
+        mock.patch.object(cli, "virsh_domstate", side_effect=domstate_side_effect),
+    ):
+        result = runner.invoke(status, [])
+
+    # Per-machine failure does NOT take the whole command down.
+    assert result.exit_code == 0, result.output
+    assert "  - alpha is unknown (virsh error)" in result.output
+    assert "  - beta is the machine is running" in result.output
+    assert "  - gamma is undeployed" in result.output
+
+
+def test_status_parse_config_typeerror_exits_nonzero() -> None:
+    """If the manifest can't be parsed, status exits 1 (existing contract)."""
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", side_effect=TypeError("bad config")),
+        mock.patch.object(cli, "virsh_list_all_names") as list_mock,
+    ):
+        result = runner.invoke(status, [])
+
+    assert result.exit_code == 1
+    # We never reach the virsh layer once parse_config fails.
+    list_mock.assert_not_called()
+
+
+def test_status_section_headers_unchanged_for_ux_continuity() -> None:
+    """The 'LvLab Environment Name', 'Machines Defined', and 'Images Used' headers stay."""
+    runner = CliRunner()
+    with (
+        _patched_config(machines=[]),  # empty machines is fine; we only check headers
+        mock.patch.object(cli, "virsh_list_all_names", return_value=[]),
+        mock.patch.object(cli, "virsh_domstate"),
+    ):
+        result = runner.invoke(status, [])
+
+    assert result.exit_code == 0, result.output
+    # Exact strings, in this order.
+    out = result.output
+    env_idx = out.find("LvLab Environment Name: demo")
+    machines_idx = out.find("Machines Defined:")
+    images_idx = out.find("Images Used:")
+    assert env_idx != -1
+    assert machines_idx != -1
+    assert images_idx != -1
+    assert env_idx < machines_idx < images_idx
+
+
+def test_status_does_not_reach_libvirt_python() -> None:
+    """Regression guard: the command must not touch the libvirt-python helpers.
+
+    After Phase 2 step 5, ``status`` is virsh-only. ``connect_to_libvirt`` /
+    ``get_machine_state`` are also slated for deletion in step 6 — this test
+    guarantees no late re-entry sneaks into ``status`` between now and then.
+    """
+    runner = CliRunner()
+    # connect_to_libvirt / get_machine_state were removed from cli's imports
+    # in this step. Patch them on the libvirt module (where they still live
+    # until step 6 deletes them) and assert nothing in the status code path
+    # imports or calls them.
+    with (
+        _patched_config(),
+        mock.patch.object(cli, "virsh_list_all_names", return_value=[]),
+        mock.patch.object(cli, "virsh_domstate"),
+        mock.patch("tkc_lvlab.utils.libvirt.connect_to_libvirt") as connect_mock,
+        mock.patch("tkc_lvlab.utils.libvirt.get_machine_state") as state_mock,
+    ):
+        result = runner.invoke(status, [])
+
+    assert result.exit_code == 0, result.output
+    connect_mock.assert_not_called()
+    state_mock.assert_not_called()

--- a/tkc_lvlab/cli.py
+++ b/tkc_lvlab/cli.py
@@ -14,14 +14,18 @@ from .config import (
 )
 from .utils.cloud_init import CloudInitIso, MetaData, NetworkConfig, UserData
 from .utils.libvirt import (
-    connect_to_libvirt,
-    get_machine_state,
     get_machine_by_vm_name,
     Machine,
 )
 from .utils.vdisk import VirtualDisk
 from .utils.images import CloudImage
-from .utils.virsh import VirshError, virsh_capabilities
+from .utils.virsh import (
+    VirshError,
+    humanize_state,
+    virsh_capabilities,
+    virsh_domstate,
+    virsh_list_all_names,
+)
 
 
 logger = get_logger(__name__)
@@ -539,40 +543,58 @@ def delete(vm_name, snapshot_name, force=False):
 
 
 @click.command()
-def status():
-    """Show the status of the environment."""
+def status() -> None:
+    """Show the status of the environment.
+
+    Lists the configured environment, every machine in the manifest with
+    its current libvirt state, and the cloud images referenced by the
+    manifest. Machines that are not present on the hypervisor are
+    reported as ``undeployed``.
+
+    Phase 2 note: this command now uses ``virsh`` exclusively. The
+    parenthesized state-reason suffix that previous releases printed
+    (e.g. ``the machine is running (normal startup from boot)``) has
+    been dropped to avoid an N+1 ``virsh domstate --reason`` call per
+    machine.
+    """
     try:
         environment, images, _, machines = parse_config()
-    except TypeError as e:
+    except TypeError:
         logger.error("Could not parse config file.")
         sys.exit(1)
 
-    click.echo()
-    click.echo(f'LvLab Environment Name: {environment.get("name", "no-name-lvlab")}\n')
-    conn = connect_to_libvirt(environment.get("libvirt_uri", None))
+    uri = environment.get("libvirt_uri", "qemu:///session")
+    env_name = environment.get("name", "no-name-lvlab")
 
-    # Get a list of current VMs
-    current_vms = [dom.name() for dom in conn.listAllDomains()]
+    click.echo()
+    click.echo(f"LvLab Environment Name: {env_name}\n")
+
+    try:
+        current_vms = virsh_list_all_names(uri)
+    except VirshError as exc:
+        logger.error("Failed to list domains at %s: %s", uri, exc)
+        sys.exit(1)
 
     click.echo("Machines Defined:\n")
     for machine in machines:
-        libvirt_vm_name = (
-            machine["vm_name"] + "_" + environment.get("name", "LvLabEnvironment")
-        )
+        libvirt_vm_name = f"{machine['vm_name']}_{env_name}"
         if libvirt_vm_name in current_vms:
-            vm = conn.lookupByName(libvirt_vm_name)
-            _, _, vm_status, vm_status_reason = get_machine_state(vm.state())
-            click.echo(
-                f"  - { machine['vm_name'] } is {vm_status} ({vm_status_reason})"
-            )
+            try:
+                state = virsh_domstate(uri, libvirt_vm_name)
+            except VirshError as exc:
+                logger.error("Failed to query state for %s: %s", libvirt_vm_name, exc)
+                click.echo(f"  - {machine['vm_name']} is unknown (virsh error)")
+                continue
+            human_state, _ = humanize_state(state, "")
+            click.echo(f"  - {machine['vm_name']} is {human_state}")
         else:
-            click.echo(f"  - { machine['vm_name'] } is undeployed")
+            click.echo(f"  - {machine['vm_name']} is undeployed")
 
     click.echo()
     click.echo("Images Used:\n")
-    for image_name, image_date in images.items():
+    for image_name, image_data in images.items():
         click.echo(
-            f'  - {image_name} from {image_date.get("image_url", "Missing Image URL.")}'
+            f"  - {image_name} from {image_data.get('image_url', 'Missing Image URL.')}"
         )
 
     click.echo()

--- a/tkc_lvlab/cli.py
+++ b/tkc_lvlab/cli.py
@@ -4,7 +4,6 @@ import os
 import sys
 
 import click
-import libvirt
 
 from ._logging import configure_logging, get_logger
 from .config import (
@@ -425,7 +424,7 @@ def list(vm_name):
                 snapshots = machine.list_snapshots(libvirt_endpoint)
                 if snapshots:
                     for snapshot in snapshots:
-                        click.echo(f"  - {snapshot.getName()}")
+                        click.echo(f"  - {snapshot}")
                 else:
                     click.echo(f"No snapshots found for {machine.vm_name}")
             else:
@@ -461,15 +460,20 @@ def create(vm_name, snapshot_name, snapshot_description=None):
         if machine:
             exists, _, _ = machine.exists_in_libvirt(libvirt_endpoint)
             if exists:
-                snapshot_status = machine.create_snapshot(
-                    libvirt_endpoint, snapshot_name, snapshot_description
-                )
-                if type(snapshot_status) == libvirt.virDomainSnapshot:
-                    click.echo(
-                        f"Snapshot {snapshot_status.getName()} created for {machine.vm_name}"
+                try:
+                    machine.create_snapshot(
+                        libvirt_endpoint, snapshot_name, snapshot_description
                     )
-                else:
-                    logger.error("Snapshot creation failed for %s", machine.vm_name)
+                    click.echo(
+                        f"Snapshot {snapshot_name} created for {machine.vm_name}"
+                    )
+                except VirshError as e:
+                    logger.error(
+                        "Failed to create snapshot %s for %s: %s",
+                        snapshot_name,
+                        machine.vm_name,
+                        e,
+                    )
             else:
                 logger.warning(
                     "Machine %s is not deployed to the configured in %s.",
@@ -512,16 +516,17 @@ def delete(vm_name, snapshot_name, force=False):
                     click.echo(f"Snapshot deletion aborted for {machine.vm_name}.")
                     return
 
-                snapshot_status = machine.delete_snapshot(
-                    libvirt_endpoint, snapshot_name
-                )
-                if snapshot_status == 0:
-                    click.echo(f"Snapshot deleted for {machine.vm_name}")
-                else:
+                try:
+                    machine.delete_snapshot(libvirt_endpoint, snapshot_name)
+                    click.echo(
+                        f"Snapshot {snapshot_name} deleted from {machine.vm_name}"
+                    )
+                except VirshError as e:
                     logger.error(
-                        "Snapshot deletion failed for %s: %s",
+                        "Failed to delete snapshot %s from %s: %s",
+                        snapshot_name,
                         machine.vm_name,
-                        snapshot_status,
+                        e,
                     )
             else:
                 logger.warning(


### PR DESCRIPTION
## Summary

Phase 2 step 5: rewrites ``lvlab status`` to use ``virsh`` exclusively, replacing the libvirt-python code path. Two ``virsh`` calls total — one ``virsh list --all --name`` for presence detection and one ``virsh domstate`` per deployed machine — instead of a libvirt connection plus per-VM ``vm.state()``.

**This PR stacks on #81** (Phase 2 step 3C). It contains the step-3C commit plus my step-5 commit; once #81 merges, GitHub will collapse the diff to just the step-5 change.

## User-visible output change (locked Phase 2 design decision)

The parenthesized state-reason suffix has been **dropped** from per-machine status lines. Phase 2 design §5 records this as the chosen trade-off to avoid an N+1 ``virsh domstate --reason`` round-trip.

```
before:  - alpha is the machine is running (normal startup from boot)
after:   - alpha is the machine is running
```

Headers (``LvLab Environment Name:``, ``Machines Defined:``, ``Images Used:``) are unchanged.

## Orphaned helpers — scheduled for deletion in step 6

``connect_to_libvirt`` and ``get_machine_state`` are no longer imported into ``cli.py`` after this step. They still live in ``tkc_lvlab/utils/libvirt.py`` (untouched, per the scope of this step) and are scheduled for deletion in Phase 2 step 6 along with the ``libvirt-python`` dependency drop. ``_humanize_machine_status`` was already orphaned by earlier steps and remains so.

A minor follow-up: ``tests/test_cli_capabilities.py::test_capabilities_does_not_reach_libvirt_python`` was patching ``cli.connect_to_libvirt`` directly. With the import removed it now patches ``tkc_lvlab.utils.libvirt.connect_to_libvirt`` (the real home). When step 6 deletes the helper, the patch will start to AttributeError; the test docstring notes this so a future cleanup can retire it cleanly.

## New tests (`tests/test_cli_status.py`, 7 tests)

- happy path with mixed states (running + shut off + undeployed), asserts humanized state strings and no parenthesized state-reason suffix
- all machines undeployed -> zero ``virsh_domstate`` calls
- ``virsh_list_all_names`` failure -> exit code 1; per-machine loop never runs
- per-machine ``virsh_domstate`` failure -> inline ``unknown (virsh error)`` fallback for that VM, other VMs render normally, command stays at exit 0
- ``parse_config`` ``TypeError`` -> exit code 1 (regression guard for existing contract)
- section headers preserved in order (``LvLab Environment Name:`` < ``Machines Defined:`` < ``Images Used:``)
- libvirt-python regression guard: status code path does not call ``connect_to_libvirt`` or ``get_machine_state``

The fallback-line wording (``unknown (virsh error)``) contains parentheses, but they're an error annotation, not a state reason — the regression assertion specifically forbids the form ``is the machine is <state> (`` that the old output emitted on success paths.

## Test plan

- [x] ``uv run pytest`` — 99 passed (92 baseline + 7 new)
- [x] ``uv run lvlab --help`` and ``uv run lvlab status --help`` render
- [x] ``pre-commit run --files`` — black, EOF, whitespace all pass
- [ ] Maintainer eyeball on the dropped reason string in real ``lvlab status`` output once Phase 2 lands end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)