### PR TITLE
feat(vdisk): default lvlab disks to standalone copies; backing-file opt-in + warn (#99)

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -127,8 +127,11 @@ If the VM already exists in libvirt:
 
 If the VM does not yet exist:
 
-1. Create the primary qcow2 vdisk via `qemu-img create -b <cloud_image>`
-    (backing-file mode — fast, low disk usage).
+1. Create the primary qcow2 vdisk. By default this is a **standalone
+    copy** of the cloud image, so the disk has no dependency on the shared
+    `cloud-images/` cache and [`images clean`](#images-clean) can never
+    break a running VM. Backing-file mode is available as an opt-in — see
+    "Disk strategy" below.
 1. Render `meta-data`, `user-data`, and `network-config` from the
     Jinja2 templates in `tkc_lvlab/templates/`.
 1. Pack the three files into `cidata.iso` in-process with `pycdlib`
@@ -150,6 +153,26 @@ primary access path. To use your own password set `cloud_init.passwd`
 `cloud_init.password: false`. The password only takes effect at
 first-boot cloud-init, so re-running `up` on an existing VM doesn't
 change it.
+
+### Disk strategy
+
+Each VM disk is created with one of two strategies:
+
+- **`copy`** (default) — a standalone copy of the cloud image. The disk
+    is self-contained, so the shared `cloud-images/` cache can be pruned
+    or re-initialized without breaking the VM. Disks cost more space (a
+    full image each), but qcow2 copies are sparse and grow with use —
+    fine for a handful of lab VMs.
+- **`backing`** (opt-in) — a thin qcow2 overlay on the cached cloud image
+    (`qemu-img create -b`). Lower disk usage, but every such disk has a
+    hard dependency on the cached base image: **do not run
+    [`images clean`](#images-clean) or wipe the cache while a backing-mode
+    VM exists**, or its disk breaks. `up` logs a warning each time it
+    creates a backing-mode disk.
+
+Set it manifest-wide under `config_defaults.disk_strategy: copy|backing`,
+or per disk with `disks[*].strategy`. (`createvm` always uses a standalone
+copy.)
 
 ## status
 

--- a/src/tkc_lvlab/utils/libvirt.py
+++ b/src/tkc_lvlab/utils/libvirt.py
@@ -936,6 +936,19 @@ class Machine:
                 logger.info("Virtual Disk: %s exists at %s", vdisk.name, vdisk.fpath)
             else:
                 logger.info("Creating Virtual Disk: %s at %s", vdisk.fpath, vdisk.size)
+                if vdisk.strategy == "backing":
+                    # Backing-file disks depend on the shared cloud-images cache
+                    # (issue #99). Warn loudly so the operator knows not to run
+                    # `lvlab images clean` / wipe the cache while this VM exists.
+                    logger.warning(
+                        "Disk %s uses backing-file mode: it depends on the "
+                        "cached base image %s. Do NOT clean/wipe the "
+                        "cloud-images cache while this VM exists, or the disk "
+                        "will break. Use the default 'copy' strategy to avoid "
+                        "this.",
+                        vdisk.fpath,
+                        vdisk.backing_image_fpath,
+                    )
                 if vdisk.create():
                     if vdisk.exists():
                         logger.info("Virtual Disk Created Successfully")

--- a/src/tkc_lvlab/utils/vdisk.py
+++ b/src/tkc_lvlab/utils/vdisk.py
@@ -1,20 +1,31 @@
 """qcow2 virtual disk creation and lifecycle helpers.
 
 Used by the manifest workflow's :class:`tkc_lvlab.utils.libvirt.Machine`
-to provision per-VM backing-file qcow2 disks under
-``<disk_image_basedir>/<environment_name>/<vm_name>/diskN.qcow2``. Every
-disk references the verified cloud image as its qcow2 backing file
-(``qemu-img create -b ...``), so on-disk size stays low across many
-manifest VMs that share an OS.
+to provision per-VM qcow2 disks under
+``<disk_image_basedir>/<environment_name>/<vm_name>/diskN.qcow2``.
 
-The standalone ``createvm`` script does NOT use this class — see
-:mod:`tkc_lvlab.scripts.createvm` for the standalone path which can opt
-into a copy-strategy disk instead of backing-file.
+Two disk strategies (issue #99):
+
+- ``copy`` (**default**) — a standalone copy of the verified cloud image
+    (``cp`` + a best-effort ``qemu-img resize``). The disk has **no**
+    dependency on the shared ``cloud-images/`` cache, so
+    ``lvlab images clean`` can never break a running VM by pruning a base
+    image. This matches what the standalone ``createvm`` script already
+    does.
+- ``backing`` (opt-in) — the disk references the cloud image as its qcow2
+    backing file (``qemu-img create -b``), so on-disk size stays low across
+    many VMs that share an OS, at the cost of a hard dependency on the
+    cached base image. Selecting it warns that the cache must not be
+    cleaned while the VM exists.
+
+Select per environment with ``config_defaults.disk_strategy: copy|backing``,
+overridable per disk with ``disks[*].strategy``.
 """
 
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 from typing import Any
 
@@ -24,18 +35,28 @@ from .._logging import get_logger
 logger = get_logger(__name__)
 
 
+#: The supported disk strategies. ``copy`` is the default (cache-safe);
+#: ``backing`` is the storage-efficient opt-in.
+DISK_STRATEGIES = ("copy", "backing")
+DEFAULT_DISK_STRATEGY = "copy"
+
+
 class VirtualDisk:
-    """A per-VM qcow2 disk with a cloud-image backing file.
+    """A per-VM qcow2 disk, created as a standalone copy or a backing-file overlay.
 
     Attributes:
         name: Friendly name from the manifest's ``disks[*].name`` entry.
         index: Zero-based disk index used to compose the filename
             (``disk0.qcow2``, ``disk1.qcow2``, ...).
         size: qemu-img size string (e.g. ``25G``) — used at create time
-            and ignored thereafter.
+            and ignored thereafter. Optional for ``copy`` (the base image
+            size is kept when absent); required for ``backing``.
+        strategy: ``copy`` (standalone copy, default) or ``backing``
+            (cloud-image backing file).
         fpath: Absolute path on disk where the qcow2 lives.
-        backing_image_fpath: Absolute path to the verified cloud image
-            this disk uses as its backing file.
+        backing_image_fpath: Absolute path to the verified cloud image —
+            the backing file (``backing`` strategy) or the copy source
+            (``copy`` strategy).
     """
 
     def __init__(
@@ -47,28 +68,30 @@ class VirtualDisk:
         environment: dict[str, Any],
         config_defaults: dict[str, Any],
     ) -> None:
-        """Resolve the per-VM disk path and capture the backing image reference.
+        """Resolve the per-VM disk path, strategy, and base-image reference.
 
         Args:
             machine_vm_name: The manifest-side VM name (``vm_name``,
                 not the libvirt domain name). Used to compose the
                 per-VM subdirectory.
             disk: One element of the manifest's ``disks`` list. Honors
-                ``name`` and ``size`` keys.
+                ``name``, ``size``, and ``strategy`` keys.
             disk_id: Zero-based position in the manifest's ``disks``
                 list. Drives the ``diskN.qcow2`` filename.
             cloud_image: The :class:`tkc_lvlab.utils.images.CloudImage`
-                whose ``image_fpath`` becomes this disk's backing file.
+                whose ``image_fpath`` is the backing file / copy source.
                 Typed as ``Any`` here to avoid a circular import.
             environment: The manifest's ``environment[0]`` dict — its
                 ``name`` is the per-environment subdirectory.
             config_defaults: The manifest's ``config_defaults`` dict.
-                Honors ``disk_image_basedir``; defaults to
-                ``/var/lib/libvirt/images/lvlab``.
+                Honors ``disk_image_basedir`` (defaults to
+                ``/var/lib/libvirt/images/lvlab``) and ``disk_strategy``
+                (defaults to ``copy``).
         """
         self.name = disk.get("name", None)
         self.index = disk_id
         self.size = disk.get("size", None)
+        self.strategy = self._resolve_strategy(disk, config_defaults)
         self.fpath = os.path.join(
             os.path.expanduser(
                 config_defaults.get(
@@ -81,6 +104,27 @@ class VirtualDisk:
         )
         self.backing_image_fpath = cloud_image.image_fpath
 
+    @staticmethod
+    def _resolve_strategy(disk: dict[str, Any], config_defaults: dict[str, Any]) -> str:
+        """Resolve the disk strategy: per-disk override, else default, else ``copy``.
+
+        An unrecognized value falls back to ``copy`` with a warning rather
+        than failing the whole provision.
+        """
+        raw = disk.get("strategy") or config_defaults.get("disk_strategy")
+        if raw is None:
+            return DEFAULT_DISK_STRATEGY
+        strategy = str(raw).strip().lower()
+        if strategy not in DISK_STRATEGIES:
+            logger.warning(
+                "Unknown disk strategy %r; valid: %s. Defaulting to %r.",
+                raw,
+                ", ".join(DISK_STRATEGIES),
+                DEFAULT_DISK_STRATEGY,
+            )
+            return DEFAULT_DISK_STRATEGY
+        return strategy
+
     def exists(self) -> bool:
         """Return True if the qcow2 file is already on disk.
 
@@ -91,16 +135,76 @@ class VirtualDisk:
         return os.path.isfile(self.fpath)
 
     def create(self) -> bool:
-        """Create the backing-file qcow2 via ``qemu-img create -b ...``.
+        """Create the qcow2 using the resolved strategy.
 
-        Ensures the parent directory exists, then shells out to
-        ``qemu-img create -b <backing> -f qcow2 -F qcow2 <fpath> <size>``.
-        On any failure (mkdir or qemu-img), the error is logged and
-        ``False`` is returned — callers should check the return value.
+        Ensures the parent directory exists, then dispatches to the
+        ``copy`` (standalone) or ``backing`` (overlay) builder.
 
         Returns:
-            ``True`` on success, ``False`` if directory creation or
-            ``qemu-img`` failed.
+            ``True`` on success, ``False`` if directory creation or the
+            underlying ``cp`` / ``qemu-img`` step failed.
+        """
+        if not self._ensure_parent_dir():
+            return False
+        if self.strategy == "backing":
+            return self._create_backing()
+        return self._create_copy()
+
+    def _ensure_parent_dir(self) -> bool:
+        """Create the disk's parent directory if absent. Returns success."""
+        parent = os.path.dirname(self.fpath)
+        if not os.path.exists(parent):
+            try:
+                os.makedirs(parent)
+            except Exception as e:  # pylint: disable=broad-except
+                logger.error("Exception creating %s: %s", parent, e)
+                return False
+        return True
+
+    def _create_copy(self) -> bool:
+        """Create a standalone qcow2 by copying the base image, then resizing.
+
+        ``cp`` of the verified cloud image, followed by a best-effort
+        ``qemu-img resize`` to :attr:`size`. qcow2 cannot shrink, so a
+        ``size`` at or below the base image's virtual size makes ``resize``
+        fail — that's tolerated (warn, keep the base size) rather than
+        failing the provision (issue #88 / #99). With no ``size`` the base
+        image size is kept as-is.
+
+        Returns:
+            ``True`` on a successful copy (resize failures are non-fatal),
+            ``False`` if the copy itself failed.
+        """
+        try:
+            shutil.copyfile(self.backing_image_fpath, self.fpath)
+        except OSError as e:
+            logger.error("Error copying base image to %s: %s", self.fpath, e)
+            return False
+
+        if self.size:
+            try:
+                subprocess.run(
+                    ["qemu-img", "resize", self.fpath, self.size],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+            except subprocess.CalledProcessError as e:
+                stderr = (e.stderr or b"").decode(errors="replace").strip()
+                logger.warning(
+                    "Could not resize %s to %s; keeping the base image size "
+                    "(qcow2 cannot shrink): %s",
+                    self.fpath,
+                    self.size,
+                    stderr,
+                )
+        return True
+
+    def _create_backing(self) -> bool:
+        """Create a backing-file qcow2 via ``qemu-img create -b ...``.
+
+        Returns:
+            ``True`` on success, ``False`` if ``qemu-img`` failed.
         """
         command = [
             "qemu-img",
@@ -114,16 +218,6 @@ class VirtualDisk:
             self.fpath,
             self.size,
         ]
-
-        if not os.path.exists(os.path.dirname(self.fpath)):
-            try:
-                os.makedirs(os.path.dirname(self.fpath))
-            except Exception as e:  # pylint: disable=broad-except
-                logger.error(
-                    "Exception creating %s: %s", os.path.dirname(self.fpath), e
-                )
-                return False
-
         try:
             subprocess.run(
                 command,

--- a/tests/test_vdisk.py
+++ b/tests/test_vdisk.py
@@ -1,0 +1,131 @@
+"""Unit tests for :class:`tkc_lvlab.utils.vdisk.VirtualDisk`.
+
+Covers the issue #99 disk strategy: ``copy`` (standalone, the new default)
+vs ``backing`` (cloud-image overlay, opt-in), strategy resolution
+(per-disk override > config default > ``copy``), and the create paths.
+``shutil.copyfile`` and ``subprocess.run`` are mocked at the module
+boundary so no real ``cp`` / ``qemu-img`` runs; the parent dir lands under
+``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+from unittest import mock
+
+from tkc_lvlab.utils.vdisk import DEFAULT_DISK_STRATEGY, VirtualDisk
+
+
+def _vdisk(tmp_path, disk: dict, config_defaults: dict | None = None) -> VirtualDisk:
+    cloud_image = SimpleNamespace(image_fpath=str(tmp_path / "base.qcow2"))
+    defaults = {"disk_image_basedir": str(tmp_path)}
+    if config_defaults:
+        defaults.update(config_defaults)
+    return VirtualDisk("web01", disk, 0, cloud_image, {"name": "env"}, defaults)
+
+
+# --- strategy resolution ---------------------------------------------------
+
+
+def test_default_strategy_is_copy(tmp_path) -> None:
+    """No strategy anywhere -> copy (the cache-safe default)."""
+    assert _vdisk(tmp_path, {"size": "10G"}).strategy == "copy"
+    assert DEFAULT_DISK_STRATEGY == "copy"
+
+
+def test_config_default_selects_backing(tmp_path) -> None:
+    """config_defaults.disk_strategy: backing is honored."""
+    vd = _vdisk(tmp_path, {"size": "10G"}, {"disk_strategy": "backing"})
+    assert vd.strategy == "backing"
+
+
+def test_per_disk_strategy_overrides_config_default(tmp_path) -> None:
+    """A per-disk strategy wins over the config default."""
+    vd = _vdisk(
+        tmp_path, {"size": "10G", "strategy": "copy"}, {"disk_strategy": "backing"}
+    )
+    assert vd.strategy == "copy"
+
+
+def test_unknown_strategy_falls_back_to_copy(tmp_path) -> None:
+    """An unrecognized strategy degrades to copy rather than failing."""
+    vd = _vdisk(tmp_path, {"size": "10G", "strategy": "wat"})
+    assert vd.strategy == "copy"
+
+
+# --- create paths ----------------------------------------------------------
+
+
+def test_create_copy_copies_then_resizes(tmp_path) -> None:
+    """copy strategy: cp the base image, then qemu-img resize to size."""
+    vd = _vdisk(tmp_path, {"size": "25G"})
+    with (
+        mock.patch("tkc_lvlab.utils.vdisk.shutil.copyfile") as copyfile,
+        mock.patch("tkc_lvlab.utils.vdisk.subprocess.run") as run,
+    ):
+        assert vd.create() is True
+
+    copyfile.assert_called_once_with(vd.backing_image_fpath, vd.fpath)
+    # qemu-img resize <fpath> 25G — and NOT a `create -b` backing call.
+    argv = run.call_args.args[0]
+    assert argv == ["qemu-img", "resize", vd.fpath, "25G"]
+
+
+def test_create_copy_no_size_skips_resize(tmp_path) -> None:
+    """copy with no size: keep the base image size, no resize call."""
+    vd = _vdisk(tmp_path, {})
+    with (
+        mock.patch("tkc_lvlab.utils.vdisk.shutil.copyfile") as copyfile,
+        mock.patch("tkc_lvlab.utils.vdisk.subprocess.run") as run,
+    ):
+        assert vd.create() is True
+
+    copyfile.assert_called_once()
+    run.assert_not_called()
+
+
+def test_create_copy_tolerates_resize_failure(tmp_path) -> None:
+    """A resize failure (qcow2 can't shrink) is non-fatal: copy still succeeds."""
+    vd = _vdisk(tmp_path, {"size": "1G"})
+    with (
+        mock.patch("tkc_lvlab.utils.vdisk.shutil.copyfile") as copyfile,
+        mock.patch(
+            "tkc_lvlab.utils.vdisk.subprocess.run",
+            side_effect=subprocess.CalledProcessError(
+                1, ["qemu-img", "resize"], stderr=b"use --shrink"
+            ),
+        ),
+    ):
+        assert vd.create() is True  # resize failure does not fail the create
+
+    copyfile.assert_called_once()
+
+
+def test_create_backing_uses_qemu_img_create_b(tmp_path) -> None:
+    """backing strategy: qemu-img create -b <base>, and NO cp of the image."""
+    vd = _vdisk(tmp_path, {"size": "25G", "strategy": "backing"})
+    with (
+        mock.patch("tkc_lvlab.utils.vdisk.shutil.copyfile") as copyfile,
+        mock.patch("tkc_lvlab.utils.vdisk.subprocess.run") as run,
+    ):
+        assert vd.create() is True
+
+    copyfile.assert_not_called()
+    argv = run.call_args.args[0]
+    assert argv[:3] == ["qemu-img", "create", "-b"]
+    assert vd.backing_image_fpath in argv
+    assert vd.fpath in argv
+
+
+def test_create_copy_failure_returns_false(tmp_path) -> None:
+    """A copy (cp) failure returns False so the caller can report it."""
+    vd = _vdisk(tmp_path, {"size": "25G"})
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.vdisk.shutil.copyfile", side_effect=OSError("no space")
+        ),
+        mock.patch("tkc_lvlab.utils.vdisk.subprocess.run") as run,
+    ):
+        assert vd.create() is False
+    run.assert_not_called()


### PR DESCRIPTION
Closes #99.

`lvlab images clean` (#55) exposed a structural risk: every `lvlab up` disk was a qcow2 **backing-file overlay** on the shared `cloud-images/` cache, so pruning a cached image could silently break a running VM — and that dependency is hard to track with confidence. Flip the default to **standalone copies** (what `createvm` already does), making `images clean` safe by construction.

## Changes
- **`VirtualDisk` gains a `strategy`:**
  - **`copy` (default)** — `cp` the verified cloud image, then a best-effort `qemu-img resize`. qcow2 can't shrink, so a `size` ≤ the base image is tolerated (warn, keep base size — same spirit as createvm's #88). Self-contained → cache pruning can't break the VM.
  - **`backing` (opt-in)** — the prior `qemu-img create -b` overlay (lower disk usage).
- **Select** manifest-wide via `config_defaults.disk_strategy: copy|backing`, overridable per disk with `disks[*].strategy`. An unknown value degrades to `copy` (warned), never fatal.
- **Warn on backing mode:** `Machine.create_vdisks` logs a loud warning each time it creates a backing-mode disk — don't clean/wipe the cache while that VM exists. (Default log level is WARNING, so it shows.)

## Reversibility
Set `disk_strategy: backing` to restore the old behavior, or `git revert`. Backing mode loses no capability.

## Tests
New `tests/test_vdisk.py` (`VirtualDisk` previously had **zero** unit coverage): strategy precedence (per-disk > config default > copy), copy does cp+resize, resize-failure is non-fatal, no-size skips resize, backing uses `create -b` (no cp), copy-failure returns False. Full suite **526 passed, 39 skipped** (+9). `pre-commit` + `zensical build -s` clean. Walkthrough documents the strategy + the `images clean` caveat.

## Follow-up (noted)
A *shared* cp+resize helper with `createvm` is a sensible later cleanup — the two now use slightly different but both-correct resize approaches (createvm pre-checks virtual size; vdisk attempts-and-tolerates). Kept separate here to avoid touching createvm's tested copy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)