### PR TITLE
Prepare 0.4.0 release

### DIFF
--- a/.github/release-notes/0.4.0.md
+++ b/.github/release-notes/0.4.0.md
@@ -1,46 +1,145 @@
-<!-- DRAFT — work in progress. Finalize when cutting 0.4.0, after the
-     createvm/deletevm changes are fine-tuned and fully tested. Bump
-     pyproject `version` to 0.4.0 before tagging. -->
-
 ## Highlights
 
-- **`createvm` / `deletevm` realigned with the `lvscripts-py` reference.**
-    The standalone one-off scripts are now faithful ports of the upstream
-    `createvm` / `deletevm` commands — same positional arguments, colored
-    output, options, and operations — keeping only lvlab's image-storage
-    paths and `Lvlab.yml`-merged image catalog.
-- **`createvm --ip4` now actually configures the guest.** The static
-    address is validated against the network's subnet/DHCP range *and*
-    rendered into the cloud-init network-config (previously it was
-    validated and then discarded — the VM always came up on DHCP).
-- **New `createvm` options:** `--netmask`, `--init-cloud-images`,
-    `--config <Lvlab.yml>`, `--version`. `VM_NAME` and `VM_DISTRO` are now
-    positional.
+First minor bump since the [0.3.0 release](https://github.com/memblin/tkc-lvlab-py/releases/tag/0.3.0).
+0.4.0 bundles a 12-issue program: new operator commands, a hardened
+one-off (`createvm` / `deletevm`) workflow, an expanded image catalog,
+a cross-distro networking correctness fix, and an internal refactor of
+the CLI/`Machine` seams. Headline changes:
+
+- **New `lvlab smoke` command.** Boots every VM in the manifest,
+    SSH-verifies it, then tears it down — a one-shot "does this whole
+    manifest still come up?" check. Runs a preflight gate (cached
+    images, free static addresses, SSH key present), detects host
+    memory + vCPUs, and **bin-packs the machines into concurrent
+    batches** under a memory budget, printing the plan before booting.
+    `--format text|json|yaml` for scripting; `--batch-size` to override
+    the computed concurrency.
+- **New `lvlab global show instances` command.** Cross-connection
+    overview of every libvirt domain across the configured URIs in one
+    Rich table — cheap reads only, never mutates state.
+- **New `lvlab images clean` command.** Prunes unreferenced cloud
+    images from the shared cache. Dry-run by default, and it
+    **protects images referenced in any manifest — including
+    commented-out `images:` entries** — so a temporarily-disabled image
+    isn't deleted out from under you.
+- **One-off scripts hardened and realigned.** `createvm` / `deletevm`
+    were brought to parity with the `lvscripts-py` one-off scripts
+    (now folded in here as the canonical implementation — `lvscripts-py`
+    is being archived). The big functional fixes:
+    - **`createvm --ip4` now actually configures the guest.** The
+        static address was previously validated and then *discarded* —
+        the VM always came up on DHCP. It's now rendered into the
+        guest's cloud-init network-config.
+    - **`deletevm` is snapshot-aware** with two confirmation tiers and
+        a `--snapshots-too` flag for fully non-interactive teardown.
+        Snapshot teardown (both `deletevm` and `lvlab destroy`) now
+        removes external disk snapshots with children **regardless of how
+        the host's libvirt phrases that limitation** — a single libvirt
+        version emits two different wordings, and the previous exact-string
+        match missed one, aborting the teardown. It's matched by semantic
+        tokens now.
+    - **Tolerant image downloads** — connect/read timeouts, retry, and
+        resume via a `.partial` file, so a flaky mirror no longer means
+        starting the multi-hundred-MB download over.
+    - **Disk-resize skip+warn** — when `--disk-size` is ≤ the base
+        image's virtual size, `createvm` keeps the base size and warns
+        instead of failing (qcow2 can't shrink).
+- **Image catalog grown to 8 guest images.** Added `debian11`,
+    `ubuntu2204`, `ubuntu2404`, and `almalinux9` to the existing
+    `debian12` / `debian13` / `almalinux10` / `fedora44`. The catalog is
+    shared by both `lvlab` and the one-off `createvm`.
+- **Cross-distro NIC binding fixed (this reverses a 0.3.0 decision —
+    see Breaking changes).** VMs now bind the right interface and get
+    their static IP / DHCP lease on **every** supported distro,
+    including Fedora.
+- **Centralized error handling.** Library code raises an `LvlabError`
+    hierarchy; the CLI translates it into clean exit codes instead of
+    leaking tracebacks on a bad manifest or an unreachable hypervisor.
 
 ## Breaking changes
 
 - **The one-off delete script `destroyvm` is renamed to `deletevm`.**
-    The `destroyvm` console-script/binary no longer exists; use `deletevm`.
-    Update any scripts, aliases, systemd units, or docs that call
-    `destroyvm`. (`lvlab destroy` — the manifest-scoped subcommand — is
-    unchanged.)
-- **`createvm`'s CLI surface changed** (matching the `lvscripts`
-    reference):
-    - The distro is now the **second positional argument**, not
-        `--distro`: `createvm myvm debian12` (was `createvm myvm --distro debian12`).
-    - Removed `--network-type`, `--copy`/`--no-copy`, and `--uri`.
+    The `destroyvm` console-script/binary no longer exists; use
+    `deletevm`. Update any scripts, aliases, systemd units, or docs that
+    call `destroyvm`. (`lvlab destroy` — the manifest-scoped subcommand —
+    is unchanged.)
+- **`createvm`'s CLI surface changed** to match the one-off reference:
+    - The distro is now the **second positional argument**, not a flag:
+        `createvm myvm debian12` (was `createvm myvm --distro debian12`).
+    - Removed `--network-type`, `--copy` / `--no-copy`, and `--uri`.
         `createvm` is `qemu:///system` only and always produces a
