### PR TITLE
feat(cli): shared output helper + tabular status with image source (#103)

### DIFF
--- a/docs/api/utils/catalog.md
+++ b/docs/api/utils/catalog.md
@@ -1,0 +1,10 @@
+# tkc_lvlab.utils.catalog
+
+The built-in cloud-image catalog (`BUILTIN_IMAGES`) and the shared
+image-entry resolution used by **both** deploy paths — the standalone
+[`createvm`](../scripts/createvm.md) script and the manifest `Machine`
+flow. `os_variant` and the first-boot username are derived from the
+image key unless the entry overrides them, so a custom or oddly-keyed
+image pins those once and both paths honour it.
+
+::: tkc_lvlab.utils.catalog

--- a/docs/api/utils/output.md
+++ b/docs/api/utils/output.md
@@ -1,0 +1,10 @@
+# tkc_lvlab.utils.output
+
+Shared CLI output helpers: one table style plus the TTY-vs-pipe gate
+that human-facing commands (`status`, `init`, `smoke`,
+`global show instances`) render through, so the whole CLI reads
+consistently. Machine-facing output (`ssh-config`, `hosts`,
+`cloudinit`, any `--format json|yaml`) deliberately does **not** route
+through here — it stays raw so piping keeps working.
+
+::: tkc_lvlab.utils.output

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -129,19 +129,30 @@ is why custom images must follow that naming convention.
 ## status
 
 Show the configured environment, every machine in the manifest along
-with its current libvirt state, and the cloud images the manifest
-references.
+with its current libvirt state, and the cloud images available to you.
 
 ```bash
 lvlab status
 ```
 
-Machines not present on the hypervisor are reported as `undeployed`.
-Present machines show the lowercase `virsh domstate` string
-(`running`, `shut off`, `paused`, `crashed`, etc.). The
-parenthesized state-reason suffix previous releases printed (e.g.
-`is the machine is running (normal startup from boot)`) was dropped
-in 0.2.x to avoid an N+1 `virsh domstate --reason` call per machine.
+Output is two tables (the shared CLI table style — see
+[`tkc_lvlab.utils.output`](api/utils/output.md)):
+
+- **Machines** — each manifest VM and its state. Machines not present
+    on the hypervisor are reported as `undeployed`; present machines
+    show the lowercase `virsh domstate` string (`running`, `shut off`,
+    `paused`, `crashed`, etc.). The parenthesized state-reason suffix
+    previous releases printed (e.g. `(normal startup from boot)`) was
+    dropped in 0.2.x to avoid an N+1 `virsh domstate --reason` call per
+    machine.
+- **Images** — the built-in default catalog merged with the manifest's
+    `images:` (manifest wins on a name collision), so you see *what
+    images are available to you*, not just what this manifest names.
+    Each row is labelled with its `source` (`manifest` vs `default`)
+    and whether the image is already `cached` on disk.
+
+When stdout is piped or redirected the tables render as plain text
+(no ANSI), widened so long image URLs aren't clipped.
 
 ## ssh-config
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,8 @@ nav:
           - images: api/utils/images.md
           - cloud_init: api/utils/cloud_init.md
           - libvirt: api/utils/libvirt.md
+          - catalog: api/utils/catalog.md
+          - output: api/utils/output.md
       - scripts:
           - createvm: api/scripts/createvm.md
           - deletevm: api/scripts/deletevm.md

--- a/src/tkc_lvlab/cli.py
+++ b/src/tkc_lvlab/cli.py
@@ -30,12 +30,15 @@ module does not flow through them.
 from __future__ import annotations
 
 import os
+from typing import Any
 
 import typer
 from rich.console import Console
 from rich.table import Table
 
 from ._logging import configure_logging, get_logger
+from .utils.catalog import resolve_catalog
+from .utils.output import get_console, styled_table
 from .config import (
     ConfigManager,
     parse_config,
@@ -64,7 +67,6 @@ from .utils.virsh import (
     DOMSTATE_RUNNING,
     DomInfo,
     VirshError,
-    humanize_state,
     virsh_capabilities,
     virsh_dominfo,
     virsh_domstate,
@@ -948,14 +950,21 @@ def status() -> None:
     (e.g. ``the machine is running (normal startup from boot)``) has
     been dropped to avoid an N+1 ``virsh domstate --reason`` call per
     machine.
+
+    Issue #103 reshaped the output into the shared-style tables (see
+    :mod:`tkc_lvlab.utils.output`): a Machines table (VM + state) and an
+    Images table that merges the built-in default catalog with the
+    manifest's ``images:`` — labelling each image's source (``manifest``
+    vs ``default``) and whether it's cached on disk — so defaults show
+    up even when the manifest doesn't reference them.
     """
-    environment, images, _, machines = _load_config().as_tuple()
+    environment, images, config_defaults, machines = _load_config().as_tuple()
 
     uri = environment.get("libvirt_uri", DEFAULT_LIBVIRT_URI)
     env_name = environment.get("name", "no-name-lvlab")
 
-    typer.echo()
-    typer.echo(f"LvLab Environment Name: {env_name}\n")
+    console = get_console()
+    console.print(f"\nLvLab Environment Name: {env_name}\n")
 
     try:
         current_vms = virsh_list_all_names(uri)
@@ -963,29 +972,81 @@ def status() -> None:
         logger.error("Failed to list domains at %s: %s", uri, exc)
         raise typer.Exit(code=1)
 
-    typer.echo("Machines Defined:\n")
+    machines_table = styled_table(title="Machines")
+    machines_table.add_column("VM", style="bold")
+    machines_table.add_column("State")
     for machine in machines:
-        libvirt_vm_name = f"{machine['vm_name']}_{env_name}"
+        vm_name = machine["vm_name"]
+        libvirt_vm_name = f"{vm_name}_{env_name}"
         if libvirt_vm_name in current_vms:
             try:
                 state = virsh_domstate(uri, libvirt_vm_name)
             except VirshError as exc:
                 logger.error("Failed to query state for %s: %s", libvirt_vm_name, exc)
-                typer.echo(f"  - {machine['vm_name']} is unknown (virsh error)")
+                machines_table.add_row(vm_name, "unknown (virsh error)")
                 continue
-            human_state, _ = humanize_state(state, "")
-            typer.echo(f"  - {machine['vm_name']} is {human_state}")
+            machines_table.add_row(vm_name, state)
         else:
-            typer.echo(f"  - {machine['vm_name']} is undeployed")
+            machines_table.add_row(vm_name, "undeployed")
+    console.print(machines_table)
 
-    typer.echo()
-    typer.echo("Images Used:\n")
-    for image_name, image_data in images.items():
-        typer.echo(
-            f"  - {image_name} from {image_data.get('image_url', 'Missing Image URL.')}"
-        )
+    console.print()
+    console.print(_build_images_table(images, environment, config_defaults))
+    console.print()
 
-    typer.echo()
+
+def _build_images_table(
+    images: dict[str, Any] | None,
+    environment: dict[str, Any],
+    config_defaults: dict[str, Any],
+) -> Table:
+    """Build the ``status`` Images table: built-in defaults merged with the manifest.
+
+    Merges the built-in catalog (:data:`tkc_lvlab.utils.catalog.BUILTIN_IMAGES`)
+    with the manifest's ``images:`` — manifest wins on a name collision —
+    so built-in defaults are listed even when the manifest doesn't
+    reference them (``status`` answers "what images are available", not
+    just "what this manifest names"). Each row is labelled with its source
+    (``manifest`` vs ``default``) and whether the image is already cached
+    on disk.
+
+    Args:
+        images: The manifest's ``images:`` dict, or ``None`` when absent.
+        environment: The manifest's ``environment[0]`` dict (passed
+            through to :class:`~tkc_lvlab.utils.images.CloudImage`).
+        config_defaults: The manifest's ``config_defaults`` dict (supplies
+            ``cloud_image_basedir`` for the cache-path lookup).
+
+    Returns:
+        A populated :class:`rich.table.Table` titled ``Images``.
+    """
+    manifest_names = set(images or {})
+    catalog = resolve_catalog(images)
+
+    table = styled_table(title="Images")
+    table.add_column("image", style="bold")
+    table.add_column("source")
+    table.add_column("cached")
+    table.add_column("url")
+
+    for name in sorted(catalog):
+        cfg = catalog[name]
+        source = "manifest" if name in manifest_names else "default"
+        url = cfg.get("image_url")
+        if url:
+            cached = (
+                "yes"
+                if CloudImage(name, cfg, environment, config_defaults).exists_locally(
+                    "image"
+                )
+                else "no"
+            )
+        else:
+            url = "(missing image_url)"
+            cached = "?"
+        table.add_row(name, source, cached, url)
+
+    return table
 
 
 @app.command()
@@ -1206,17 +1267,12 @@ def _global_collect_instances(
 def _global_console() -> Console:
     """Return a Console that does not truncate the instances table.
 
