### PR TITLE
fix(images): clean error on download failure + gzip/416 resume bugs (#98)

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -71,6 +71,14 @@ no need to duplicate images for multiple environments. Unreferenced
 images can be removed with [`lvlab images clean`](#images-clean) (dry-run
 by default).
 
+Downloads tolerate flaky mirrors (connect/read timeouts, retry, and
+resume via a `.partial` file). If a download still fails — a 404, a
+refused connection, or a mirror that simply won't serve a file — `init`
+stops with a clear message instead of a traceback and tells you the
+exact cache path to drop the file at manually, then re-run. (This also
+handles gzip-served sidecars like Fedora's GPG key, which previously
+tripped a false "incomplete transfer".)
+
 ### Image Naming
 
 Custom images, and multiple versions of the same OS, need to follow a

--- a/src/tkc_lvlab/cli.py
+++ b/src/tkc_lvlab/cli.py
@@ -708,7 +708,15 @@ def init() -> None:
     # a list of CloudImages?
     for image_name, image_config in images.items():
         image = CloudImage(image_name, image_config, environment, config_defaults)
-        _init_process_image(image)
+        try:
+            _init_process_image(image)
+        except LvlabError as exc:
+            # Clean boundary (issue #98): a download/verify failure (e.g. a
+            # gzip-served sidecar that 416s, a 404, connection refused) surfaces
+            # as the ImageError's actionable message + workaround, not a
+            # traceback.
+            logger.error("%s", exc)
+            raise typer.Exit(code=1)
         typer.echo()
 
 

--- a/src/tkc_lvlab/exceptions.py
+++ b/src/tkc_lvlab/exceptions.py
@@ -21,6 +21,7 @@ Hierarchy::
     │   └── ManifestError  — semantic manifest-validation failure
     ├── VirshError         — a ``virsh`` invocation failed
     ├── LibvirtNetworkError — libvirt network info unresolvable / invalid
+    ├── ImageError         — a cloud image / sidecar could not be obtained
     ├── DependencyError    — a required host binary is missing
     ├── OsInfoLookupError  — virt-install osinfo enumeration failed
     ├── PasswordHashError  — password hash could not be generated
@@ -124,6 +125,19 @@ class LibvirtNetworkError(LvlabError, RuntimeError):
 
     Both are operator-actionable errors; the message names the specific
     failure.
+    """
+
+
+class ImageError(LvlabError, RuntimeError):
+    """Raised when a cloud image (or its checksum/GPG sidecar) can't be obtained.
+
+    Wraps the download path's transport/HTTP failures
+    (:class:`requests.RequestException`, including ``HTTPError`` and
+    exhausted retries) into a clean, operator-actionable message instead
+    of leaking a raw ``requests`` traceback at the CLI boundary. The
+    message names the URL, a short reason, and the manual-placement
+    workaround — drop the file into the cache directory and re-run (issue
+    #98).
     """
 
 

--- a/src/tkc_lvlab/scripts/createvm.py
+++ b/src/tkc_lvlab/scripts/createvm.py
@@ -47,6 +47,7 @@ from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn
 
 from .. import __version__
 from ..config import parse_config
+from ..exceptions import ImageError
 from ..utils.catalog import (
     BUILTIN_IMAGES,
     ImageEntry as CatalogEntry,
@@ -347,13 +348,22 @@ def _ensure_image_available(cloud_image: CloudImage) -> None:
     Raises:
         typer.Exit: Download or verification failed.
     """
-    if not cloud_image.exists_locally("image"):
-        if not cloud_image.download_image():
-            _fail(f"Failed to download cloud image from {cloud_image.image_url}")
-    if cloud_image.checksum_url and not cloud_image.exists_locally("checksum"):
-        cloud_image.download_checksum()
-    if cloud_image.checksum_url_gpg and not cloud_image.exists_locally("checksum_gpg"):
-        cloud_image.download_checksum_gpg()
+    try:
+        if not cloud_image.exists_locally("image"):
+            if not cloud_image.download_image():
+                _fail(f"Failed to download cloud image from {cloud_image.image_url}")
+        if cloud_image.checksum_url and not cloud_image.exists_locally("checksum"):
+            cloud_image.download_checksum()
+        if cloud_image.checksum_url_gpg and not cloud_image.exists_locally(
+            "checksum_gpg"
+        ):
+            cloud_image.download_checksum_gpg()
+    except ImageError as exc:
+        # Clean boundary (issue #98): a transport/HTTP download failure (e.g.
+        # the gzip-served Fedora GPG key returning 416) surfaces the
+        # ImageError's actionable message + manual-placement workaround
+        # instead of a raw requests traceback.
+        _fail(str(exc))
     if cloud_image.checksum_url_gpg:
         cloud_image.gpg_verify_checksum_file()
     if cloud_image.checksum_url and not cloud_image.checksum_verify_image():

--- a/src/tkc_lvlab/utils/images.py
+++ b/src/tkc_lvlab/utils/images.py
@@ -38,6 +38,7 @@ import requests
 from tqdm import tqdm
 
 from .._logging import get_logger
+from ..exceptions import ImageError
 from .catalog import derive_os_variant, derive_username
 
 
@@ -235,7 +236,9 @@ class CloudImage:  # pylint: disable=too-many-instance-attributes
             requests.exceptions.RequestException: Transport-layer failures
                 (timeouts, dropped connections) propagate to the retry loop.
             requests.HTTPError: A genuine HTTP error status (404/403/...) from
-                ``raise_for_status`` — fatal, not retried.
+                ``raise_for_status`` — fatal, not retried. (HTTP 416 on a
+                resume is the exception: it's handled here as a stale partial,
+                not re-raised — see below.)
         """
         already = os.path.getsize(partial_path) if os.path.exists(partial_path) else 0
 
@@ -246,19 +249,57 @@ class CloudImage:  # pylint: disable=too-many-instance-attributes
         response = requests.get(
             url, stream=True, timeout=_DOWNLOAD_TIMEOUT, headers=headers
         )
+
+        # HTTP 416 (Range Not Satisfiable) on a resume means our ``.partial``
+        # is stale or longer than the resource — its byte count starts past
+        # the resource's end. The classic cause is a gzip-DECODED partial
+        # measured against a COMPRESSED Content-Length (issue #98). Discard the
+        # partial and signal "incomplete" so the retry loop restarts fresh
+        # (no Range) instead of treating 416 as a fatal HTTP error.
+        if response.status_code == 416:
+            response.close()
+            if os.path.exists(partial_path):
+                os.remove(partial_path)
+            return False
+
         response.raise_for_status()
+
+        # ``Content-Encoding`` (gzip/deflate/br) transforms the body in
+        # transit: requests writes DECODED bytes, while Content-Length and
+        # Range describe the ENCODED representation. So for an encoded response
+        # both byte-resume and the byte-length completeness check are invalid —
+        # a clean end of stream is the only completeness signal (issue #98:
+        # fedoraproject.org/fedora.gpg is gzip-served, which made the length
+        # check report "incomplete" on every otherwise-perfect download).
+        encoding = response.headers.get("content-encoding", "").strip().lower()
+        content_encoded = encoding not in ("", "identity")
+
+        # If we requested a byte range but the server returned an encoded body,
+        # the range applies to encoded bytes we cannot append to decoded
+        # output. Discard the partial and retry fresh (next attempt sees no
+        # partial, sends no Range, and gets a clean full 200).
+        if content_encoded and headers.get("Range"):
+            response.close()
+            if os.path.exists(partial_path):
+                os.remove(partial_path)
+            return False
 
         # A 206 means the server honored our Range request — append. Anything
         # else (200, or no resume requested) means we get the whole body, so
         # start the partial over to avoid a corrupt prefix.
-        resuming = already and response.status_code == 206
+        resuming = bool(already) and response.status_code == 206 and not content_encoded
         if not resuming:
             already = 0
 
-        content_length = int(response.headers.get("content-length", 0))
-        # content-length on a 206 is the size of the *remaining* range, so the
-        # full expected size is the resume offset plus what's left to come.
-        total_size = content_length + already if content_length else 0
+        if content_encoded:
+            # Can't trust Content-Length for an encoded body; rely on the
+            # stream ending cleanly.
+            total_size = 0
+        else:
+            content_length = int(response.headers.get("content-length", 0))
+            # content-length on a 206 is the size of the *remaining* range, so
+            # the full expected size is the resume offset plus what's left.
+            total_size = content_length + already if content_length else 0
 
         block_size = 1024
         mode = "ab" if resuming else "wb"
@@ -359,6 +400,40 @@ class CloudImage:  # pylint: disable=too-many-instance-attributes
             raise last_exc
         return False
 
+    @classmethod
+    def _download_or_raise(cls, url: str, destination: str) -> bool:
+        """Download ``url`` to ``destination``, raising a clean ImageError on failure.
+
+        Thin wrapper over :meth:`_download_file` that translates the raw
+        ``requests`` transport/HTTP failures (connection refused, timeouts,
+        a fatal 404/403, exhausted retries) into an :class:`ImageError`
+        carrying the manual-placement workaround, so the CLI boundary can
+        surface a clean message instead of a ``requests`` traceback (issue
+        #98). The bool return (``True`` complete / ``False`` content-length
+        mismatch) passes through unchanged.
+
+        Args:
+            url: HTTP(S) URL to download.
+            destination: Local filesystem path to write to on success.
+
+        Returns:
+            ``True`` on a complete write; ``False`` on a content-length
+            mismatch that survived every retry.
+
+        Raises:
+            ImageError: The download failed with a transport or HTTP error.
+        """
+        try:
+            return cls._download_file(url, destination)
+        except requests.RequestException as exc:
+            response = getattr(exc, "response", None)
+            status = getattr(response, "status_code", None)
+            reason = f"HTTP {status}" if status else exc.__class__.__name__
+            raise ImageError(
+                f"Could not download {url} ({reason}). You can place the file "
+                f"manually at {destination} and re-run."
+            ) from exc
+
     def _manage_image_dir(self) -> None:
         """Ensure the cloud-images directory exists, expanding ``~`` if needed."""
         if "~" in self.image_dir:
@@ -375,11 +450,12 @@ class CloudImage:  # pylint: disable=too-many-instance-attributes
 
         Creates the cache directory if needed. Returns ``True`` on
         successful download, ``False`` on content-length mismatch.
+
+        Raises:
+            ImageError: The download failed with a transport or HTTP error.
         """
         self._manage_image_dir()
-        if self._download_file(self.image_url, self.image_fpath):
-            return True
-        return False
+        return self._download_or_raise(self.image_url, self.image_fpath)
 
     def download_checksum(self) -> bool:
         """Download the checksum manifest to :attr:`checksum_fpath`.
@@ -387,10 +463,11 @@ class CloudImage:  # pylint: disable=too-many-instance-attributes
         Returns:
             ``True`` on successful download, ``False`` on content-length
             mismatch.
+
+        Raises:
+            ImageError: The download failed with a transport or HTTP error.
         """
-        if self._download_file(self.checksum_url, self.checksum_fpath):
-            return True
-        return False
+        return self._download_or_raise(self.checksum_url, self.checksum_fpath)
 
     def download_checksum_gpg(self) -> bool:
         """Download the GPG keyring to :attr:`checksum_gpg_fpath`.
@@ -398,10 +475,11 @@ class CloudImage:  # pylint: disable=too-many-instance-attributes
         Returns:
             ``True`` on successful download, ``False`` on content-length
             mismatch.
+
+        Raises:
+            ImageError: The download failed with a transport or HTTP error.
         """
-        if self._download_file(self.checksum_url_gpg, self.checksum_gpg_fpath):
-            return True
-        return False
+        return self._download_or_raise(self.checksum_url_gpg, self.checksum_gpg_fpath)
 
     def exists_locally(self, file_type: str = "image") -> bool:
         """Check whether one of the on-disk artifacts is already cached.

--- a/tests/test_images_download.py
+++ b/tests/test_images_download.py
@@ -30,6 +30,7 @@ from unittest.mock import patch
 import pytest
 import requests
 
+from tkc_lvlab.exceptions import ImageError
 from tkc_lvlab.utils.images import CloudImage
 
 
@@ -48,17 +49,32 @@ class _FakeResponse:
         status_code: int = 200,
         accept_ranges: bool = False,
         http_error: bool = False,
+        content_encoding: str | None = None,
+        content_length: int | None = None,
     ) -> None:
         self._body = body
         self.status_code = status_code
-        self.headers: dict[str, str] = {"content-length": str(len(body))}
+        # ``content_length`` lets a test advertise a length that differs from
+        # the written body — e.g. the COMPRESSED size on a gzip response.
+        length = content_length if content_length is not None else len(body)
+        self.headers: dict[str, str] = {"content-length": str(length)}
         if accept_ranges:
             self.headers["accept-ranges"] = "bytes"
+        if content_encoding:
+            self.headers["content-encoding"] = content_encoding
         self._http_error = http_error
+        self.closed = False
 
     def raise_for_status(self) -> None:
         if self._http_error:
-            raise requests.HTTPError(f"{self.status_code} error")
+            # Mirror requests: the raised HTTPError carries the response, so
+            # callers can read ``exc.response.status_code``.
+            err = requests.HTTPError(f"{self.status_code} error")
+            err.response = self  # type: ignore[attr-defined]
+            raise err
+
+    def close(self) -> None:
+        self.closed = True
 
     def iter_content(self, block_size: int) -> Iterable[bytes]:
         for i in range(0, len(self._body), block_size):
@@ -196,3 +212,101 @@ def test_connection_refused_fails_fast_with_no_retry(tmp_path: Path) -> None:
 
     assert get.call_count == 1
     sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Content-Encoding + 416 + clean error boundary (issue #98)
+# ---------------------------------------------------------------------------
+
+
+def test_gzip_encoded_response_completes_without_false_incomplete(
+    tmp_path: Path,
+) -> None:
+    """A Content-Encoding: gzip response completes without a bogus retry.
+
+    Real-bug surface (issue #98): for a gzip-served file the Content-Length is
+    the COMPRESSED size, but requests writes DECODED bytes, so the byte-length
+    completeness check reported "incomplete" on every perfect download — then
+    the retry sent a Range past EOF and 416'd. The fix skips the length check
+    for content-encoded bodies, so a single clean stream completes.
+    """
+    destination = tmp_path / "fedora.gpg"
+    decoded = b"d" * 4700  # bytes requests actually writes (decoded)
+    # Advertise the COMPRESSED length (smaller) — the trap.
+    resp = _FakeResponse(body=decoded, content_encoding="gzip", content_length=4494)
+
+    with patch("tkc_lvlab.utils.images.requests.get", return_value=resp) as get:
+        with patch("tkc_lvlab.utils.images.time.sleep") as sleep:
+            result = CloudImage._download_file(
+                "https://fedoraproject.example/fedora.gpg", str(destination)
+            )
+
+    assert result is True
+    assert destination.read_bytes() == decoded
+    assert get.call_count == 1  # no bogus "incomplete" retry
+    sleep.assert_not_called()
+    assert not (tmp_path / "fedora.gpg.partial").exists()
+
+
+def test_http_416_on_resume_discards_stale_partial_and_restarts(
+    tmp_path: Path,
+) -> None:
+    """A stale .partial that 416s on resume is discarded; the retry restarts fresh.
+
+    Real-bug surface (issue #98): a leftover/over-long ``.partial`` made the
+    resume send ``Range: bytes=<n>-`` past the resource end; the server's 416
+    was treated as a fatal HTTPError and exploded a traceback. The fix discards
+    the partial on 416 and restarts without a Range.
+    """
+    destination = tmp_path / "image.qcow2"
+    partial = tmp_path / "image.qcow2.partial"
+    partial.write_bytes(b"stale" * 1000)  # 5000 bytes — past the resource end
+    payload = b"y" * 3000
+
+    calls = {"n": 0}
+
+    def fake_get(url, *, stream, timeout, headers):  # noqa: ARG001
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # A partial exists -> we resume with a Range -> server says 416.
+            assert headers.get("Range") == "bytes=5000-"
+            return _FakeResponse(status_code=416)
+        # Retry: the stale partial was discarded, so no Range, full 200.
+        assert "Range" not in headers
+        return _FakeResponse(body=payload)
+
+    with patch("tkc_lvlab.utils.images.requests.get", side_effect=fake_get):
+        with patch("tkc_lvlab.utils.images.time.sleep"):
+            result = CloudImage._download_file(
+                "https://mirror.example/image.qcow2", str(destination)
+            )
+
+    assert result is True
+    assert destination.read_bytes() == payload
+    assert calls["n"] == 2
+    assert not partial.exists()
+
+
+def test_download_or_raise_wraps_http_error_with_workaround(tmp_path: Path) -> None:
+    """A fatal HTTP error surfaces as a clean ImageError naming the workaround.
+
+    Real-bug surface (issue #98): a hard download failure propagated a raw
+    ``requests`` traceback to the CLI. ``_download_or_raise`` (used by every
+    public ``download_*`` method) must translate it into an actionable
+    ImageError that names the URL, the reason, and the manual cache path.
+    """
+    destination = tmp_path / "image.qcow2"
+    not_found = _FakeResponse(status_code=404, http_error=True)
+
+    with patch("tkc_lvlab.utils.images.requests.get", return_value=not_found):
+        with patch("tkc_lvlab.utils.images.time.sleep"):
+            with pytest.raises(ImageError) as excinfo:
+                CloudImage._download_or_raise(
+                    "https://mirror.example/missing.qcow2", str(destination)
+                )
+
+    message = str(excinfo.value)
+    assert "Could not download https://mirror.example/missing.qcow2" in message
+    assert "HTTP 404" in message
+    assert str(destination) in message
+    assert "place the file manually" in message


### PR DESCRIPTION
Closes #98.

During 0.4.0 validation, `createvm --init-cloud-images` died with a **raw traceback** fetching Fedora's gzip-served GPG key. Two compounding download bugs + a missing error boundary.

## Correctness (`utils/images._stream_to_partial`)
- **gzip completeness false-negative.** For a `Content-Encoding: gzip` response, `Content-Length` is the *compressed* size but requests writes *decoded* bytes — so the byte-length completeness check reported "incomplete" on every perfect download. Encoded responses now **skip the byte-length check** (a clean end-of-stream is the only valid signal) and are **never byte-resumed** (Range describes encoded bytes).
- **HTTP 416 on resume is no longer fatal.** A stale/over-long `.partial` made resume send a `Range` past EOF; the server's 416 was a fatal `HTTPError`. Now treated as "stale partial" → discard it → restart fresh (no Range).

## Clean error boundary (the primary ask)
- New `ImageError(LvlabError)`. The public `download_image` / `download_checksum` / `download_checksum_gpg` route through `_download_or_raise`, which translates a `requests` transport/HTTP failure into an `ImageError` naming **the URL, the reason, and the manual-placement workaround** (drop the file at the named cache path and re-run). `lvlab init` and `createvm`'s image path catch it and exit cleanly — **no traceback**.
- `_download_file`'s low-level raise contract (404 / connection-refused → `requests` exceptions, fail-fast, no retry) is **unchanged** — existing #87 tests still pass.

## Tests
- gzip response completes without a bogus retry (single GET, body written, no `.partial`).
- 416-on-resume discards the stale partial and restarts fresh → completes.
- `_download_or_raise` wraps a hard 404 into an actionable `ImageError` (names URL, `HTTP 404`, the cache path, "place the file manually").

Walkthrough `init` section documents the resilience + manual fallback. Full suite **507 passed, 39 skipped** (+3). `pre-commit` + `zensical build -s` clean.

> Note: the progress-callback refactor (decoupling download progress from the tqdm display) is **not** here — it lands with its consumer in #104 (init live table), keeping that the single place tqdm is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)