-        standalone (copied) qcow2. Rootless `qemu:///session` + user-mode
-        networking for the one-off scripts is deferred (see TODO below).
-    - Default `--disk-size` is now `35G` (was `20G`); `--cpu` / `--memory`
-        accept unit suffixes (`2G`, `512M`).
+        standalone (copied) qcow2.
+    - Default `--disk-size` is now `35G`; `--cpu` / `--memory` accept
+        unit suffixes (`2G`, `512M`).
+    - New options: `--netmask`, `--init-cloud-images`,
+        `--config <Lvlab.yml>`, `--version` / `-V`.
 - **`deletevm` acts on raw libvirt domain names only.** No `Lvlab.yml`
     translation: a short manifest name like `web01` won't resolve, but a
     manifest VM's full `<vm>_<env>` domain name *will* be removed if
     passed. Use `lvlab destroy` for manifest VMs.
+- **Generated network-config changed — `match: macaddress` replaces
+    `match.driver` + `set-name`.** 0.3.0 bound NICs by
+    `match.driver: virtio_net` and renamed the device via netplan
+    `set-name`; that **silently failed on Fedora** (the NetworkManager
+    renderer ignores a driver match), leaving static-IP and DHCP guests
+    unconfigured. 0.4.0 pins a per-interface MAC, passes it to
+    `virt-install --network ...,mac=`, and matches on that MAC in both
+    the v1 and v2 templates — the only selector cloud-init honours on
+    both the netplan (Debian/Ubuntu) and NetworkManager (Fedora/RHEL)
+    renderers. **Existing manifests need no changes** and running VMs are
+    unaffected until you re-`up` them; but the rendered config differs
+    and `iface.name` is now only the netplan stanza label, never the
+    in-guest device name (which keeps its kernel name — `enp1s0` /
+    `ens3` / `eth0`). The 0.3.0 "operator-chosen `iface.name` works the
+    same on every distro" note no longer holds.
 
-## Known follow-ups (not in this release)
+## Install / upgrade
 
