### PR TITLE
fix(smoke): reap the empty environment dir after teardown (#100)

### DIFF
--- a/src/tkc_lvlab/smoke.py
+++ b/src/tkc_lvlab/smoke.py
@@ -975,6 +975,57 @@ def _run_case(
     return result
 
 
+def smoke_env_dir(config_defaults: dict[str, Any], environment: dict[str, Any]) -> str:
+    """Return the environment's storage directory the smoke run uses.
+
+    Mirrors :class:`~tkc_lvlab.utils.libvirt.Machine`'s layout: per-VM
+    artifacts live under ``<disk_image_basedir>/<env>/<vm>/``, so the
+    environment directory is ``<disk_image_basedir>/<env>/``.
+
+    Args:
+        config_defaults: The manifest's ``config_defaults`` (supplies
+            ``disk_image_basedir``).
+        environment: The manifest's ``environment[0]`` (supplies ``name``).
+
+    Returns:
+        The absolute environment-directory path (``~`` expanded).
+    """
+    basedir = os.path.expanduser(
+        config_defaults.get("disk_image_basedir", "/var/lib/libvirt/images/lvlab")
+    )
+    return os.path.join(basedir, environment.get("name", "LvLabEnvironment"))
+
+
+def cleanup_empty_env_dir(
+    config_defaults: dict[str, Any], environment: dict[str, Any]
+) -> bool:
+    """Remove the smoke environment directory iff it's empty.
+
+    ``lvlab destroy`` removes each VM's per-VM directory during teardown,
+    but leaves the parent environment directory behind empty (issue #100).
+    Smoke owns its teardown end-to-end, so it reaps its own env dir here.
+    ``os.rmdir`` only removes an *empty* directory, so an env dir that
+    still holds files (e.g. a VM whose teardown failed) is never touched —
+    that's the safety guarantee that keeps this from being a destructive
+    change to the shared ``destroy`` semantics.
+
+    Args:
+        config_defaults: The manifest's ``config_defaults``.
+        environment: The manifest's ``environment[0]``.
+
+    Returns:
+        ``True`` when the directory was removed, ``False`` when it was
+        absent or left in place (not empty).
+    """
+    env_dir = smoke_env_dir(config_defaults, environment)
+    try:
+        os.rmdir(env_dir)
+        return True
+    except OSError:
+        # Missing, or not empty (a teardown left files) — leave it alone.
+        return False
+
+
 def run_smoke(
     config_path: str,
     *,
@@ -1069,6 +1120,13 @@ def run_smoke(
 
     order = {c.vm_name: i for i, c in enumerate(cases)}
     results.sort(key=lambda r: order.get(r.vm_name, 0))
+
+    # Every case tore its VM down; reap the now-empty environment storage
+    # directory smoke created (issue #100). No-op if a teardown left files.
+    if cleanup_empty_env_dir(config_defaults, environment) and fmt is OutputFormat.TEXT:
+        print(
+            f"Removed empty environment directory {smoke_env_dir(config_defaults, environment)}"
+        )
 
     print(render_results(results, fmt))
     return 0 if all(r.result == "pass" for r in results) else 1

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -25,9 +25,11 @@ from tkc_lvlab.smoke import (
     check_images_cached,
     check_ssh_key_present,
     check_static_ips_free,
+    cleanup_empty_env_dir,
     format_plan,
     plan_batches,
     render_results,
+    smoke_env_dir,
     summarize,
 )
 from tkc_lvlab.utils.network import LibvirtNetworkInfo
@@ -417,3 +419,51 @@ def test_no_vm_boot_under_pytest():
     assert callable(smoke._run_case)
     # The Batch carrier is a plain data type, not a VM action.
     assert Batch(cases=()).cases == ()
+
+
+# ---------------------------------------------------------------------------
+# Environment-directory cleanup (issue #100)
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_env_dir_matches_machine_layout(tmp_path) -> None:
+    """smoke_env_dir resolves to <disk_image_basedir>/<env> (Machine's layout)."""
+    config_defaults = {"disk_image_basedir": str(tmp_path)}
+    environment = {"name": "smoke"}
+    assert smoke_env_dir(config_defaults, environment) == str(tmp_path / "smoke")
+
+
+def test_cleanup_empty_env_dir_removes_empty_dir(tmp_path) -> None:
+    """An empty env dir (every VM torn down) is reaped; returns True."""
+    env_dir = tmp_path / "smoke"
+    env_dir.mkdir()
+    config_defaults = {"disk_image_basedir": str(tmp_path)}
+    environment = {"name": "smoke"}
+
+    assert cleanup_empty_env_dir(config_defaults, environment) is True
+    assert not env_dir.exists()
+
+
+def test_cleanup_empty_env_dir_leaves_non_empty_dir(tmp_path) -> None:
+    """A non-empty env dir (a teardown left files) is left intact; returns False.
+
+    This is the safety guarantee: cleanup never deletes a dir that still
+    holds a VM's artifacts.
+    """
+    env_dir = tmp_path / "smoke"
+    env_dir.mkdir()
+    leftover = env_dir / "still-here.qcow2"
+    leftover.write_text("not empty")
+    config_defaults = {"disk_image_basedir": str(tmp_path)}
+    environment = {"name": "smoke"}
+
+    assert cleanup_empty_env_dir(config_defaults, environment) is False
+    assert env_dir.exists()
+    assert leftover.exists()
+
+
+def test_cleanup_empty_env_dir_missing_dir_is_noop(tmp_path) -> None:
+    """A missing env dir is a no-op (no raise); returns False."""
+    config_defaults = {"disk_image_basedir": str(tmp_path)}
+    environment = {"name": "never-created"}
+    assert cleanup_empty_env_dir(config_defaults, environment) is False


### PR DESCRIPTION
Closes #100.

After `lvlab smoke` (boot → verify → `down` → `destroy --force` every VM), `/var/lib/libvirt/images/lvlab/smoke/` was left behind **empty**: `lvlab destroy` removes each VM's per-VM dir (`<basedir>/<env>/<vm>/`) but never the parent environment dir.

## Fix (option 1 — smoke-scoped, lowest blast radius)
After the teardown loop, `cleanup_empty_env_dir()` does an `os.rmdir` of `<disk_image_basedir>/<env>/`. **`os.rmdir` only removes an empty directory**, so an env dir still holding a VM's artifacts (a failed teardown) is never touched — that's the safety guarantee that keeps this from altering the shared `destroy` semantics. TEXT format prints a one-line notice; JSON/YAML stdout stays clean.

Factored into `smoke_env_dir()` + `cleanup_empty_env_dir()` so it's unit-tested **without booting a VM**.

## Tests
- `smoke_env_dir` matches `Machine`'s `<basedir>/<env>` layout.
- empty env dir → reaped (returns True); non-empty → left intact **with its files** (returns False); missing → no-op (returns False).

Full suite **504 passed, 39 skipped** (+4). `pre-commit` clean.

## Not done here (deliberate)
The general fix — have `_DomainDestroyer._cleanup_files` rmdir the parent env dir so plain `lvlab destroy` of the *last* VM in any env also cleans up — touches the shared destroy path CLAUDE.md flags as intentionally leaving files behind. Left as a follow-up for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)