### PR TITLE
feat(up): one-time console password + SSH hint, shared with createvm (#106)

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -134,6 +134,16 @@ The `--os-variant` virt-install needs is derived from the image
 name's first hyphenated segment (see "Image Naming" above), which
 is why custom images must follow that naming convention.
 
+On first create, `up` also generates a **one-time console password**
+(the same way `createvm` does), injects only its hash into cloud-init,
+and prints the plaintext **once** along with an example SSH command —
+a console fallback for before SSH is reachable. SSH keys remain the
+primary access path. To use your own password set `cloud_init.passwd`
+(a crypt hash) in the manifest; to opt out entirely (key-only VM) set
+`cloud_init.password: false`. The password only takes effect at
+first-boot cloud-init, so re-running `up` on an existing VM doesn't
+change it.
+
 ## status
 
 Show the configured environment, every machine in the manifest along

--- a/src/tkc_lvlab/cli.py
+++ b/src/tkc_lvlab/cli.py
@@ -38,7 +38,13 @@ from rich.table import Table
 
 from ._logging import configure_logging, get_logger
 from .utils.catalog import resolve_catalog
-from .utils.output import get_console, styled_table
+from .utils.output import (
+    get_console,
+    render_one_time_password,
+    render_ssh_hint,
+    styled_table,
+)
+from .utils.passwords import generate_one_time_password
 from .config import (
     ConfigManager,
     parse_config,
@@ -46,7 +52,7 @@ from .config import (
     generate_hosts_entries,
     parse_hosts_file,
 )
-from .exceptions import ConfigError, LvlabError
+from .exceptions import ConfigError, LvlabError, PasswordHashError
 from .smoke import OutputFormat, SmokeError, run_smoke
 from .utils.cloud_init import CloudInitIso
 from .utils.libvirt import (
@@ -1126,13 +1132,87 @@ def _up_start_existing(
         typer.echo(f"The virtual machine {machine.vm_name} is running already")
 
 
+def _resolve_up_password(
+    machine: Machine, config_defaults: dict
+) -> tuple[str | None, str | None]:
+    """Decide the one-time console password for a first-boot ``up`` (issue #106).
+
+    Returns ``(plaintext, hash)``. ``(None, None)`` when the manifest
+    already configures a password (``cloud_init.passwd``) or explicitly
+    opts out (``cloud_init.password: false`` / ``generate_password: false``)
+    — nothing to generate, inject, or print. Otherwise a freshly generated
+    phrase and its SHA-512-crypt hash. If ``openssl`` is unavailable the
+    password is skipped (logged) rather than failing the deploy — the SSH
+    key is the primary access path; the console password is a convenience.
+
+    Args:
+        machine: The resolved :class:`Machine`.
+        config_defaults: The manifest's ``config_defaults`` block.
+
+    Returns:
+        ``(plaintext, hash)`` to generate+print, or ``(None, None)``.
+    """
+    ci_machine = machine.cloud_init_config or {}
+    ci_defaults = config_defaults.get("cloud_init", {}) or {}
+
+    if ci_machine.get("passwd") or ci_defaults.get("passwd"):
+        return None, None
+
+    def _opted_out(ci: dict) -> bool:
+        return ci.get("password") is False or ci.get("generate_password") is False
+
+    if _opted_out(ci_machine) or _opted_out(ci_defaults):
+        return None, None
+
+    try:
+        return generate_one_time_password()
+    except PasswordHashError as exc:
+        logger.warning("Skipping one-time console password: %s", exc)
+        return None, None
+
+
+def _machine_login_user(machine: Machine, config_defaults: dict) -> str:
+    """Return the effective first-boot login user for the SSH hint.
+
+    Mirrors :meth:`Machine.cloud_init`'s resolution: an explicit
+    ``cloud_init.user`` (machine, then defaults) wins, else the image's
+    conventional account (already set on the machine's resolved ``os``
+    via the catalog) — falling back to ``root``.
+    """
+    ci_machine = machine.cloud_init_config or {}
+    ci_defaults = config_defaults.get("cloud_init", {}) or {}
+    return ci_machine.get("user") or ci_defaults.get("user") or "root"
+
+
+def _machine_static_ip(machine: Machine) -> str | None:
+    """Return the first interface's static IPv4 (CIDR stripped), or ``None``.
+
+    ``None`` means the machine uses DHCP, so the SSH hint can't name an
+    address up front.
+    """
+    interfaces = machine.interfaces or []
+    if isinstance(interfaces, dict):
+        interfaces = [interfaces]
+    for iface in interfaces:
+        ip4 = iface.get("ip4") if isinstance(iface, dict) else None
+        if ip4:
+            return str(ip4).split("/", maxsplit=1)[0]
+    return None
+
+
 def _up_build_cloud_init_iso(
-    machine: Machine, cloud_image: CloudImage, config_defaults: dict, machines: list
+    machine: Machine,
+    cloud_image: CloudImage,
+    config_defaults: dict,
+    machines: list,
+    password_hash: str | None = None,
 ) -> None:
     """Render cloud-init files, pack them into cidata.iso, exit on failure."""
     try:
         metadata_config_fpath, userdata_config_fpath, network_config_fpath = (
-            machine.cloud_init(cloud_image, config_defaults, machines)
+            machine.cloud_init(
+                cloud_image, config_defaults, machines, password_hash=password_hash
+            )
         )
     except LvlabError as exc:
         logger.error("%s", exc)
@@ -1164,10 +1244,17 @@ def _up_first_time_create(
     image_config = _resolve_image_config(images, machine.os, machine.vm_name)
     cloud_image = CloudImage(machine.os, image_config, environment, config_defaults)
 
-    machine.create_vdisks(environment, config_defaults, cloud_image)
-    _up_build_cloud_init_iso(machine, cloud_image, config_defaults, machines)
+    # Generate a one-time console password (issue #106) unless the manifest
+    # configures or opts out of one. The hash goes into cloud-init; the
+    # plaintext is printed once below.
+    password_plain, password_hash = _resolve_up_password(machine, config_defaults)
 
-    typer.echo(f"Attempting to start virtual maching: {machine.vm_name}")
+    machine.create_vdisks(environment, config_defaults, cloud_image)
+    _up_build_cloud_init_iso(
+        machine, cloud_image, config_defaults, machines, password_hash=password_hash
+    )
+
+    typer.echo(f"Attempting to start virtual machine: {machine.vm_name}")
     if machine.deploy(
         machine.config_fpath,
         config_defaults,
@@ -1175,6 +1262,15 @@ def _up_first_time_create(
         os_variant=cloud_image.os_variant,
     ):
         typer.echo("Virtual machine deployment complete.")
+        typer.echo()
+        # Surface the one-time password (shown once) + an SSH hint, aligned
+        # with createvm's output (issue #106). The plaintext is never logged.
+        if password_plain:
+            render_one_time_password(password_plain)
+        render_ssh_hint(
+            _machine_login_user(machine, config_defaults),
+            _machine_static_ip(machine),
+        )
     else:
         logger.error("Virtual machine installation failed.")
         raise typer.Exit(code=1)

--- a/src/tkc_lvlab/scripts/createvm.py
+++ b/src/tkc_lvlab/scripts/createvm.py
@@ -66,6 +66,7 @@ from ..utils.network import (
     validate_static_ip,
 )
 from ..utils.osinfo import OsInfoLookupError, resolve_os_variant
+from ..utils.output import render_one_time_password, render_ssh_hint
 from ..utils.passwords import (
     PasswordHashError,
     generate_password_phrase,
@@ -954,18 +955,13 @@ def _print_completion_details(
 
     typer.secho("VM creation completed.", fg=typer.colors.GREEN)
     typer.echo()
-    typer.secho(
-        "One-time VM password (shown once and not retrievable later):",
-        fg=typer.colors.YELLOW,
-    )
-    typer.secho(ctx.password_plain, fg=typer.colors.YELLOW)
-    typer.echo()
+    # Shared one-time-password + SSH-hint output (issue #106): lvlab up uses
+    # the same helpers so both read consistently.
+    render_one_time_password(ctx.password_plain)
 
     if ctx.vm_ip is not None:
         static_ip = ctx.vm_ip.split("/", maxsplit=1)[0]
-        typer.secho("Example SSH command:", fg=typer.colors.BLUE)
-        typer.secho(f"  $ ssh {username}@{static_ip}", fg=typer.colors.GREEN)
-        typer.echo()
+        render_ssh_hint(username, static_ip)
         return
 
     if ctx.forward_mode.lower() != "nat":
@@ -1000,10 +996,7 @@ def _print_completion_details(
             f"DHCP lease detected for {vm_hostname}: {lease_ip}", fg=typer.colors.GREEN
         )
         typer.echo()
-        ssh_ip = lease_ip.split("/", maxsplit=1)[0]
-        typer.secho("Example SSH command:", fg=typer.colors.BLUE)
-        typer.secho(f"  $ ssh {username}@{ssh_ip}", fg=typer.colors.GREEN)
-        typer.echo()
+        render_ssh_hint(username, lease_ip.split("/", maxsplit=1)[0])
         return
 
     typer.secho(

--- a/src/tkc_lvlab/templates/user-data.j2
+++ b/src/tkc_lvlab/templates/user-data.j2
@@ -10,6 +10,10 @@ users:
       - {{ config.cloud_init.pubkey }}
     sudo: {{ config.cloud_init.sudo }}
     shell: {{ config.cloud_init.shell }}
+{%- if config.cloud_init.passwd %}
+    lock_passwd: false
+    passwd: {{ config.cloud_init.passwd }}
+{%- endif %}
 {%- if config.cloud_init.runcmd is defined and config.cloud_init.runcmd | length > 0 %}
 runcmd:
   {%- for command in config.cloud_init.runcmd %}

--- a/src/tkc_lvlab/utils/libvirt.py
+++ b/src/tkc_lvlab/utils/libvirt.py
@@ -456,6 +456,7 @@ class _CloudInitComposer:
         cloud_image: "CloudImage",
         config_defaults: dict[str, Any],
         machines: list[dict[str, Any]] | None = None,
+        password_hash: str | None = None,
     ) -> tuple[str, str, str]:
         """Render the three cloud-init documents to disk.
 
@@ -470,6 +471,11 @@ class _CloudInitComposer:
             machines: The manifest's ``machines`` list for the ``/etc/hosts``
                 render. ``None`` triggers a one-time :func:`parse_config`
                 fallback.
+            password_hash: A generated SHA-512-crypt console password hash
+                to inject as ``users[*].passwd`` (issue #106). Only applied
+                when the merged ``cloud_init`` has no explicit ``passwd`` —
+                a manifest-configured password always wins. ``None`` injects
+                nothing (key-only VM).
 
         Returns:
             ``(meta_data_path, user_data_path, network_config_path)``.
@@ -503,6 +509,12 @@ class _CloudInitComposer:
         # using the same derivation createvm applies. An explicit
         # cloud_init.user still wins.
         cloud_init_config.setdefault("user", cloud_image.default_username)
+        # Inject a generated one-time console password hash (issue #106) only
+        # when the manifest didn't configure one — an explicit cloud_init.passwd
+        # always wins, and password_hash=None (opt-out / key-only) injects
+        # nothing.
+        if password_hash is not None:
+            cloud_init_config.setdefault("passwd", password_hash)
 
         # The CLI passes the already-parsed machines list so the manifest is
         # read once per command path. The None fallback re-parses only for
@@ -808,6 +820,7 @@ class Machine:
         cloud_image: "CloudImage",
         config_defaults: dict[str, Any],
         machines: list[dict[str, Any]] | None = None,
+        password_hash: str | None = None,
     ) -> tuple[str, str, str]:
         """Render this machine's three cloud-init documents to disk.
 
@@ -834,6 +847,10 @@ class Machine:
                 the manifest is not re-read here. When ``None`` (a
                 convenience fallback for callers without the list handy), the
                 manifest is parsed once via :func:`parse_config`.
+            password_hash: Optional SHA-512-crypt console password hash to
+                inject as ``users[*].passwd`` (issue #106). Applied only when
+                the manifest has no explicit ``cloud_init.passwd``; ``None``
+                injects nothing.
 
         Returns:
             ``(meta_data_path, user_data_path, network_config_path)`` —
@@ -851,7 +868,9 @@ class Machine:
                 structurally invalid). The CLI boundary converts it to a
                 ``typer.Exit``.
         """
-        return self._composer().render(cloud_image, config_defaults, machines)
+        return self._composer().render(
+            cloud_image, config_defaults, machines, password_hash=password_hash
+        )
 
     def _composer(self) -> _CloudInitComposer:
         """Return this machine's cloud-init composer, building one if absent.

--- a/src/tkc_lvlab/utils/output.py
+++ b/src/tkc_lvlab/utils/output.py
@@ -94,3 +94,54 @@ def styled_table(title: str | None = None, *, box: Box = SQUARE) -> Table:
         header_style="bold cyan",
         title_justify="left",
     )
+
+
+def render_one_time_password(
+    password_plain: str, *, console: Console | None = None
+) -> None:
+    """Print a one-time console password block (shown once, not retrievable).
+
+    Shared by ``createvm`` and ``lvlab up`` so both surface a generated
+    console password identically (issue #106). The plaintext is written to
+    stdout exactly once and never logged.
+
+    Args:
+        password_plain: The plaintext password phrase to display.
+        console: Console to print to; defaults to the shared console.
+    """
+    console = console or get_console()
+    console.print(
+        "One-time VM password (shown once and not retrievable later):",
+        style="yellow",
+    )
+    console.print(password_plain, style="bold yellow")
+    console.print()
+
+
+def render_ssh_hint(
+    username: str, ip: str | None, *, console: Console | None = None
+) -> None:
+    """Print an example SSH command, or a hint for finding the address.
+
+    Shared by ``createvm`` and ``lvlab up`` (issue #106). When ``ip`` is
+    known (a static address or a resolved DHCP lease) it prints a ready
+    ``ssh user@ip`` line; otherwise it points the operator at how to find
+    the address.
+
+    Args:
+        username: The first-boot account to SSH in as.
+        ip: The resolved IPv4 address, or ``None`` when unknown.
+        console: Console to print to; defaults to the shared console.
+    """
+    console = console or get_console()
+    if ip:
+        console.print("Example SSH command:", style="blue")
+        console.print(f"  $ ssh {username}@{ip}", style="green")
+    else:
+        console.print(
+            "Once it finishes booting, find its address (e.g. "
+            "`lvlab global show instances`), then:",
+            style="blue",
+        )
+        console.print(f"  $ ssh {username}@<ip>", style="green")
+    console.print()

--- a/src/tkc_lvlab/utils/passwords.py
+++ b/src/tkc_lvlab/utils/passwords.py
@@ -192,6 +192,30 @@ def hash_password_sha512(password: str, rounds: int = 4096) -> str:
     return result.stdout.strip()
 
 
+def generate_one_time_password(rounds: int = 4096) -> tuple[str, str]:
+    """Generate a one-time console password as ``(plaintext, crypt_hash)``.
+
+    Pairs :func:`generate_password_phrase` with :func:`hash_password_sha512`
+    so both deploy paths — the standalone ``createvm`` script and
+    ``lvlab up`` — mint the console password identically (issue #106). The
+    plaintext is meant to be printed once and never persisted; only the
+    hash is written into cloud-init's ``users[*].passwd``.
+
+    Args:
+        rounds: SHA-512-crypt rounds, forwarded to
+            :func:`hash_password_sha512`.
+
+    Returns:
+        A ``(plaintext, crypt_hash)`` pair.
+
+    Raises:
+        PasswordHashError: ``openssl`` is missing or ``openssl passwd``
+            failed.
+    """
+    plaintext = generate_password_phrase()
+    return plaintext, hash_password_sha512(plaintext, rounds=rounds)
+
+
 def _generate_sha512_crypt_salt(length: int = 16) -> str:
     """Return a random crypt-compatible salt of the given length.
 

--- a/tests/test_cli_up.py
+++ b/tests/test_cli_up.py
@@ -39,6 +39,12 @@ def _make_fake_machine(deploy_returns: bool, tmp_path) -> mock.Mock:
     m.libvirt_vm_name = "alpha_demo"
     m.config_fpath = str(tmp_path)
     m.os = "debian13"
+    # Realistic empties so the #106 one-time-password / SSH-hint reads behave:
+    # opt out of the generated console password (that path has its own tests
+    # below) so these orchestration tests stay deterministic and never shell
+    # out to openssl; no interfaces -> DHCP -> generic SSH hint.
+    m.cloud_init_config = {"password": False}
+    m.interfaces = []
     m.exists_in_libvirt.return_value = (False, None, None)
     m.cloud_init.return_value = ("metadata", "userdata", "network")
     m.deploy.return_value = deploy_returns
@@ -265,3 +271,82 @@ def test_up_create_parses_manifest_once_and_passes_machines(tmp_path) -> None:
     # cloud_init received the parsed machines list as its 3rd positional arg.
     _, _, machines_arg = fake_machine.cloud_init.call_args.args
     assert machines_arg == SAMPLE_MACHINES
+
+
+# ---------------------------------------------------------------------------
+# One-time console password + SSH hint (issue #106)
+# ---------------------------------------------------------------------------
+
+
+def test_up_generates_injects_and_prints_password_once(tmp_path) -> None:
+    """First-time up with no configured password: generate, inject the hash,
+    print the plaintext exactly once."""
+    runner = CliRunner()
+    fake_machine = _make_fake_machine(deploy_returns=True, tmp_path=tmp_path)
+    fake_machine.cloud_init_config = {}  # no configured password -> generate
+    fake_iso = _make_fake_iso(tmp_path)
+    phrase = "Cedar-Spruce-Atlas-Pine"
+    hashed = "$6$rounds=4096$salt$hash"
+
+    with (
+        _patched_config(),
+        mock.patch.object(cli, "Machine", return_value=fake_machine),
+        mock.patch.object(cli, "CloudImage"),
+        mock.patch.object(cli, "CloudInitIso", return_value=fake_iso),
+        mock.patch.object(
+            cli, "generate_one_time_password", return_value=(phrase, hashed)
+        ),
+    ):
+        result = runner.invoke(app, ["up", "alpha"])
+
+    assert result.exit_code == 0, result.output
+    # The generated hash is injected into cloud-init.
+    assert fake_machine.cloud_init.call_args.kwargs["password_hash"] == hashed
+    # The plaintext is shown exactly once.
+    assert result.output.count(phrase) == 1
+
+
+def test_up_respects_manifest_configured_password(tmp_path) -> None:
+    """A manifest-configured cloud_init.passwd is respected: no generation,
+    and no generated hash is injected."""
+    runner = CliRunner()
+    fake_machine = _make_fake_machine(deploy_returns=True, tmp_path=tmp_path)
+    fake_machine.cloud_init_config = {"passwd": "$6$manifest$preset"}
+    fake_iso = _make_fake_iso(tmp_path)
+
+    with (
+        _patched_config(),
+        mock.patch.object(cli, "Machine", return_value=fake_machine),
+        mock.patch.object(cli, "CloudImage"),
+        mock.patch.object(cli, "CloudInitIso", return_value=fake_iso),
+        mock.patch.object(cli, "generate_one_time_password") as gen,
+    ):
+        result = runner.invoke(app, ["up", "alpha"])
+
+    assert result.exit_code == 0, result.output
+    gen.assert_not_called()
+    # The manifest passwd is rendered by Machine.cloud_init itself; up injects
+    # no generated hash.
+    assert fake_machine.cloud_init.call_args.kwargs["password_hash"] is None
+
+
+def test_up_password_opt_out_generates_nothing(tmp_path) -> None:
+    """cloud_init.password: false opts out — no generation, no injected hash."""
+    runner = CliRunner()
+    fake_machine = _make_fake_machine(deploy_returns=True, tmp_path=tmp_path)
+    fake_machine.cloud_init_config = {"password": False}
+    fake_iso = _make_fake_iso(tmp_path)
+
+    with (
+        _patched_config(),
+        mock.patch.object(cli, "Machine", return_value=fake_machine),
+        mock.patch.object(cli, "CloudImage"),
+        mock.patch.object(cli, "CloudInitIso", return_value=fake_iso),
+        mock.patch.object(cli, "generate_one_time_password") as gen,
+    ):
+        result = runner.invoke(app, ["up", "alpha"])
+
+    assert result.exit_code == 0, result.output
+    gen.assert_not_called()
+    assert fake_machine.cloud_init.call_args.kwargs["password_hash"] is None
+    assert "One-time VM password" not in result.output

--- a/tests/test_cloud_init_user_data.py
+++ b/tests/test_cloud_init_user_data.py
@@ -1,0 +1,41 @@
+"""Render-level tests for ``user-data.j2`` via :class:`UserData`.
+
+Focused on the issue #106 template change: a one-time console password
+hash (``cloud_init.passwd``) renders as ``users[*].passwd`` with
+``lock_passwd: false``, and is absent when no password is configured (so
+key-only VMs don't grow a spurious password field).
+"""
+
+from __future__ import annotations
+
+from tkc_lvlab.utils.cloud_init import UserData
+
+
+# A slash-free literal key so UserData.__post_init__ treats it as a literal
+# (a real base64 key can contain ``/`` and would be mistaken for a path).
+_LITERAL_PUBKEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5testkeymaterial user@host"
+
+
+def _user_data(**cloud_init_extra: object) -> str:
+    cloud_init = {
+        "user": "debian",
+        "pubkey": _LITERAL_PUBKEY,
+        "sudo": "ALL=(ALL) NOPASSWD:ALL",
+        "shell": "/bin/bash",
+        **cloud_init_extra,
+    }
+    return UserData(cloud_init, "web01", "test.local", "web01.test.local").render_config()
+
+
+def test_user_data_renders_passwd_and_unlocks_when_present() -> None:
+    """A configured passwd hash renders with lock_passwd: false."""
+    rendered = _user_data(passwd="$6$rounds=4096$salt$hash")
+    assert "passwd: $6$rounds=4096$salt$hash" in rendered
+    assert "lock_passwd: false" in rendered
+
+
+def test_user_data_omits_passwd_when_absent() -> None:
+    """No passwd configured -> no passwd / lock_passwd lines (key-only VM)."""
+    rendered = _user_data()
+    assert "passwd:" not in rendered
+    assert "lock_passwd" not in rendered

--- a/tests/test_cloud_init_user_data.py
+++ b/tests/test_cloud_init_user_data.py
@@ -24,7 +24,9 @@ def _user_data(**cloud_init_extra: object) -> str:
         "shell": "/bin/bash",
         **cloud_init_extra,
     }
-    return UserData(cloud_init, "web01", "test.local", "web01.test.local").render_config()
+    return UserData(
+        cloud_init, "web01", "test.local", "web01.test.local"
+    ).render_config()
 
 
 def test_user_data_renders_passwd_and_unlocks_when_present() -> None:

--- a/tests/test_libvirt_cloud_init.py
+++ b/tests/test_libvirt_cloud_init.py
@@ -60,12 +60,14 @@ def _patch_collaborators():
     return network_obj, metadata_obj, userdata_obj, cloud_image
 
 
-def _run_cloud_init(machine, config_defaults, userdata_capture: list):
+def _run_cloud_init(machine, config_defaults, userdata_capture: list, **kwargs):
     """Invoke ``machine.cloud_init`` with all rendering + IO collaborators stubbed.
 
     ``userdata_capture`` is a list the test passes in; the patched
     ``UserData`` mock appends the cloud_init_config kwarg it was
-    constructed with so the test can assert on the merged config.
+    constructed with so the test can assert on the merged config. Extra
+    ``kwargs`` (e.g. ``password_hash``) are forwarded to
+    :meth:`Machine.cloud_init`.
     """
     network_obj, metadata_obj, userdata_obj, cloud_image = _patch_collaborators()
 
@@ -88,7 +90,7 @@ def _run_cloud_init(machine, config_defaults, userdata_capture: list):
             ),
         ),
     ):
-        return machine.cloud_init(cloud_image, config_defaults)
+        return machine.cloud_init(cloud_image, config_defaults, **kwargs)
 
 
 def test_cloud_init_writes_three_files_to_config_fpath(tmp_path: Path) -> None:
@@ -296,3 +298,39 @@ def test_cloud_init_falls_back_to_parse_config_when_machines_none(
         machine.cloud_init(cloud_image, {"cloud_init": {}})
 
     parse_config_mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# One-time console password injection (issue #106)
+# ---------------------------------------------------------------------------
+
+
+def test_cloud_init_injects_generated_password_hash(tmp_path: Path) -> None:
+    """A password_hash with no manifest passwd lands in the merged config."""
+    machine = _make_machine(tmp_path)
+    machine.cloud_init_config = {}
+    captured: list = []
+    _run_cloud_init(
+        machine, {"cloud_init": {}}, captured, password_hash="$6$rounds=4096$abc$xyz"
+    )
+    assert captured[0].get("passwd") == "$6$rounds=4096$abc$xyz"
+
+
+def test_cloud_init_manifest_passwd_wins_over_generated(tmp_path: Path) -> None:
+    """An explicit manifest passwd is never overwritten by a generated one."""
+    machine = _make_machine(tmp_path)
+    machine.cloud_init_config = {"passwd": "$6$manifest$set"}
+    captured: list = []
+    _run_cloud_init(
+        machine, {"cloud_init": {}}, captured, password_hash="$6$generated$ignored"
+    )
+    assert captured[0].get("passwd") == "$6$manifest$set"
+
+
+def test_cloud_init_no_password_hash_injects_nothing(tmp_path: Path) -> None:
+    """password_hash=None (opt-out / key-only) leaves passwd unset."""
+    machine = _make_machine(tmp_path)
+    machine.cloud_init_config = {}
+    captured: list = []
+    _run_cloud_init(machine, {"cloud_init": {}}, captured, password_hash=None)
+    assert "passwd" not in captured[0]


### PR DESCRIPTION
Closes #106.

`createvm` minted a one-time console password and surfaced it; `lvlab up` did neither. Same lab, two behaviors. Consolidated.

## `lvlab up` (first create) now:
1. **Generates a one-time console password** when the manifest configures none, injects only the SHA-512-crypt **hash** into cloud-init `users[*].passwd` (with `lock_passwd: false`), and **prints the plaintext once** plus an example SSH command. SSH keys stay the primary access path; the password is a console fallback.
2. **Respects an explicit `cloud_init.passwd`** (manifest wins — no generation). **Opt out** (key-only VM) with `cloud_init.password: false` (or `generate_password: false`).
3. If `openssl` is unavailable the password is **skipped (logged), not fatal** — `up` still deploys.

## Consolidation (the "share with createvm" ask)
- `generate_one_time_password` (utils/passwords) and `render_one_time_password` / `render_ssh_hint` (utils/output, the #103 shared-style module). **createvm's completion output now calls the same renderers.**
- `user-data.j2` gains a conditional `passwd` / `lock_passwd` block (mirrors the one-off template).
- `Machine.cloud_init(..., password_hash=)` threads the hash to the composer (injects only when no manifest passwd).
- Fixed the `lvlab up` log typo **"maching" → "machine"**.

## Idempotency / scope notes
- The password only takes effect at first-boot cloud-init, so re-`up` of an existing VM doesn't change it (documented in the walkthrough).
- The SSH hint uses the static manifest IP when present; for DHCP it prints a generic "find the address, then ssh user@<ip>" hint rather than blocking on a lease wait. A lease-wait-for-hint (matching createvm's NAT wait) is a natural follow-up.

## Tests
Composer injects / respects-manifest / omits the hash; `user-data.j2` renders **and omits** the passwd block; `up` generates+injects+prints-once, respects a configured password, opt-out generates nothing. Full suite **515 passed, 39 skipped** (+8). `pre-commit` + `zensical build -s` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)