-    Rich defaults a non-interactive Console (piped output, the test runner) to
-    80 columns and *truncates* table cells that overflow — which would clip
-    long domain names and connection URIs. When attached to a terminal we honor
-    its width; otherwise we widen enough that the table renders in full. The
-    ``COLUMNS`` env var still wins if the user sets it.
+    Thin wrapper over the shared :func:`tkc_lvlab.utils.output.get_console`
+    (issue #103): a non-interactive console is widened so long domain
+    names and connection URIs aren't clipped, while a real terminal's
+    width and a user-set ``COLUMNS`` are honored.
     """
-    console = Console()
-    if not console.is_terminal and "COLUMNS" not in os.environ:
-        # Wide enough for Name + URI + every metric column without clipping.
-        return Console(width=200)
-    return console
+    return get_console()
 
 
 def _global_format_memory(max_memory_kib: int | None) -> str:

--- a/src/tkc_lvlab/scripts/createvm.py
+++ b/src/tkc_lvlab/scripts/createvm.py
@@ -47,7 +47,13 @@ from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn
 
 from .. import __version__
 from ..config import parse_config
-from ..utils.catalog import ImageEntry as CatalogEntry, build_image_entry
+from ..utils.catalog import (
+    BUILTIN_IMAGES,
+    ImageEntry as CatalogEntry,
+    build_image_entry,
+    resolve_catalog,
+    resolve_image_entry,
+)
 from ..utils.cloud_init import CloudInitIso, NetworkConfig
 from ..utils.images import CloudImage
 from ..utils.network import (
@@ -101,175 +107,11 @@ _ONEOFF_STORAGE_ROOT = Path("/var/lib/libvirt/images/lvlab/oneoff")
 # ---------------------------------------------------------------------------
 
 
-# ``CatalogEntry`` (the resolved image type) and the ``os_variant`` /
-# ``default_username`` derivation now live in ``utils/catalog.py`` so the
-# manifest ``Machine`` path resolves images the same way — see the import
-# above (``ImageEntry as CatalogEntry``).
-
-
-# Built-in cloud images the standalone ``createvm`` script can resolve via
-# ``VM_DISTRO`` out of the box. Each value uses the **same schema as an
-# ``Lvlab.yml`` ``images:`` entry** so the built-in catalog and a cwd
-# manifest merge through one code path (:func:`resolve_catalog`). The
-# optional ``os_variant`` / ``username`` keys are omitted here: they're
-# derived from the key (debian12 -> debian12 / debian) via
-# ``utils/catalog`` and only need to appear when the derivation is wrong
-# (both createvm and ``lvlab up`` honour them — see that module).
-#
-# The ``refresh-cloud-images`` skill under ``.claude/skills/`` keeps these
-# in sync with upstream and surfaces new-major / EOL drift.
-BUILTIN_IMAGES: dict[str, dict[str, Any]] = {
-    "debian12": {
-        "image_url": (
-            "https://cloud.debian.org/images/cloud/bookworm/20260518-2482/"
-            "debian-12-generic-amd64-20260518-2482.qcow2"
-        ),
-        "checksum_url": (
-            "https://cloud.debian.org/images/cloud/bookworm/20260518-2482/SHA512SUMS"
-        ),
-        "checksum_type": "sha512",
-        "checksum_url_gpg": None,
-        "network_version": 2,
-    },
-    "debian13": {
-        "image_url": (
-            "https://cloud.debian.org/images/cloud/trixie/latest/"
-            "debian-13-generic-amd64.qcow2"
-        ),
-        "checksum_url": "https://cloud.debian.org/images/cloud/trixie/latest/SHA512SUMS",
-        "checksum_type": "sha512",
-        "checksum_url_gpg": None,
-        "network_version": 2,
-    },
-    "fedora44": {
-        "image_url": (
-            "https://download.fedoraproject.org/pub/fedora/linux/releases/44/"
-            "Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
-        ),
-        "checksum_url": (
-            "https://download.fedoraproject.org/pub/fedora/linux/releases/44/"
-            "Cloud/x86_64/images/Fedora-Cloud-44-1.7-x86_64-CHECKSUM"
-        ),
-        "checksum_type": "sha256",
-        "checksum_url_gpg": "https://fedoraproject.org/fedora.gpg",
-        "network_version": 2,
-    },
-    "almalinux10": {
-        "image_url": (
-            "https://repo.almalinux.org/almalinux/10/cloud/x86_64/images/"
-            "AlmaLinux-10-GenericCloud-latest.x86_64.qcow2"
-        ),
-        "checksum_url": (
-            "https://repo.almalinux.org/almalinux/10/cloud/x86_64/images/CHECKSUM"
-        ),
-        "checksum_type": "sha256",
-        "checksum_url_gpg": None,
-        "network_version": 2,
-    },
-    "almalinux9": {
-        "image_url": (
-            "https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/"
-            "AlmaLinux-9-GenericCloud-latest.x86_64.qcow2"
-        ),
-        "checksum_url": (
-            "https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/CHECKSUM"
-        ),
-        "checksum_type": "sha256",
-        "checksum_url_gpg": None,
-        "network_version": 2,
-    },
-    "debian11": {
-        "image_url": (
-            "https://cloud.debian.org/images/cloud/bullseye/20260518-2482/"
-            "debian-11-generic-amd64-20260518-2482.qcow2"
-        ),
-        "checksum_url": (
-            "https://cloud.debian.org/images/cloud/bullseye/20260518-2482/SHA512SUMS"
-        ),
-        "checksum_type": "sha512",
-        "checksum_url_gpg": None,
-        # Debian 11 stays on network-config v1 (ENI): the v2/netplan path
-        # stalls networking.service ~5 min via the ifupdown DHCPv6 hang.
-        "network_version": 1,
-    },
-    # Ubuntu publishes its cloud image as a ``.img`` (still qcow2 inside),
-    # checksums as ``hex *filename`` (binary marker), and a *detached* GPG
-    # signature (``SHA256SUMS.gpg``) that our clearsign verifier can't use
-    # — so ``checksum_url_gpg`` is left unset. The key ``ubuntu2204`` would
-    # derive the osinfo-unknown ``ubuntu2204``, so pin ``os_variant``.
-    "ubuntu2204": {
-        "image_url": (
-            "https://cloud-images.ubuntu.com/jammy/current/"
-            "jammy-server-cloudimg-amd64.img"
-        ),
-        "checksum_url": "https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS",
-        "checksum_type": "sha256",
-        "checksum_url_gpg": None,
-        "network_version": 2,
-        "os_variant": "ubuntu22.04",
-    },
-    "ubuntu2404": {
-        "image_url": (
-            "https://cloud-images.ubuntu.com/noble/current/"
-            "noble-server-cloudimg-amd64.img"
-        ),
-        "checksum_url": "https://cloud-images.ubuntu.com/noble/current/SHA256SUMS",
-        "checksum_type": "sha256",
-        "checksum_url_gpg": None,
-        "network_version": 2,
-        "os_variant": "ubuntu24.04",
-    },
-}
-
-
-def resolve_catalog(
-    manifest_images: dict[str, Any] | None,
-) -> dict[str, dict[str, Any]]:
-    """Merge the built-in catalog with a manifest's ``images:`` section.
-
-    Args:
-        manifest_images: The ``images:`` map from an ``Lvlab.yml``, or
-            ``None`` when no manifest is present.
-
-    Returns:
-        A new dict of ``{name: image_config}``. Manifest entries override
-        built-ins on a name collision; built-in names not redefined by the
-        manifest remain resolvable.
-    """
-    catalog: dict[str, dict[str, Any]] = {
-        name: dict(cfg) for name, cfg in BUILTIN_IMAGES.items()
-    }
-    if manifest_images:
-        for name, cfg in manifest_images.items():
-            catalog[name] = dict(cfg)
-    return catalog
-
-
-def resolve_image_entry(
-    distro: str, catalog: dict[str, dict[str, Any]]
-) -> CatalogEntry:
-    """Resolve a ``VM_DISTRO`` value against a merged catalog.
-
-    Matching is case-insensitive. ``os_variant`` and ``default_username``
-    are taken from the source dict when present, else derived from the key.
-
-    Args:
-        distro: The user-supplied ``VM_DISTRO`` value.
-        catalog: A merged catalog from :func:`resolve_catalog`.
-
-    Returns:
-        A fully-populated :class:`CatalogEntry`.
-
-    Raises:
-        ValueError: ``distro`` isn't in the catalog (message lists the
-            available names).
-    """
-    index = {name.lower(): name for name in catalog}
-    real_key = index.get(distro.lower())
-    if real_key is None:
-        available = ", ".join(sorted(catalog))
-        raise ValueError(f"Unknown distro '{distro}'. Available: {available}")
-    return build_image_entry(real_key, catalog[real_key])
+# ``BUILTIN_IMAGES`` and the catalog resolvers (``resolve_catalog`` /
+# ``resolve_image_entry``) now live in ``utils/catalog.py`` so ``lvlab``
+# (``cli.py``) can share them without importing from ``scripts/``. They are
+# re-exported above for backwards-compatible imports
+# (``from tkc_lvlab.scripts.createvm import BUILTIN_IMAGES``).
 
 
 def load_manifest_images(config_path: Path | None = None) -> dict[str, Any] | None:

--- a/src/tkc_lvlab/utils/catalog.py
+++ b/src/tkc_lvlab/utils/catalog.py
@@ -1,7 +1,7 @@
-"""Shared cloud-image entry resolution for both deploy paths.
+"""Shared cloud-image catalog + entry resolution for both deploy paths.
 
-A cloud image is described the same way everywhere — in
-:data:`tkc_lvlab.scripts.createvm.BUILTIN_IMAGES`, in an ``Lvlab.yml``
+A cloud image is described the same way everywhere — in the built-in
+:data:`BUILTIN_IMAGES` catalog (defined here), in an ``Lvlab.yml``
 ``images:`` entry, and in the smoke manifest. This module turns one such
 description plus its key into a fully-resolved :class:`ImageEntry`, with
 two fields derived from the key unless the entry overrides them:
@@ -156,3 +156,172 @@ def build_image_entry(key: str, cfg: dict[str, Any]) -> ImageEntry:
         os_variant=derive_os_variant(key, cfg.get("os_variant")),
         default_username=derive_username(key, cfg.get("username")),
     )
+
+
+# ---------------------------------------------------------------------------
+# Built-in cloud-image catalog
+# ---------------------------------------------------------------------------
+
+
+# Built-in cloud images resolvable out of the box by both the standalone
+# ``createvm`` script (via ``VM_DISTRO``) and ``lvlab init`` when no
+# manifest is present. Each value uses the **same schema as an
+# ``Lvlab.yml`` ``images:`` entry** so the built-in catalog and a cwd
+# manifest merge through one code path (:func:`resolve_catalog`). The
+# optional ``os_variant`` / ``username`` keys are omitted here: they're
+# derived from the key (debian12 -> debian12 / debian) via
+# :func:`build_image_entry` and only need to appear when the derivation is
+# wrong (both createvm and ``lvlab up`` honour them — see this module).
+#
+# The ``refresh-cloud-images`` skill under ``.claude/skills/`` keeps these
+# in sync with upstream and surfaces new-major / EOL drift.
+BUILTIN_IMAGES: dict[str, dict[str, Any]] = {
+    "debian12": {
+        "image_url": (
+            "https://cloud.debian.org/images/cloud/bookworm/20260518-2482/"
+            "debian-12-generic-amd64-20260518-2482.qcow2"
+        ),
+        "checksum_url": (
+            "https://cloud.debian.org/images/cloud/bookworm/20260518-2482/SHA512SUMS"
+        ),
+        "checksum_type": "sha512",
+        "checksum_url_gpg": None,
+        "network_version": 2,
+    },
+    "debian13": {
+        "image_url": (
+            "https://cloud.debian.org/images/cloud/trixie/latest/"
+            "debian-13-generic-amd64.qcow2"
+        ),
+        "checksum_url": "https://cloud.debian.org/images/cloud/trixie/latest/SHA512SUMS",
+        "checksum_type": "sha512",
+        "checksum_url_gpg": None,
+        "network_version": 2,
+    },
+    "fedora44": {
+        "image_url": (
+            "https://download.fedoraproject.org/pub/fedora/linux/releases/44/"
+            "Cloud/x86_64/images/Fedora-Cloud-Base-Generic-44-1.7.x86_64.qcow2"
+        ),
+        "checksum_url": (
+            "https://download.fedoraproject.org/pub/fedora/linux/releases/44/"
+            "Cloud/x86_64/images/Fedora-Cloud-44-1.7-x86_64-CHECKSUM"
+        ),
+        "checksum_type": "sha256",
+        "checksum_url_gpg": "https://fedoraproject.org/fedora.gpg",
+        "network_version": 2,
+    },
+    "almalinux10": {
+        "image_url": (
+            "https://repo.almalinux.org/almalinux/10/cloud/x86_64/images/"
+            "AlmaLinux-10-GenericCloud-latest.x86_64.qcow2"
+        ),
+        "checksum_url": (
+            "https://repo.almalinux.org/almalinux/10/cloud/x86_64/images/CHECKSUM"
+        ),
+        "checksum_type": "sha256",
+        "checksum_url_gpg": None,
+        "network_version": 2,
+    },
+    "almalinux9": {
+        "image_url": (
+            "https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/"
+            "AlmaLinux-9-GenericCloud-latest.x86_64.qcow2"
+        ),
+        "checksum_url": (
+            "https://repo.almalinux.org/almalinux/9/cloud/x86_64/images/CHECKSUM"
+        ),
+        "checksum_type": "sha256",
+        "checksum_url_gpg": None,
+        "network_version": 2,
+    },
+    "debian11": {
+        "image_url": (
+            "https://cloud.debian.org/images/cloud/bullseye/20260518-2482/"
+            "debian-11-generic-amd64-20260518-2482.qcow2"
+        ),
+        "checksum_url": (
+            "https://cloud.debian.org/images/cloud/bullseye/20260518-2482/SHA512SUMS"
+        ),
+        "checksum_type": "sha512",
+        "checksum_url_gpg": None,
+        # Debian 11 stays on network-config v1 (ENI): the v2/netplan path
+        # stalls networking.service ~5 min via the ifupdown DHCPv6 hang.
+        "network_version": 1,
+    },
+    # Ubuntu publishes its cloud image as a ``.img`` (still qcow2 inside),
+    # checksums as ``hex *filename`` (binary marker), and a *detached* GPG
+    # signature (``SHA256SUMS.gpg``) that our clearsign verifier can't use
+    # — so ``checksum_url_gpg`` is left unset. The key ``ubuntu2204`` would
+    # derive the osinfo-unknown ``ubuntu2204``, so pin ``os_variant``.
+    "ubuntu2204": {
+        "image_url": (
+            "https://cloud-images.ubuntu.com/jammy/current/"
+            "jammy-server-cloudimg-amd64.img"
+        ),
+        "checksum_url": "https://cloud-images.ubuntu.com/jammy/current/SHA256SUMS",
+        "checksum_type": "sha256",
+        "checksum_url_gpg": None,
+        "network_version": 2,
+        "os_variant": "ubuntu22.04",
+    },
+    "ubuntu2404": {
+        "image_url": (
+            "https://cloud-images.ubuntu.com/noble/current/"
+            "noble-server-cloudimg-amd64.img"
+        ),
+        "checksum_url": "https://cloud-images.ubuntu.com/noble/current/SHA256SUMS",
+        "checksum_type": "sha256",
+        "checksum_url_gpg": None,
+        "network_version": 2,
+        "os_variant": "ubuntu24.04",
+    },
+}
+
+
+def resolve_catalog(
+    manifest_images: dict[str, Any] | None,
+) -> dict[str, dict[str, Any]]:
+    """Merge the built-in catalog with a manifest's ``images:`` section.
+
+    Args:
+        manifest_images: The ``images:`` map from an ``Lvlab.yml``, or
+            ``None`` when no manifest is present.
+
+    Returns:
+        A new dict of ``{name: image_config}``. Manifest entries override
+        built-ins on a name collision; built-in names not redefined by the
+        manifest remain resolvable.
+    """
+    catalog: dict[str, dict[str, Any]] = {
+        name: dict(cfg) for name, cfg in BUILTIN_IMAGES.items()
+    }
+    if manifest_images:
+        for name, cfg in manifest_images.items():
+            catalog[name] = dict(cfg)
+    return catalog
+
+
+def resolve_image_entry(distro: str, catalog: dict[str, dict[str, Any]]) -> ImageEntry:
+    """Resolve a ``VM_DISTRO`` value against a merged catalog.
+
+    Matching is case-insensitive. ``os_variant`` and ``default_username``
+    are taken from the source dict when present, else derived from the key.
+
+    Args:
+        distro: The user-supplied ``VM_DISTRO`` value.
+        catalog: A merged catalog from :func:`resolve_catalog`.
+
+    Returns:
+        A fully-populated :class:`ImageEntry`.
+
+    Raises:
+        ValueError: ``distro`` isn't in the catalog (message lists the
+            available names).
+    """
+    index = {name.lower(): name for name in catalog}
+    real_key = index.get(distro.lower())
+    if real_key is None:
+        available = ", ".join(sorted(catalog))
+        raise ValueError(f"Unknown distro '{distro}'. Available: {available}")
+    return build_image_entry(real_key, catalog[real_key])

--- a/src/tkc_lvlab/utils/output.py
+++ b/src/tkc_lvlab/utils/output.py
@@ -1,0 +1,96 @@
+"""Shared CLI output helpers: one table style + a TTY-vs-pipe gate.
+
+Establishes the single human-facing output style the ``lvlab`` commands
+converge on (issue #103, the foundation of the #107 output-unification
+epic). The ``lvlab global show instances`` Rich table is the reference
+aesthetic; this module factors that out so ``status`` / ``init`` /
+``smoke`` render consistently, and provides the TTY detection that lets
+live views degrade to plain lines when stdout is piped, redirected, or
+running under CI.
+
+Audience split (see #107):
+
+- **Human-facing** summaries/tables route through here. Static tables
+    render through :func:`get_console`, which widens a non-interactive
+    console so cells aren't clipped — a Rich table printed to a pipe is
+    already plain (no ANSI), so it stays readable in logs.
+- **Live** views (progress, phase tables) should consult :func:`is_tty`
+    and fall back to plain incremental lines off a terminal, since a Rich
+    ``Live`` emits cursor-control escapes that garble captured logs.
+- **Machine-facing** output (``ssh-config``, ``hosts``, ``cloudinit``,
+    any ``--format json|yaml``) must NOT route through here — it stays
+    raw so piping keeps working.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from rich.box import Box, SQUARE
+from rich.console import Console
+from rich.table import Table
+
+
+# Width used for a non-interactive console (piped output, the test
+# runner). Rich defaults those to 80 columns and *truncates* cells that
+# overflow, which would clip long domain names, URIs, and image URLs.
+# Wide enough that the project's tables render in full; the ``COLUMNS``
+# env var still wins when the user sets it.
+NON_TTY_WIDTH = 200
+
+
+def get_console(*, stderr: bool = False) -> Console:
+    """Return the shared console, widened when stdout is not a TTY.
+
+    Use for static, human-facing tables. When attached to a terminal the
+    terminal's width is honored; otherwise the console is widened to
+    :data:`NON_TTY_WIDTH` so a piped/redirected table isn't clipped. A
+    user-set ``COLUMNS`` always wins.
+
+    Args:
+        stderr: Render to stderr instead of stdout.
+
+    Returns:
+        A configured :class:`rich.console.Console`.
+    """
+    console = Console(stderr=stderr)
+    if not console.is_terminal and "COLUMNS" not in os.environ:
+        return Console(stderr=stderr, width=NON_TTY_WIDTH)
+    return console
+
+
+def is_tty() -> bool:
+    """Return ``True`` when stdout is an interactive terminal.
+
+    Live/progress commands use this to decide between a Rich ``Live``
+    view (terminal) and a plain-line fallback (pipe/redirect/CI), the
+    #107 degradation rule. Reads ``sys.stdout`` directly so it reflects
+    the real stream rather than a transient console instance.
+
+    Returns:
+        ``True`` if ``sys.stdout`` is attached to a terminal.
+    """
+    return bool(getattr(sys.stdout, "isatty", lambda: False)())
+
+
+def styled_table(title: str | None = None, *, box: Box = SQUARE) -> Table:
+    """Return a :class:`~rich.table.Table` in the shared lvlab style.
+
+    Centralizes the title/header conventions so every tabular command
+    reads the same. Callers add columns/rows on the returned table.
+
+    Args:
+        title: Optional table title rendered above the grid.
+        box: Box-drawing style; defaults to a clean square border.
+
+    Returns:
+        An empty styled :class:`rich.table.Table`.
+    """
+    return Table(
+        title=title,
+        box=box,
+        title_style="bold",
+        header_style="bold cyan",
+        title_justify="left",
+    )

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -2,9 +2,19 @@
 
 These tests stub the virsh helpers and :func:`parse_config` at the
 ``tkc_lvlab.cli`` import boundary so nothing here ever invokes ``virsh``
-or libvirt. They lock in the Phase 2 port: ``status`` now uses
-``virsh_list_all_names`` + ``virsh_domstate`` and the user-visible
-output no longer carries a parenthesized state-reason suffix.
+or libvirt. They lock in two things:
+
+- The Phase 2 port: ``status`` uses ``virsh_list_all_names`` +
+    ``virsh_domstate`` and only queries state for *deployed* domains
+    (no N+1 ``virsh domstate`` for undeployed machines).
+- The issue #103 reshape: machines and images render as the shared-style
+    tables, the Images table merges the built-in default catalog with the
+    manifest (labelling each image's ``source``), and built-in defaults
+    appear even when the manifest doesn't reference them.
+
+``cached`` reflects real on-disk state, so tests that assert it point
+``cloud_image_basedir`` at an empty ``tmp_path`` to keep it deterministic;
+the others simply don't assert on the cached column.
 """
 
 from __future__ import annotations
@@ -36,6 +46,7 @@ def _patched_config(
     env: dict | None = None,
     images: dict | None = None,
     machines: list | None = None,
+    config_defaults: dict | None = None,
 ) -> mock._patch:
     """Patch ``cli.parse_config`` with a deterministic tuple."""
     return mock.patch.object(
@@ -44,14 +55,14 @@ def _patched_config(
         return_value=(
             env if env is not None else SAMPLE_ENV,
             images if images is not None else SAMPLE_IMAGES,
-            {},
+            config_defaults if config_defaults is not None else {},
             machines if machines is not None else SAMPLE_MACHINES,
         ),
     )
 
 
 def test_status_happy_path_mixed_states_no_reason_suffix() -> None:
-    """alpha running, beta shut off, gamma undeployed — all rendered humanly."""
+    """alpha running, beta shut off, gamma undeployed — rendered in the Machines table."""
     runner = CliRunner()
     # Only the two deployed VMs come back from virsh list.
     listed = ["alpha_demo", "beta_demo"]
@@ -75,31 +86,25 @@ def test_status_happy_path_mixed_states_no_reason_suffix() -> None:
 
     assert result.exit_code == 0, result.output
     assert "LvLab Environment Name: demo" in result.output
-    assert "Machines Defined:" in result.output
-    assert "Images Used:" in result.output
+    # Table titles (shared-style tables, issue #103).
+    assert "Machines" in result.output
+    assert "Images" in result.output
 
-    # Per-machine lines, with humanized state and no reason suffix.
-    assert "  - alpha is the machine is running" in result.output
-    assert "  - beta is the machine is shut off" in result.output
-    assert "  - gamma is undeployed" in result.output
+    # Machine rows: name + bare state (running / shut off), undeployed for gamma.
+    out = result.output
+    assert "alpha" in out and "running" in out
+    assert "beta" in out and "shut off" in out
+    assert "gamma" in out and "undeployed" in out
 
-    # Regression guard: dropped reason string. None of the successful
-    # state lines may carry a parenthesized reason like ``(normal startup
-    # from boot)``. The natural form to forbid is the substring ``is the
-    # machine is <state> (`` which is exactly what the old output emitted.
-    assert "is the machine is running (" not in result.output
-    assert "is the machine is shut off (" not in result.output
-    # And no successful-state line ends with ``)``.
-    for line in result.output.splitlines():
-        if "is the machine is" in line:
-            assert not line.rstrip().endswith(")"), line
-
-    # Image URLs surface in the Images Used block.
-    assert "fedora-40 from https://example.invalid/fedora.qcow2" in result.output
-    assert "debian-12 from https://example.invalid/debian.qcow2" in result.output
-
-    # Only the two deployed VMs are queried; the undeployed one is not.
+    # Regression guard: the dropped state-reason suffix must not reappear.
+    # The N+1 ``virsh domstate --reason`` avoidance is the real contract —
+    # only the two DEPLOYED VMs are queried, never the undeployed one.
+    assert "normal startup" not in out
     assert domstate_mock.call_count == 2
+
+    # Image URLs surface in the Images table.
+    assert "https://example.invalid/fedora.qcow2" in out
+    assert "https://example.invalid/debian.qcow2" in out
 
 
 def test_status_all_undeployed_skips_domstate_entirely() -> None:
@@ -113,9 +118,10 @@ def test_status_all_undeployed_skips_domstate_entirely() -> None:
         result = runner.invoke(app, ["status"])
 
     assert result.exit_code == 0, result.output
-    assert "  - alpha is undeployed" in result.output
-    assert "  - beta is undeployed" in result.output
-    assert "  - gamma is undeployed" in result.output
+    out = result.output
+    for vm in ("alpha", "beta", "gamma"):
+        assert vm in out
+    assert "undeployed" in out
     domstate_mock.assert_not_called()
 
 
@@ -133,9 +139,9 @@ def test_status_list_failure_exits_nonzero() -> None:
     assert result.exit_code == 1
     # We never reach the per-machine loop if listing fails.
     domstate_mock.assert_not_called()
-    # The "Machines Defined:" banner must not have been printed either —
-    # the failure happens before that section.
-    assert "Machines Defined:" not in result.output
+    # The Machines table is built only after a successful list, so its
+    # header column must not have been rendered.
+    assert "undeployed" not in result.output
 
 
 def test_status_per_machine_domstate_failure_continues() -> None:
@@ -159,9 +165,10 @@ def test_status_per_machine_domstate_failure_continues() -> None:
 
     # Per-machine failure does NOT take the whole command down.
     assert result.exit_code == 0, result.output
-    assert "  - alpha is unknown (virsh error)" in result.output
-    assert "  - beta is the machine is running" in result.output
-    assert "  - gamma is undeployed" in result.output
+    out = result.output
+    assert "unknown (virsh error)" in out
+    assert "running" in out
+    assert "undeployed" in out  # gamma
 
 
 def test_status_parse_config_typeerror_exits_nonzero() -> None:
@@ -178,23 +185,74 @@ def test_status_parse_config_typeerror_exits_nonzero() -> None:
     list_mock.assert_not_called()
 
 
-def test_status_section_headers_unchanged_for_ux_continuity() -> None:
-    """The 'LvLab Environment Name', 'Machines Defined', and 'Images Used' headers stay."""
+def test_status_renders_env_name_then_machines_then_images_in_order() -> None:
+    """The environment line, Machines table, and Images table appear in that order."""
     runner = CliRunner()
     with (
-        _patched_config(machines=[]),  # empty machines is fine; we only check headers
+        _patched_config(machines=[]),  # empty machines is fine; we check section order
         mock.patch.object(cli, "virsh_list_all_names", return_value=[]),
         mock.patch.object(cli, "virsh_domstate"),
     ):
         result = runner.invoke(app, ["status"])
 
     assert result.exit_code == 0, result.output
-    # Exact strings, in this order.
     out = result.output
     env_idx = out.find("LvLab Environment Name: demo")
-    machines_idx = out.find("Machines Defined:")
-    images_idx = out.find("Images Used:")
+    machines_idx = out.find("Machines")
+    images_idx = out.find("Images")
     assert env_idx != -1
     assert machines_idx != -1
     assert images_idx != -1
     assert env_idx < machines_idx < images_idx
+
+
+def test_status_images_table_labels_source_and_shows_defaults(tmp_path) -> None:
+    """Images table: manifest entries labelled 'manifest', built-ins 'default' and shown."""
+    runner = CliRunner()
+    # Manifest names two images, one of which (debian12) *overrides* a
+    # built-in (collision -> manifest wins) and one custom (rocky9).
+    images = {
+        "debian12": {"image_url": "https://example.invalid/custom-debian12.qcow2"},
+        "rocky9": {"image_url": "https://example.invalid/rocky9.qcow2"},
+    }
+    config_defaults = {"cloud_image_basedir": str(tmp_path)}  # empty -> cached "no"
+    with (
+        _patched_config(images=images, machines=[], config_defaults=config_defaults),
+        mock.patch.object(cli, "virsh_list_all_names", return_value=[]),
+        mock.patch.object(cli, "virsh_domstate"),
+    ):
+        result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0, result.output
+    out = result.output
+
+    # Both source labels are present.
+    assert "manifest" in out
+    assert "default" in out
+    # A built-in NOT named by the manifest still shows up (defaults shown).
+    assert "fedora44" in out
+    assert "almalinux10" in out
+    # The manifest's custom image shows up.
+    assert "rocky9" in out
+    # Collision: the manifest's debian12 URL wins over the built-in one.
+    assert "https://example.invalid/custom-debian12.qcow2" in out
+    assert (
+        "https://cloud.debian.org/images/cloud/bookworm" not in out
+    ), "built-in debian12 URL should be overridden by the manifest entry"
+
+
+def test_status_image_missing_url_does_not_crash(tmp_path) -> None:
+    """An images entry without image_url renders a placeholder, not a traceback."""
+    runner = CliRunner()
+    images = {"broken": {}}  # no image_url
+    config_defaults = {"cloud_image_basedir": str(tmp_path)}
+    with (
+        _patched_config(images=images, machines=[], config_defaults=config_defaults),
+        mock.patch.object(cli, "virsh_list_all_names", return_value=[]),
+        mock.patch.object(cli, "virsh_domstate"),
+    ):
+        result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0, result.output
+    assert "broken" in result.output
+    assert "missing image_url" in result.output

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,78 @@
+"""Unit tests for :mod:`tkc_lvlab.utils.output` — the shared CLI output
+helper (issue #103, foundation of the #107 output-unification epic).
+
+What matters here:
+
+- ``get_console`` widens a *non-interactive* console so piped/redirected
+    tables aren't clipped (the whole reason the helper exists), while a
+    user-set ``COLUMNS`` still wins.
+- ``is_tty`` is the gate live views use to fall back to plain lines off a
+    terminal.
+- ``styled_table`` round-trips its title/headers/cells through a console.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+
+from rich.console import Console
+
+from tkc_lvlab.utils import output
+from tkc_lvlab.utils.output import NON_TTY_WIDTH, get_console, is_tty, styled_table
+
+
+def test_styled_table_round_trips_title_headers_and_cells() -> None:
+    """A styled table renders its title, column headers, and row cells."""
+    table = styled_table(title="Demo")
+    table.add_column("col-a")
+    table.add_column("col-b")
+    table.add_row("alpha", "beta-value")
+
+    console = Console(width=NON_TTY_WIDTH, file=io.StringIO())
+    console.print(table)
+    rendered = console.file.getvalue()
+
+    assert "Demo" in rendered
+    assert "col-a" in rendered and "col-b" in rendered
+    assert "alpha" in rendered and "beta-value" in rendered
+
+
+def test_get_console_widens_when_not_a_terminal(monkeypatch) -> None:
+    """Off a terminal (and with COLUMNS unset) the console is widened so cells
+    aren't truncated to the 80-col non-interactive default."""
+    monkeypatch.delenv("COLUMNS", raising=False)
+    monkeypatch.setattr(output.Console, "is_terminal", property(lambda self: False))
+
+    console = get_console()
+
+    assert console.width == NON_TTY_WIDTH
+
+
+def test_get_console_respects_columns_env(monkeypatch) -> None:
+    """A user-set COLUMNS wins over the non-TTY widening."""
+    monkeypatch.setenv("COLUMNS", "123")
+    monkeypatch.setattr(output.Console, "is_terminal", property(lambda self: False))
+
+    console = get_console()
+
+    # COLUMNS is honored -> NOT forced to NON_TTY_WIDTH.
+    assert console.width == 123
+
+
+def test_is_tty_reflects_stdout(monkeypatch) -> None:
+    """is_tty mirrors sys.stdout.isatty so live views can degrade off a TTY."""
+
+    class FakeTTY:
+        def isatty(self) -> bool:
+            return True
+
+    class FakePipe:
+        def isatty(self) -> bool:
+            return False
+
+    monkeypatch.setattr(sys, "stdout", FakeTTY())
+    assert is_tty() is True
+
+    monkeypatch.setattr(sys, "stdout", FakePipe())
+    assert is_tty() is False


### PR DESCRIPTION
Closes #103. **Foundation** for the output-unification epic (#107).

## What

- **New `utils/output.py`** — the single human-facing output style: `get_console()` (widens a non-interactive console so piped tables aren't clipped; `COLUMNS` still wins), `is_tty()` (the gate live views will use to degrade off a terminal), and `styled_table()`. The `lvlab global show instances` table is now routed through `get_console()` so the de-facto reference command adopts the helper too.
- **`lvlab status` reshaped into two tables** (Machines, Images). The **Images table merges the built-in default catalog with the manifest's `images:`** (manifest wins on a name collision), labels each row's **source** (`manifest` vs `default`), and shows whether the image is **cached** on disk — so built-in defaults appear even when the manifest doesn't name them.
- **Catalog move:** `BUILTIN_IMAGES` + `resolve_catalog` + `resolve_image_entry` moved from `scripts/createvm.py` to `utils/catalog.py` so `cli.py` can share them without importing from `scripts/`. Re-exported from `createvm` for backwards-compatible imports (`from tkc_lvlab.scripts.createvm import BUILTIN_IMAGES` still works).

## Audience split (per #107)
Human-facing/static tables route through the helper. Machine-facing output (`ssh-config`, `hosts`, `cloudinit`, `--format json|yaml`) deliberately stays raw — untouched here.

## Tests
- New `tests/test_output.py`: non-TTY widening, `COLUMNS` override, `is_tty` gate, styled-table round-trip.
- `tests/test_cli_status.py` updated to the table format — **every behavioral guard preserved** (only-deployed-VMs queried / no N+1 `domstate`, exit codes, continue-on-per-machine-failure) — plus new coverage for source labelling, defaults-shown, collision=manifest-wins, and missing-`image_url` robustness.
- `cached` reflects real disk state, so tests that assert it point `cloud_image_basedir` at an empty `tmp_path`.

Full suite: **492 passed, 39 skipped** (baseline was 486; +6 new tests, 0 regressions). `pre-commit` clean; `zensical build -s` clean (added `catalog` + `output` to the API nav — `catalog` was previously missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)