-- User-mode networking for the one-off scripts + a fix for lvlab's
-    manifest user-mode path so `qemu:///session` VMs are reachable
-    (libvirt `<portForward>` / hostfwd). Tracked separately.
+```bash
+uv tool install --upgrade \
+  https://github.com/memblin/tkc-lvlab-py/releases/download/0.4.0/tkc_lvlab-0.4.0-py3-none-any.whl
+```
+
+The same wheel installs three console scripts: `lvlab` (manifest
+workflow), `createvm`, and `deletevm` (one-off VMs). Host package list
+per distro is in
+[`scripts/host-bootstrap.sh`](https://github.com/memblin/tkc-lvlab-py/blob/0.4.0/scripts/host-bootstrap.sh).
+
+## Supported hosts
+
+Validated end-to-end on the same four hosts as 0.3.0:
+
+- **Debian 12** bookworm (Python 3.11)
+- **Debian 13** trixie (Python 3.13)
+- **AlmaLinux 10** (Python 3.12)
+- **Fedora 44** (Python 3.14)
+
+That's the host matrix (what you run `lvlab` *on*) — distinct from the
+8-image **guest** catalog above. See
+[`docs-extra/host-validation.md`](https://github.com/memblin/tkc-lvlab-py/blob/0.4.0/docs-extra/host-validation.md)
+for the full matrix and the bootstrap/validation procedure.
+
+## Internal / toolchain
+
+Not user-facing, but worth knowing if you build from source or read the code:
+
+- **Build backend migrated to Hatchling + `uv-dynamic-versioning`.**
+    The package version is now derived from the git tag — there is no
+    `version` field in `pyproject.toml` to bump.
+- **`ConfigManager`** parses the manifest once per command (removed a
+    duplicate `parse_config` in `Machine.cloud_init`).
+- **`Machine` is now a thin facade** over extracted snapshot / destroy /
+    cloud-init collaborators; CLI command orchestration consolidated
+    behind shared resolve/error-boundary seams.
+- **Docs site auto-deploys to GitHub Pages** on push to `main`; the user
+    guide was restructured for an SRE / systems-engineer audience.
+
+## Full commit log
+
+```
+git log --oneline 0.3.0..0.4.0
+```
+
+(See the compare view at
+<https://github.com/memblin/tkc-lvlab-py/compare/0.3.0...0.4.0>
+for the full list — 50 commits, too long to inline here.)

--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -29,22 +29,20 @@ which uses its contents verbatim as the release body.
 
 ## Procedure for a new release
 
-1. Bump `version` in `pyproject.toml` (e.g. `0.3.0` → `0.3.1`).
-
-1. `uv lock` to pin the new version.
-
 1. Copy the template: `cp .github/release-notes/_template.md .github/release-notes/0.3.1.md`.
 
 1. Edit the new file. Replace the template sentinel and every
     `<placeholder>`. Keep sections relevant to the release; remove
     sections that don't apply.
 
-1. Commit `pyproject.toml`, `uv.lock`, and the notes file in one
-    commit (`chore: bump version to 0.3.1`).
+1. Commit the notes file — plus any release-time doc fixes, e.g. the
+    pinned install URL in `README.md` / `docs/index.md` — on `main`
+    and push. **There is no version bump:** the version is derived
+    from the git tag by `uv-dynamic-versioning`, so there is no
+    `version` field in `pyproject.toml` and nothing to `uv lock`.
 
-1. Push to `main`.
-
-1. Tag at the bump commit and push the tag:
+1. Tag at the notes commit and push the tag. The tag name *is* the
+    version (the semver decision is made here):
 
     ```bash
     git tag -m 'v0.3.1' 0.3.1

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ exact apt/dnf package list per supported host.
 curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Install the release wheel directly
-uv tool install https://github.com/memblin/tkc-lvlab-py/releases/download/0.3.0/tkc_lvlab-0.3.0-py3-none-any.whl
+uv tool install https://github.com/memblin/tkc-lvlab-py/releases/download/0.4.0/tkc_lvlab-0.4.0-py3-none-any.whl
 
 # lvlab should be ready for use
 lvlab up salt.local

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,7 +47,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Install the release wheel directly — grab the URL for the latest version
 # from https://github.com/memblin/tkc-lvlab-py/releases
-uv tool install https://github.com/memblin/tkc-lvlab-py/releases/download/0.3.0/tkc_lvlab-0.3.0-py3-none-any.whl
+uv tool install https://github.com/memblin/tkc-lvlab-py/releases/download/0.4.0/tkc_lvlab-0.4.0-py3-none-any.whl
 ```
 
 The wheel installs three console scripts on your `PATH`: `lvlab` (manifest

--- a/src/tkc_lvlab/utils/snapshot_cleanup.py
+++ b/src/tkc_lvlab/utils/snapshot_cleanup.py
@@ -11,9 +11,12 @@ Two helpers live here:
 - :func:`delete_all_snapshots` walks the snapshot list and deletes each
     one, falling back from ``--children`` (cascading delete) to
     ``--metadata`` (orphan metadata so undefine can proceed) when the
-    upstream qcow2 chain prevents the cleaner cascading delete. Includes
-    progress detection: if the same snapshot list comes back twice in a
-    row, the function refuses to loop forever.
+    upstream qcow2 chain prevents the cleaner cascading delete. The
+    "external snapshot" failure is detected by semantic tokens, not a
+    fixed phrase, because the wording varies across libvirt versions and
+    snapshot positions (issue #95). Includes progress detection: if the
+    same snapshot list comes back twice in a row, the function refuses to
+    loop forever.
 - :func:`undefine_with_snapshot_cleanup` tries ``virsh undefine`` first,
     detects the snapshot-related failure mode by stderr matching, and
     calls into :func:`delete_all_snapshots` before retrying. Other
@@ -31,7 +34,15 @@ from .virsh import VirshError, run_virsh, virsh_snapshot_names
 
 _SNAPSHOT_UNDEFINE_MARKER = "cannot delete inactive domain"
 _SNAPSHOT_KEYWORD = "snapshot"
-_EXTERNAL_CHILDREN_MARKER = "external children disk snapshots not supported"
+# Tokens that together identify libvirt's "can't --children-delete an external
+# snapshot" family. The exact phrasing varies by libvirt version *and* by the
+# snapshot's position in the chain — a single host (libvirt 12.0.0) emits both
+# "external children disk snapshots not supported" (deleting a parent) and
+# "external disk snapshots with children not supported" (deleting a leaf). An
+# exact-substring match on one phrasing missed the other and aborted the whole
+# teardown (issue #95); match the semantic tokens instead.
+_EXTERNAL_SNAPSHOT_TOKENS = ("external", "snapshot")
+_UNSUPPORTED_TOKENS = ("not supported", "unsupported")
 
 
 def _is_snapshot_undefine_error(stderr: str) -> bool:
@@ -51,17 +62,30 @@ def _is_snapshot_undefine_error(stderr: str) -> bool:
 
 
 def _is_external_children_error(stderr: str) -> bool:
-    """Return True when ``virsh snapshot-delete --children`` reports external children.
+    """Return True when ``virsh snapshot-delete --children`` can't delete an external snapshot.
+
+    libvirt refuses ``--children`` (cascading) deletes for external disk
+    snapshots, but the exact wording is not stable: it varies across
+    libvirt versions and even across the snapshot's position in the chain
+    on a single host (see :data:`_EXTERNAL_SNAPSHOT_TOKENS`). Rather than
+    pin one phrasing — which silently missed the other and aborted the
+    teardown (issue #95) — match the semantic tokens: the message names
+    an ``external`` ``snapshot`` and says the operation is ``unsupported``
+    / ``not supported``. In that case ``--metadata`` is the right
+    fallback. Unrelated failures (no ``external``/``snapshot`` mention)
+    do not match and propagate.
 
     Args:
         stderr: Captured stderr text from a failed ``snapshot-delete``.
 
     Returns:
-        True iff the stderr names the "external children disk snapshots
-        not supported" condition, in which case ``--metadata`` is the
-        right fallback.
+        True iff the stderr names an unsupported external-snapshot
+        operation, in which case ``--metadata`` is the right fallback.
     """
-    return _EXTERNAL_CHILDREN_MARKER in stderr.lower()
+    s = stderr.lower()
+    return all(t in s for t in _EXTERNAL_SNAPSHOT_TOKENS) and any(
+        t in s for t in _UNSUPPORTED_TOKENS
+    )
 
 
 def delete_all_snapshots(uri: str, domain_name: str) -> None:

--- a/tests/test_snapshot_cleanup.py
+++ b/tests/test_snapshot_cleanup.py
@@ -155,25 +155,41 @@ def test_delete_all_snapshots_uses_children_flag_by_default(
     assert deleted == ["a", "b", "c"]
 
 
+# Real ``virsh snapshot-delete --children`` stderr seen in the wild. libvirt
+# 12.0.0 emits BOTH of these on one host depending on the snapshot's position
+# in the chain, and the exact phrasing has shifted across versions — so the
+# detector must match the family, not one fixed phrase (issue #95).
+_EXTERNAL_SNAPSHOT_WORDINGS = [
+    # Parent-with-children (matched the pre-#95 exact-string marker).
+    "error: unsupported configuration: external children disk snapshots not supported",
+    # Leaf / newer wording (the one that aborted teardown on the user's host).
+    "error: unsupported configuration: "
+    "deletion of external disk snapshots with children not supported",
+]
+
+
+@pytest.mark.parametrize("stderr_msg", _EXTERNAL_SNAPSHOT_WORDINGS)
 def test_delete_all_snapshots_falls_back_to_metadata_on_external_children(
     monkeypatch: pytest.MonkeyPatch,
+    stderr_msg: str,
 ) -> None:
-    """--children failure with the 'external children' message → retry with --metadata."""
+    """A --children failure naming an unsupported external snapshot → retry with --metadata.
+
+    Regression for issue #95: the fallback must fire for every libvirt
+    wording of the external-snapshot limitation, not just the one phrase
+    the original exact-substring marker happened to carry.
+    """
     snap_lists = [["only-snap"], []]
     snap_names = mock.Mock(side_effect=snap_lists)
     monkeypatch.setattr(sc_mod, "virsh_snapshot_names", snap_names)
 
-    external_children_err = VirshError(
-        1,
-        "error: unsupported configuration: external children disk snapshots not supported",
-        ["snapshot-delete"],
-    )
+    external_children_err = VirshError(1, stderr_msg, ["snapshot-delete"])
 
     calls: list[list[str]] = []
 
     def fake_run(uri: str, args: list[str], **kwargs):
         calls.append(args)
-        # First call (--children): fail with external-children message.
+        # First call (--children): fail with external-snapshot message.
         # Second call (--metadata): succeed.
         if args[-1] == "--children":
             raise external_children_err


### PR DESCRIPTION
Prepares the **0.4.0** release. Tracking: #94.

## What's in here

Three commits:

1. **`fix(snapshot): match all libvirt wordings for external-snapshot delete (#95)`** — `deletevm` / `lvlab destroy` aborted on external disk snapshots with children because the fallback detector matched one exact libvirt phrase; a single libvirt version emits two wordings, so the `--metadata` fallback never fired. Now matched by semantic tokens. Verified end-to-end on real libvirt; regression test parametrized over both wordings. Closes #95.
2. **`docs: align release-notes README with tag-derived versioning`** — drops the stale Poetry-era "bump version + uv lock" steps; versioning is git-tag-derived via `uv-dynamic-versioning`.
3. **`docs: add 0.4.0 release notes + bump install URL to 0.4.0`** — the full-program `0.4.0.md` (the verbatim GitHub-release body) + pinned install-wheel URL `0.3.0` → `0.4.0` in `README.md` and `docs/index.md`.

## Notes

- **No version bump** — the tag *is* the version (`uv-dynamic-versioning`); there's no `version` field to change.
- The `0.4.0` install URLs intentionally 404 until the release workflow publishes the wheel; they're correct in the tagged commit.
- Tests: 486 passed / 39 skipped; `zensical build -s` clean.

## After merge

Tag `0.4.0` on `main` (a commit that contains `.github/release-notes/0.4.0.md`) to trigger `build-release.yml`:

```bash
git tag -m 'v0.4.0' 0.4.0
git push --tags
```

Prefer a fast-forward merge to preserve the three commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
