### PR TITLE
feat(init): lvlab init initializes built-in defaults with no manifest; deprecate createvm --init-cloud-images (#97)

### DIFF
--- a/docs/one-off-vms.md
+++ b/docs/one-off-vms.md
@@ -49,6 +49,8 @@ sudo createvm testvm.local debian12
 sudo createvm testvm.local debian13 --ip4 192.168.122.50
 
 # Pre-download every catalog image (built-ins + any cwd Lvlab.yml).
+# DEPRECATED: prefer `lvlab init`, which initializes the built-in
+# defaults when there's no Lvlab.yml. This flag still works for now.
 sudo createvm --init-cloud-images
 ```
 
@@ -58,20 +60,20 @@ and must be given together.
 
 ### Flags
 
-| Flag                     | Purpose                                                                                                                                                                                                                                                        |
-| ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `VM_NAME` (positional)   | FQDN / domain name for the VM. Required together with `VM_DISTRO`.                                                                                                                                                                                             |
-| `VM_DISTRO` (positional) | Image key, matched case-insensitively against the built-in catalog (`debian11`, `debian12`, `debian13`, `almalinux9`, `almalinux10`, `ubuntu2204`, `ubuntu2404`, `fedora44`) merged with any `images:` in a cwd `Lvlab.yml`. Required together with `VM_NAME`. |
-| `--ip4`                  | Optional static IPv4. Accepts `IP` (uses `--network`) or `NETWORK,IP`. Validated against the network's subnet AND DHCP range, then rendered into the guest's cloud-init network-config. For DHCP, pass `dhcp` (or `default` / `auto`) or omit the flag.        |
-| `--netmask`              | CIDR prefix appended to `--ip4` when it lacks one. Default `24`.                                                                                                                                                                                               |
-| `--disk-size`            | qcow2 disk size. Default `35G`.                                                                                                                                                                                                                                |
-| `--cpu`                  | vCPU count. Default `2`.                                                                                                                                                                                                                                       |
-| `--memory`               | RAM, optional unit suffix (`2048`, `2G`, `512M`). Default `2048` (MiB).                                                                                                                                                                                        |
-| `--network`              | libvirt network name. Default `default` (the stock NAT).                                                                                                                                                                                                       |
-| `--public-key`           | Optional extra SSH public key file (appended after discovered defaults).                                                                                                                                                                                       |
-| `--init-cloud-images`    | Download every catalog image that isn't cached. With no positional args, exits after; with them, pre-fetches then creates.                                                                                                                                     |
-| `--config`               | Path to a specific `Lvlab.yml` whose `images:` are merged into the catalog, instead of the cwd lookup.                                                                                                                                                         |
-| `--version` / `-V`       | Print the installed `tkc-lvlab` version and exit.                                                                                                                                                                                                              |
+| Flag                     | Purpose                                                                                                                                                                                                                                                               |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `VM_NAME` (positional)   | FQDN / domain name for the VM. Required together with `VM_DISTRO`.                                                                                                                                                                                                    |
+| `VM_DISTRO` (positional) | Image key, matched case-insensitively against the built-in catalog (`debian11`, `debian12`, `debian13`, `almalinux9`, `almalinux10`, `ubuntu2204`, `ubuntu2404`, `fedora44`) merged with any `images:` in a cwd `Lvlab.yml`. Required together with `VM_NAME`.        |
+| `--ip4`                  | Optional static IPv4. Accepts `IP` (uses `--network`) or `NETWORK,IP`. Validated against the network's subnet AND DHCP range, then rendered into the guest's cloud-init network-config. For DHCP, pass `dhcp` (or `default` / `auto`) or omit the flag.               |
+| `--netmask`              | CIDR prefix appended to `--ip4` when it lacks one. Default `24`.                                                                                                                                                                                                      |
+| `--disk-size`            | qcow2 disk size. Default `35G`.                                                                                                                                                                                                                                       |
+| `--cpu`                  | vCPU count. Default `2`.                                                                                                                                                                                                                                              |
+| `--memory`               | RAM, optional unit suffix (`2048`, `2G`, `512M`). Default `2048` (MiB).                                                                                                                                                                                               |
+| `--network`              | libvirt network name. Default `default` (the stock NAT).                                                                                                                                                                                                              |
+| `--public-key`           | Optional extra SSH public key file (appended after discovered defaults).                                                                                                                                                                                              |
+| `--init-cloud-images`    | **Deprecated** — prefer `lvlab init` (the single image-init path; it initializes the built-in defaults with no `Lvlab.yml`). Still works: downloads every catalog image that isn't cached. With no positional args, exits after; with them, pre-fetches then creates. |
+| `--config`               | Path to a specific `Lvlab.yml` whose `images:` are merged into the catalog, instead of the cwd lookup.                                                                                                                                                                |
+| `--version` / `-V`       | Print the installed `tkc-lvlab` version and exit.                                                                                                                                                                                                                     |
 
 `createvm` attaches the guest to a managed libvirt network
 (`--network network=<name>,model=virtio`), defaulting to the stock NAT

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -41,13 +41,20 @@ lvlab -vv up salt.local
 
 ## init
 
-Initialize the environment defined in `Lvlab.yml`.
+Initialize cloud images. With an `Lvlab.yml` in the current directory,
+`init` downloads the images its `images:` section names. **With no
+manifest, `lvlab init` initializes the built-in default catalog** — so a
+bare `lvlab init` works without writing a manifest first. This is the
+single image-init path; `createvm --init-cloud-images` is deprecated in
+favour of it.
 
 ```bash
+# Manifest images (cwd Lvlab.yml), or the built-in defaults if there's no manifest
 lvlab init
 ```
 
-For each image referenced under the manifest's `images` block, `init`:
+For each image referenced under the manifest's `images` block (or each
+built-in default when there's no manifest), `init`:
 
 1. Creates `cloud_image_basedir/cloud-images` if missing.
 1. Downloads the image's `image_url`, `checksum_url`, and (when defined)

--- a/src/tkc_lvlab/cli.py
+++ b/src/tkc_lvlab/cli.py
@@ -37,7 +37,7 @@ from rich.console import Console
 from rich.table import Table
 
 from ._logging import configure_logging, get_logger
-from .utils.catalog import resolve_catalog
+from .utils.catalog import BUILTIN_IMAGES, resolve_catalog
 from .utils.output import (
     get_console,
     render_one_time_password,
@@ -704,14 +704,20 @@ def _init_process_image(image: CloudImage) -> None:
 
 @app.command()
 def init() -> None:
-    """Initialize the environment: download and verify cloud images."""
-    environment, images, config_defaults, _ = _load_config().as_tuple()
+    """Initialize cloud images: the manifest's, or the built-in defaults.
+
+    With an ``Lvlab.yml`` in the current directory, downloads and verifies
+    the images its ``images:`` section names. **With no manifest, it
+    initializes the built-in default catalog** (issue #97) — so a bare
+    ``lvlab init`` works without writing a manifest first, and is the single
+    image-init path (`createvm --init-cloud-images` is deprecated in favour
+    of it).
+    """
+    environment, images, config_defaults = _init_image_source()
 
     typer.echo()
     typer.echo(f'Initializing Libvirt Lab Environment: {environment["name"]}\n')
 
-    # TODO: Would this classify well into an environment object with
-    # a list of CloudImages?
     for image_name, image_config in images.items():
         image = CloudImage(image_name, image_config, environment, config_defaults)
         try:
@@ -724,6 +730,37 @@ def init() -> None:
             logger.error("%s", exc)
             raise typer.Exit(code=1)
         typer.echo()
+
+
+def _init_image_source() -> tuple[dict, dict, dict]:
+    """Resolve ``lvlab init``'s image source: manifest images, else built-ins.
+
+    Reads the cwd ``Lvlab.yml`` via :func:`parse_config`. When a manifest is
+    present its ``environment[0]`` / ``images`` / ``config_defaults`` are
+    used. When **no** manifest exists (``parse_config`` returns ``None``),
+    the built-in default catalog
+    (:data:`tkc_lvlab.utils.catalog.BUILTIN_IMAGES`) is initialized into the
+    shared cache under a synthetic ``default`` environment (issue #97). A
+    structurally invalid manifest still fails loudly.
+
+    Returns:
+        ``(environment, images, config_defaults)``.
+
+    Raises:
+        typer.Exit: Code 1 when a manifest exists but cannot be parsed.
+    """
+    try:
+        parsed = parse_config()
+    except (ConfigError, TypeError):
+        logger.error(CONFIG_PARSE_ERROR_MSG)
+        raise typer.Exit(code=1)
+
+    if parsed is None:
+        logger.info("No Lvlab.yml found; initializing the built-in default catalog.")
+        return {"name": "default"}, dict(BUILTIN_IMAGES), {}
+
+    environment, images, config_defaults, _ = parsed
+    return environment, images, config_defaults
 
 
 def _read_manifest_text(fpath: str = "Lvlab.yml") -> str:

--- a/src/tkc_lvlab/scripts/createvm.py
+++ b/src/tkc_lvlab/scripts/createvm.py
@@ -1055,7 +1055,10 @@ def createvm(  # pylint: disable=too-many-arguments,too-many-locals
     init_cloud_images: bool = typer.Option(
         False,
         "--init-cloud-images",
-        help="Download any missing cloud images before VM creation.",
+        help=(
+            "Download any missing cloud images before VM creation. "
+            "DEPRECATED: prefer 'lvlab init' (the single image-init path)."
+        ),
     ),
     config_path: Path | None = typer.Option(
         None,
@@ -1093,6 +1096,15 @@ def createvm(  # pylint: disable=too-many-arguments,too-many-locals
         _fail(str(exc))
 
     if init_cloud_images:
+        # Deprecated in favour of `lvlab init`, which is now the single
+        # image-init path and also initializes the built-in defaults when no
+        # Lvlab.yml is present (issue #97). Kept working for compatibility.
+        typer.secho(
+            "Note: 'createvm --init-cloud-images' is deprecated; use 'lvlab init' "
+            "instead (it initializes the built-in defaults with no Lvlab.yml). "
+            "This flag still works for now.",
+            fg=typer.colors.YELLOW,
+        )
         _initialize_cloud_images(catalog)
         if not has_all_vm_args:
             typer.secho("Cloud images initialized.", fg=typer.colors.GREEN)

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -165,3 +165,49 @@ def test_init_handles_parse_failure_via_configerror() -> None:
 
     assert result.exit_code == 1
     mocked_logger.error.assert_called_with("Could not parse config file.")
+
+
+# ---------------------------------------------------------------------------
+# No-manifest built-in default catalog (issue #97)
+# ---------------------------------------------------------------------------
+
+
+def test_init_with_no_manifest_initializes_builtin_defaults() -> None:
+    """`lvlab init` with no Lvlab.yml downloads the built-in default catalog.
+
+    Previously this errored (parse_config -> None -> exit 1), forcing users to
+    `createvm --init-cloud-images`. Now it initializes BUILTIN_IMAGES.
+    """
+    from tkc_lvlab.utils.catalog import BUILTIN_IMAGES
+
+    runner = CliRunner()
+    images = [
+        _mock_image(name, has_gpg=False, has_checksum=False) for name in BUILTIN_IMAGES
+    ]
+    with (
+        mock.patch.object(cli, "parse_config", return_value=None),
+        mock.patch.object(cli, "CloudImage", side_effect=images) as cloud_image_cls,
+    ):
+        result = runner.invoke(app, ["init"])
+
+    assert result.exit_code == 0, result.output
+    # One CloudImage per built-in, named for the catalog keys.
+    assert cloud_image_cls.call_count == len(BUILTIN_IMAGES)
+    built_names = [c.args[0] for c in cloud_image_cls.call_args_list]
+    assert set(built_names) == set(BUILTIN_IMAGES)
+    # Each image was fetched (not local in this test).
+    for img in images:
+        img.download_image.assert_called_once()
+
+
+def test_init_with_no_manifest_still_fails_on_bad_manifest() -> None:
+    """A structurally invalid manifest still fails loudly (not the None path)."""
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", side_effect=ConfigError("boom")),
+        mock.patch.object(cli, "CloudImage") as cloud_image_cls,
+    ):
+        result = runner.invoke(app, ["init"])
+
+    assert result.exit_code == 1
+    cloud_image_cls.assert_not_called()

--- a/tests/test_createvm.py
+++ b/tests/test_createvm.py
@@ -654,6 +654,10 @@ def test_init_cloud_images_only(
     )
     assert result.exit_code == 0, result.output
     assert "Cloud images initialized." in result.output
+    # Deprecation notice steers users to `lvlab init` (issue #97), but the
+    # flag still works.
+    assert "deprecated" in result.output.lower()
+    assert "lvlab init" in result.output
     # Every built-in image was visited for download.
     assert set(built) == set(BUILTIN_IMAGES)
     # No VM was created.


### PR DESCRIPTION
Closes #97.

During 0.4.0 validation a bare `lvlab init` errored without an `Lvlab.yml`, forcing `createvm --init-cloud-images` — which "did not feel natural in the flow."

## Changes
- **`lvlab init` is the single image-init path.** With a manifest → downloads its `images:` (unchanged). **With no manifest → initializes the built-in default catalog** (`utils.catalog.BUILTIN_IMAGES`) into the shared cache under a synthetic `default` environment. A structurally invalid manifest still fails loudly (the None path and the parse-error path are kept distinct).
- **`createvm --init-cloud-images` is deprecated but still works** — it prints a notice steering to `lvlab init`, and the `--help` text says so. Kept functional (not removed) so this is fully `git revert`-able.
- Image-source decision factored into `_init_image_source()`.

## Tests
- `lvlab init` with no manifest builds one `CloudImage` per built-in (named for each catalog key) and fetches each; a `ConfigError` manifest still exits 1 with no `CloudImage` built.
- The createvm `--init-cloud-images` test now also asserts the deprecation notice + that it still completes.

Docs: walkthrough `init` section + `one-off-vms` (`--init-cloud-images` row/example) updated. Full suite **517 passed, 39 skipped** (+2). `pre-commit` + `zensical build -s` clean.

## Deliberately deferred
Full unification of the two download *orchestration loops* (cli `init` vs createvm `_ensure_image_available`) — they have intentionally different error semantics (init logs+continues; createvm fails hard), so merging them is a behavior-sensitive refactor better done on its own. The catalog source is already shared (#103 moved `BUILTIN_IMAGES`/resolvers to `utils.catalog`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)