### PR TITLE
refactor(teardown): one-shot `undefine --snapshots-metadata` for destroy paths (#96)

### DIFF
--- a/src/tkc_lvlab/scripts/deletevm.py
+++ b/src/tkc_lvlab/scripts/deletevm.py
@@ -44,7 +44,7 @@ from pathlib import Path
 import typer
 
 from .. import __version__
-from ..utils.snapshot_cleanup import delete_all_snapshots
+from ..utils.snapshot_cleanup import undefine_with_snapshot_cleanup
 from ..utils.virsh import VirshError, run_virsh, virsh_snapshot_names, vm_exists
 from .createvm import storage_dir_for
 
@@ -92,30 +92,21 @@ def _domain_has_snapshots(vm_name: str) -> bool:
         return False  # unreachable; _fail raises. Keeps the type checker happy.
 
 
-def _delete_snapshots_or_fail(vm_name: str) -> None:
-    """Delete every snapshot of ``vm_name`` via the shared robust helper.
-
-    Raises:
-        typer.Exit: Snapshot deletion failed.
-    """
-    typer.secho(f"Deleting snapshots for VM '{vm_name}'...", fg=typer.colors.RED)
-    try:
-        delete_all_snapshots(_SYSTEM_URI, vm_name)
-    except VirshError as exc:
-        _fail(f"Failed to delete snapshots for VM '{vm_name}': {exc.stderr or exc}")
-
-
 def _undefine_or_fail(vm_name: str) -> None:
-    """Undefine ``vm_name``; any failure surfaces via :func:`_fail`.
+    """Undefine ``vm_name``, dropping any snapshots in one shot.
 
-    Snapshots are removed before this point (see the tier logic in
-    :func:`deletevm`), so a snapshot-blocked undefine should not occur here.
+    Delegates to
+    :func:`tkc_lvlab.utils.snapshot_cleanup.undefine_with_snapshot_cleanup`,
+    which retries with ``undefine --snapshots-metadata`` when the domain
+    still owns snapshots (issue #96) — no separate snapshot-delete pass.
+    The tier-2 consent in :func:`deletevm` still gates whether we reach
+    this point for a snapshot-bearing VM.
 
     Raises:
         typer.Exit: ``virsh undefine`` failed.
     """
     try:
-        run_virsh(_SYSTEM_URI, ["undefine", vm_name])
+        undefine_with_snapshot_cleanup(_SYSTEM_URI, vm_name)
     except VirshError as exc:
         _fail(f"Failed to undefine VM '{vm_name}': {exc.stderr or exc}")
 
@@ -197,13 +188,17 @@ def deletevm(
     # The domain may already be shut off; ignore a nonzero destroy.
     run_virsh(_SYSTEM_URI, ["destroy", domain_name], check=False)
 
-    # Snapshots must go before undefine — virsh refuses to undefine a domain
-    # that still owns snapshot metadata. We've already obtained consent above
-    # (or the operator passed --force --snapshots-too).
+    # Consent for snapshot removal was obtained above (tier-2, or
+    # --force --snapshots-too). The undefine drops the domain AND all its
+    # snapshot metadata in one shot (issue #96), so there's no separate
+    # snapshot-delete pass.
     if has_snapshots:
-        _delete_snapshots_or_fail(domain_name)
-
-    typer.secho(f"Undefining VM '{domain_name}'...", fg=typer.colors.RED)
+        typer.secho(
+            f"Removing snapshots and undefining VM '{domain_name}'...",
+            fg=typer.colors.RED,
+        )
+    else:
+        typer.secho(f"Undefining VM '{domain_name}'...", fg=typer.colors.RED)
     _undefine_or_fail(domain_name)
 
     # Storage cleanup is best-effort: a one-off VM's dir lives here, but a

--- a/src/tkc_lvlab/utils/libvirt.py
+++ b/src/tkc_lvlab/utils/libvirt.py
@@ -31,7 +31,7 @@ from .subprocess_env import system_first_env
 from .vdisk import VirtualDisk
 from .cloud_init import MetaData, NetworkConfig, UserData
 from .network import NETWORK_TYPES, USER_MODE_NETWORK_TYPES, generate_mac
-from .snapshot_cleanup import delete_all_snapshots
+from .snapshot_cleanup import undefine_with_snapshot_cleanup
 from .virsh import (
     DEAD_STATES,
     RUNNING_STATES,
@@ -123,13 +123,13 @@ class _SnapshotManager:
     A focused collaborator extracted from :class:`Machine` (issue #48). It
     owns the ``virsh snapshot-*`` interactions for one domain so the
     :class:`Machine` facade methods ``list_snapshots`` / ``create_snapshot``
-    / ``delete_snapshot`` (and :class:`_DomainDestroyer`'s pre-undefine
-    teardown) can delegate without changing their public contracts. All
-    ``virsh`` work goes
-    through the module-level helpers (``virsh_list_all_names``,
-    ``virsh_snapshot_names``, ``run_virsh``, ``delete_all_snapshots``,
-    ``_xml_tempfile``) so behaviour — including the issue #84
-    cascading-then-metadata teardown — is preserved verbatim.
+    / ``delete_snapshot`` can delegate without changing their public
+    contracts. All ``virsh`` work goes through the module-level helpers
+    (``virsh_list_all_names``, ``virsh_snapshot_names``, ``run_virsh``,
+    ``_xml_tempfile``). (Bulk teardown before ``undefine`` now lives in
+    :class:`_DomainDestroyer`, which uses the one-shot
+    ``undefine --snapshots-metadata`` — issue #96 — rather than a
+    snapshot-delete loop here.)
 
     Args:
         libvirt_vm_name: The env-namespaced libvirt domain name (the real
@@ -247,39 +247,14 @@ class _SnapshotManager:
             timeout=120.0,
         )
 
-    def delete_all(self, uri: str) -> bool:
-        """Delete every snapshot of the domain; required before ``undefine``.
-
-        ``virsh undefine`` refuses when snapshot metadata still exists, so
-        this is mandatory cleanup. Delegates to the shared
-        :func:`tkc_lvlab.utils.snapshot_cleanup.delete_all_snapshots` helper
-        (cascading ``--children`` delete, with the ``--metadata`` fallback
-        for external-children qcow2 chains — issue #84). The no-snapshots
-        case is a no-op inside the helper.
-
-        Args:
-            uri: A libvirt connection URI (e.g. ``qemu:///session``).
-
-        Returns:
-            ``True`` on success (including the no-snapshots case). ``False``
-            if snapshot cleanup raised ``VirshError``.
-        """
-        try:
-            delete_all_snapshots(uri, self.libvirt_vm_name)
-        except VirshError as e:
-            logger.error("Failed to delete snapshots for %s: %s", self.vm_name, e)
-            return False
-        return True
-
 
 class _DomainDestroyer:
     """The full destroy sequence for a single libvirt domain.
 
     A focused collaborator extracted from :class:`Machine` (issue #48). It
-    owns the ordered teardown — force-off (if alive) -> snapshot teardown
-    (via :class:`_SnapshotManager`, which routes through the robust issue
-    #84 ``delete_all_snapshots`` util) -> undefine -> on-disk file cleanup
-    — so the :class:`Machine.destroy` facade can delegate without changing
+    owns the ordered teardown — force-off (if alive) -> undefine (which
+    drops any snapshots in one shot, issue #96) -> on-disk file cleanup —
+    so the :class:`Machine.destroy` facade can delegate without changing
     its ``bool`` contract or its "stop at the first failed step" behaviour.
 
     Args:
@@ -289,8 +264,6 @@ class _DomainDestroyer:
         config_fpath: On-disk directory holding the domain's artifacts
             (qcow2 disks, ``cidata.iso``, rendered cloud-init files); the
             target of the file-cleanup step.
-        snapshots: The domain's :class:`_SnapshotManager`, used for the
-            pre-undefine snapshot teardown.
     """
 
     def __init__(
@@ -298,12 +271,10 @@ class _DomainDestroyer:
         libvirt_vm_name: str,
         vm_name: str,
         config_fpath: str,
-        snapshots: "_SnapshotManager",
     ) -> None:
         self.libvirt_vm_name = libvirt_vm_name
         self.vm_name = vm_name
         self.config_fpath = config_fpath
-        self.snapshots = snapshots
 
     def destroy(self, uri: str) -> bool:
         """Forcefully power off, undefine, and clean up files for the domain.
@@ -348,8 +319,8 @@ class _DomainDestroyer:
             )
             return False
 
-        if not self.snapshots.delete_all(uri):
-            return False
+        # Undefine drops any snapshots in one shot (issue #96), so there's no
+        # separate pre-undefine snapshot-deletion step.
         if not self._undefine(uri):
             return False
         return self._cleanup_files()
@@ -384,10 +355,16 @@ class _DomainDestroyer:
             return None
 
     def _undefine(self, uri: str) -> bool:
-        """Undefine the libvirt domain. Returns False on virsh failure."""
+        """Undefine the libvirt domain, dropping any snapshots in one shot.
+
+        Delegates to
+        :func:`tkc_lvlab.utils.snapshot_cleanup.undefine_with_snapshot_cleanup`,
+        which retries with ``undefine --snapshots-metadata`` if the domain
+        still owns snapshots (issue #96). Returns False on virsh failure.
+        """
         logger.info("Undefining %s", self.vm_name)
         try:
-            run_virsh(uri, ["undefine", self.libvirt_vm_name])
+            undefine_with_snapshot_cleanup(uri, self.libvirt_vm_name)
         except VirshError as e:
             logger.error(
                 "Failed to undefine (remove from Libvirt) %s: %s", self.vm_name, e
@@ -811,7 +788,7 @@ class Machine:
         # rather than copying it, so they never drift from the facade.
         self._snapshots = _SnapshotManager(self.libvirt_vm_name, self.vm_name)
         self._destroyer = _DomainDestroyer(
-            self.libvirt_vm_name, self.vm_name, self.config_fpath, self._snapshots
+            self.libvirt_vm_name, self.vm_name, self.config_fpath
         )
         self._cloud_init_composer = _CloudInitComposer(self)
 
@@ -1090,7 +1067,6 @@ class Machine:
                 self.libvirt_vm_name,
                 self.vm_name,
                 self.config_fpath,
-                self._get_snapshots(),
             )
         return destroyer
 

--- a/src/tkc_lvlab/utils/snapshot_cleanup.py
+++ b/src/tkc_lvlab/utils/snapshot_cleanup.py
@@ -1,26 +1,26 @@
-"""Snapshot deletion + undefine helpers with the lvscripts-style fallback.
+"""Undefine helpers with the virt-manager-style one-shot snapshot teardown.
 
-Phase 6 step 5. Standalone ``deletevm`` and the manifest ``Machine.destroy``
-both need to deal with the same libvirt awkwardness: ``virsh undefine``
-refuses to drop a domain that owns snapshots, and ``virsh snapshot-delete``
-itself can fail when the snapshot has *external* children (the common case
-for backing-file qcow2 chains).
+Standalone ``deletevm`` and the manifest ``Machine.destroy`` both need to
+deal with the same libvirt awkwardness: ``virsh undefine`` refuses to drop
+a domain that still owns snapshots.
 
-Two helpers live here:
+:func:`undefine_with_snapshot_cleanup` resolves this the way virt-manager
+does — in **one** call:
 
-- :func:`delete_all_snapshots` walks the snapshot list and deletes each
-    one, falling back from ``--children`` (cascading delete) to
-    ``--metadata`` (orphan metadata so undefine can proceed) when the
-    upstream qcow2 chain prevents the cleaner cascading delete. The
-    "external snapshot" failure is detected by semantic tokens, not a
-    fixed phrase, because the wording varies across libvirt versions and
-    snapshot positions (issue #95). Includes progress detection: if the
-    same snapshot list comes back twice in a row, the function refuses to
-    loop forever.
-- :func:`undefine_with_snapshot_cleanup` tries ``virsh undefine`` first,
-    detects the snapshot-related failure mode by stderr matching, and
-    calls into :func:`delete_all_snapshots` before retrying. Other
-    failure modes propagate.
+1. ``virsh undefine <dom>`` is tried first.
+2. If that fails *because the domain owns snapshots* (detected by stderr
+    matching), it retries with ``virsh undefine <dom> --snapshots-metadata``,
+    which drops the domain **and** all snapshot metadata together.
+
+This supersedes the earlier two-step approach (loop ``snapshot-delete``,
+falling back from ``--children`` to ``--metadata`` on external-snapshot
+chains). The one-shot has **zero dependence on ``snapshot-delete`` error
+wordings**, so it structurally cannot regress the way issue #95 did — a
+single libvirt version emitting two different "external snapshot
+unsupported" phrasings broke the old exact-string fallback. See issue #96
+for the evaluation that chose this. The overlay qcow2 files are left on
+disk (same as before); the callers ``rmtree`` the VM storage dir next, so
+nothing is orphaned.
 
 Everything goes through :func:`tkc_lvlab.utils.virsh.run_virsh` so the
 locale lock and timeout handling are uniform; failures raise
@@ -29,20 +29,11 @@ locale lock and timeout handling are uniform; failures raise
 
 from __future__ import annotations
 
-from .virsh import VirshError, run_virsh, virsh_snapshot_names
+from .virsh import VirshError, run_virsh
 
 
 _SNAPSHOT_UNDEFINE_MARKER = "cannot delete inactive domain"
 _SNAPSHOT_KEYWORD = "snapshot"
-# Tokens that together identify libvirt's "can't --children-delete an external
-# snapshot" family. The exact phrasing varies by libvirt version *and* by the
-# snapshot's position in the chain — a single host (libvirt 12.0.0) emits both
-# "external children disk snapshots not supported" (deleting a parent) and
-# "external disk snapshots with children not supported" (deleting a leaf). An
-# exact-substring match on one phrasing missed the other and aborted the whole
-# teardown (issue #95); match the semantic tokens instead.
-_EXTERNAL_SNAPSHOT_TOKENS = ("external", "snapshot")
-_UNSUPPORTED_TOKENS = ("not supported", "unsupported")
 
 
 def _is_snapshot_undefine_error(stderr: str) -> bool:
@@ -61,117 +52,27 @@ def _is_snapshot_undefine_error(stderr: str) -> bool:
     return _SNAPSHOT_UNDEFINE_MARKER in s and _SNAPSHOT_KEYWORD in s
 
 
-def _is_external_children_error(stderr: str) -> bool:
-    """Return True when ``virsh snapshot-delete --children`` can't delete an external snapshot.
-
-    libvirt refuses ``--children`` (cascading) deletes for external disk
-    snapshots, but the exact wording is not stable: it varies across
-    libvirt versions and even across the snapshot's position in the chain
-    on a single host (see :data:`_EXTERNAL_SNAPSHOT_TOKENS`). Rather than
-    pin one phrasing — which silently missed the other and aborted the
-    teardown (issue #95) — match the semantic tokens: the message names
-    an ``external`` ``snapshot`` and says the operation is ``unsupported``
-    / ``not supported``. In that case ``--metadata`` is the right
-    fallback. Unrelated failures (no ``external``/``snapshot`` mention)
-    do not match and propagate.
-
-    Args:
-        stderr: Captured stderr text from a failed ``snapshot-delete``.
-
-    Returns:
-        True iff the stderr names an unsupported external-snapshot
-        operation, in which case ``--metadata`` is the right fallback.
-    """
-    s = stderr.lower()
-    return all(t in s for t in _EXTERNAL_SNAPSHOT_TOKENS) and any(
-        t in s for t in _UNSUPPORTED_TOKENS
-    )
-
-
-def delete_all_snapshots(uri: str, domain_name: str) -> None:
-    """Delete every snapshot for ``domain_name``, falling back on external children.
-
-    Walks ``virsh snapshot-list <domain> --name`` repeatedly, deleting
-    the first snapshot in the list each pass. ``--children`` is tried
-    first (faster, cascades); on the "external children" failure,
-    ``--metadata`` is tried (drops only the libvirt metadata, leaving
-    the backing-chain qcow2 files in place — undefine can then proceed).
-
-    A progress detector breaks the loop if the same snapshot set comes
-    back twice in a row. Without it, a snapshot that won't delete
-    under either flag would spin forever.
-
-    Args:
-        uri: libvirt URI to operate against.
-        domain_name: The libvirt domain whose snapshots to delete.
-
-    Raises:
-        VirshError: A snapshot deletion failed for a reason other than
-            external children, OR progress stalled (same snapshot set
-            twice). The exception message names the specific failure.
-    """
-    previous: tuple[str, ...] | None = None
-    while True:
-        names = virsh_snapshot_names(uri, domain_name)
-        if not names:
-            return
-
-        current = tuple(names)
-        if previous == current:
-            raise VirshError(
-                1,
-                (
-                    f"Snapshot cleanup stalled for {domain_name}: same set seen "
-                    f"twice. Remaining: {', '.join(current)}"
-                ),
-                ["snapshot-cleanup"],
-            )
-        previous = current
-        snapshot_name = names[0]
-
-        try:
-            run_virsh(
-                uri,
-                [
-                    "snapshot-delete",
-                    domain_name,
-                    "--snapshotname",
-                    snapshot_name,
-                    "--children",
-                ],
-            )
-        except VirshError as exc:
-            if not _is_external_children_error(exc.stderr):
-                raise
-            # External-children fallback: drop just the metadata.
-            run_virsh(
-                uri,
-                [
-                    "snapshot-delete",
-                    domain_name,
-                    "--snapshotname",
-                    snapshot_name,
-                    "--metadata",
-                ],
-            )
-
-
 def undefine_with_snapshot_cleanup(uri: str, domain_name: str) -> None:
-    """Undefine ``domain_name``, deleting any blocking snapshots first.
+    """Undefine ``domain_name``, dropping any blocking snapshots in one shot.
 
     Tries ``virsh undefine`` directly. On the specific snapshot-related
-    failure mode (detected via stderr matching), calls
-    :func:`delete_all_snapshots` and retries. All other undefine failures
-    propagate so the caller can decide.
+    failure mode (detected via stderr matching), retries with
+    ``virsh undefine --snapshots-metadata`` — which removes the domain and
+    all of its snapshot metadata together, regardless of how the host's
+    libvirt phrases its external-snapshot limitations (issue #96). All
+    other undefine failures propagate so the caller can decide.
+
+    The qcow2 overlay files for any external snapshots remain on disk;
+    callers remove the VM's storage directory afterward.
 
     Args:
-        uri: libvirt URI.
+        uri: libvirt connection URI.
         domain_name: The libvirt domain to undefine.
 
     Raises:
-        VirshError: The retry also failed, OR the original undefine
-            failed for a non-snapshot reason. The exception carries the
-            failing virsh stderr.
+        VirshError: The ``--snapshots-metadata`` retry also failed, OR the
+            original undefine failed for a non-snapshot reason. The
+            exception carries the failing ``virsh`` stderr.
     """
     try:
         run_virsh(uri, ["undefine", domain_name])
@@ -179,6 +80,6 @@ def undefine_with_snapshot_cleanup(uri: str, domain_name: str) -> None:
     except VirshError as exc:
         if not _is_snapshot_undefine_error(exc.stderr):
             raise
-        # Snapshots blocking. Clean them up and retry.
-        delete_all_snapshots(uri, domain_name)
-        run_virsh(uri, ["undefine", domain_name])
+        # Snapshots are blocking the undefine. Drop the domain and every
+        # snapshot's metadata in a single call (virt-manager's approach).
+        run_virsh(uri, ["undefine", domain_name, "--snapshots-metadata"])

--- a/tests/test_deletevm.py
+++ b/tests/test_deletevm.py
@@ -33,6 +33,7 @@ from typer.testing import CliRunner
 
 from tkc_lvlab.scripts import deletevm as dv_mod
 from tkc_lvlab.scripts.deletevm import run
+from tkc_lvlab.utils import snapshot_cleanup as sc_mod
 from tkc_lvlab.utils.virsh import VirshError
 
 
@@ -50,12 +51,14 @@ def stub(monkeypatch: pytest.MonkeyPatch) -> dict:
         ),
         "vm_exists": mock.Mock(return_value=True),
         "virsh_snapshot_names": mock.Mock(return_value=[]),
-        "delete_all_snapshots": mock.Mock(),
     }
     monkeypatch.setattr(dv_mod, "run_virsh", mocks["run_virsh"])
     monkeypatch.setattr(dv_mod, "vm_exists", mocks["vm_exists"])
     monkeypatch.setattr(dv_mod, "virsh_snapshot_names", mocks["virsh_snapshot_names"])
-    monkeypatch.setattr(dv_mod, "delete_all_snapshots", mocks["delete_all_snapshots"])
+    # The one-shot undefine (issue #96) routes through snapshot_cleanup's
+    # run_virsh; funnel it into the same mock so `_virsh_calls(stub, "undefine")`
+    # captures it.
+    monkeypatch.setattr(sc_mod, "run_virsh", mocks["run_virsh"])
     return mocks
 
 
@@ -140,8 +143,8 @@ def test_confirmation_no_aborts(stub: dict, tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 # Snapshot tier matrix. Snapshot presence is detected UP FRONT via
 # virsh_snapshot_names, so the prompts branch on it before any mutation.
-# Ordering invariant for the snapshot path: destroy -> delete_all_snapshots
-# -> undefine (virsh refuses to undefine a domain that still owns snapshots).
+# Ordering invariant for the snapshot path: destroy -> undefine (the undefine
+# drops any snapshots in one shot via --snapshots-metadata, issue #96).
 # ---------------------------------------------------------------------------
 
 
@@ -165,10 +168,8 @@ def test_no_force_tier1_then_tier2_deletes_snapshots(
     assert result.exit_code == 0, result.output
     assert "Are you sure?" in result.output  # tier-1
     assert "snapshots" in result.output.lower()  # tier-2
-    stub["delete_all_snapshots"].assert_called_once_with(
-        dv_mod._SYSTEM_URI, "testvm.local"
-    )
-    # Ordering: destroy precedes delete_all_snapshots precedes undefine.
+    # Ordering: destroy precedes undefine (which drops snapshots in one shot,
+    # issue #96).
     assert _virsh_calls(stub, "destroy")
     assert _virsh_calls(stub, "undefine")
     assert not vm_dir.exists()
@@ -187,7 +188,6 @@ def test_no_force_tier1_declined_aborts_before_snapshot_check(
     )
     assert result.exit_code == 0, result.output
     assert "Aborted." in result.output
-    stub["delete_all_snapshots"].assert_not_called()
     assert _virsh_calls(stub, "destroy") == []
     assert _virsh_calls(stub, "undefine") == []
     assert vm_dir.exists()
@@ -204,7 +204,6 @@ def test_no_force_tier2_declined_fails(stub: dict, tmp_path: Path) -> None:
     )
     assert result.exit_code != 0
     assert "Aborted: snapshots were not deleted" in result.output
-    stub["delete_all_snapshots"].assert_not_called()
     # We refuse before undefining a snapshot-bearing domain.
     assert _virsh_calls(stub, "undefine") == []
     assert vm_dir.exists()
@@ -221,7 +220,6 @@ def test_force_no_snapshots_is_fully_noninteractive(stub: dict, tmp_path: Path) 
     )
     assert result.exit_code == 0, result.output
     assert "Are you sure?" not in result.output
-    stub["delete_all_snapshots"].assert_not_called()
     assert not vm_dir.exists()
 
 
@@ -243,7 +241,7 @@ def test_force_with_snapshots_still_fires_tier2(stub: dict, tmp_path: Path) -> N
     assert result.exit_code == 0, result.output
     assert "Are you sure?" not in result.output  # tier-1 skipped by --force
     assert "snapshots" in result.output.lower()  # tier-2 still fired
-    stub["delete_all_snapshots"].assert_called_once()
+    assert _virsh_calls(stub, "undefine")
     assert not vm_dir.exists()
 
 
@@ -260,7 +258,6 @@ def test_force_with_snapshots_tier2_declined_fails(stub: dict, tmp_path: Path) -
     )
     assert result.exit_code != 0
     assert "Aborted: snapshots were not deleted" in result.output
-    stub["delete_all_snapshots"].assert_not_called()
     assert _virsh_calls(stub, "undefine") == []
     assert vm_dir.exists()
 
@@ -281,9 +278,7 @@ def test_force_snapshots_too_is_fully_noninteractive(
     assert result.exit_code == 0, result.output
     assert "Are you sure?" not in result.output
     assert "Delete all VM snapshots" not in result.output
-    stub["delete_all_snapshots"].assert_called_once_with(
-        dv_mod._SYSTEM_URI, "testvm.local"
-    )
+    assert _virsh_calls(stub, "undefine")
     assert not vm_dir.exists()
 
 
@@ -307,7 +302,7 @@ def test_snapshots_too_without_force_still_prompts_tier2(
     assert result.exit_code == 0, result.output
     assert "Are you sure?" in result.output  # tier-1 still fired (no --force)
     assert "snapshots" in result.output.lower()  # tier-2 still fired
-    stub["delete_all_snapshots"].assert_called_once()
+    assert _virsh_calls(stub, "undefine")
 
 
 def test_snapshot_list_failure_aborts_before_mutation(
@@ -330,12 +325,21 @@ def test_snapshot_list_failure_aborts_before_mutation(
     assert vm_dir.exists()
 
 
-def test_snapshot_deletion_failure_fails(stub: dict, tmp_path: Path) -> None:
-    """If delete_all_snapshots raises, deletevm fails and leaves the dir."""
+def test_undefine_failure_fails_and_leaves_dir(stub: dict, tmp_path: Path) -> None:
+    """If the one-shot undefine raises, deletevm fails and leaves the dir.
+
+    With snapshots present, the undefine retries with --snapshots-metadata;
+    if even that fails, the error surfaces and storage is left for
+    inspection (issue #96 folded snapshot teardown into undefine).
+    """
     stub["virsh_snapshot_names"].return_value = ["snap-a"]
-    stub["delete_all_snapshots"].side_effect = VirshError(
-        1, "snapshot cleanup stalled", ["snapshot-cleanup"]
-    )
+
+    def fake_run(uri, args, **kwargs):
+        if args[0] == "undefine":
+            raise VirshError(1, "error: undefine failed somehow", args)
+        return CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+    stub["run_virsh"].side_effect = fake_run
     vm_dir = tmp_path / "testvm.local"
     vm_dir.mkdir()
 
@@ -344,9 +348,8 @@ def test_snapshot_deletion_failure_fails(stub: dict, tmp_path: Path) -> None:
         ["testvm.local", "--force", "--snapshots-too", "--storage-root", str(tmp_path)],
     )
     assert result.exit_code != 0
-    assert "Failed to delete snapshots" in result.output
-    # Failure is before undefine; the dir survives for inspection.
-    assert _virsh_calls(stub, "undefine") == []
+    assert "Failed to undefine" in result.output
+    # Undefine failed before file cleanup; the dir survives for inspection.
     assert vm_dir.exists()
 
 

--- a/tests/test_libvirt_lifecycle.py
+++ b/tests/test_libvirt_lifecycle.py
@@ -55,7 +55,13 @@ def machine(tmp_path) -> Machine:
 def test_destroy_running_vm_calls_destroy_then_undefine(machine: Machine) -> None:
     """A running domain gets ``virsh destroy`` first, then (no snapshots)
     ``virsh undefine``. Ordering matters: undefining a running domain fails
-    on real libvirt, so the destroy must come first."""
+    on real libvirt, so the destroy must come first.
+
+    The undefine routes through ``undefine_with_snapshot_cleanup`` (whose
+    own ``run_virsh`` lives in the snapshot_cleanup module), so both
+    modules' ``run_virsh`` are funneled into one mock to capture ordering.
+    """
+    run_mock = mock.Mock()
     with (
         mock.patch(
             "tkc_lvlab.utils.libvirt.virsh_list_all_names",
@@ -65,66 +71,82 @@ def test_destroy_running_vm_calls_destroy_then_undefine(machine: Machine) -> Non
             "tkc_lvlab.utils.libvirt.virsh_domstate",
             side_effect=["running", "shut off"],
         ),
-        mock.patch("tkc_lvlab.utils.libvirt.delete_all_snapshots"),
-        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh", run_mock),
+        mock.patch("tkc_lvlab.utils.snapshot_cleanup.run_virsh", run_mock),
     ):
         result = machine.destroy(URI)
 
     assert result is True
-    # Order: destroy, then undefine. No snapshot-delete because there were none.
-    called_subcommands = [call.args[1][0] for call in run_mock.call_args_list]
-    assert called_subcommands == ["destroy", "undefine"]
-    run_mock.assert_any_call(URI, ["destroy", "web01_lab"])
-    run_mock.assert_any_call(URI, ["undefine", "web01_lab"])
+    # Order: destroy, then undefine. No --snapshots-metadata since the plain
+    # undefine succeeds (no snapshots).
+    calls = [call.args[1] for call in run_mock.call_args_list]
+    assert calls == [["destroy", "web01_lab"], ["undefine", "web01_lab"]]
 
 
 def test_destroy_already_shut_off_skips_destroy(machine: Machine) -> None:
     """A domain that is already ``shut off`` must NOT have ``virsh destroy``
     invoked against it — that's an error on a stopped domain. The method
-    should go straight to snapshot cleanup + undefine."""
+    should go straight to undefine."""
+    run_mock = mock.Mock()
     with (
         mock.patch(
             "tkc_lvlab.utils.libvirt.virsh_list_all_names",
             return_value=["web01_lab"],
         ),
         mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="shut off"),
-        mock.patch("tkc_lvlab.utils.libvirt.delete_all_snapshots"),
-        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh", run_mock),
+        mock.patch("tkc_lvlab.utils.snapshot_cleanup.run_virsh", run_mock),
     ):
         result = machine.destroy(URI)
 
     assert result is True
-    called_subcommands = [call.args[1][0] for call in run_mock.call_args_list]
-    assert "destroy" not in called_subcommands
-    assert called_subcommands == ["undefine"]
-
-
-def test_destroy_routes_snapshot_teardown_through_shared_util(
-    machine: Machine,
-) -> None:
-    """``Machine.destroy`` must route snapshot teardown through the robust
-    shared :func:`utils.snapshot_cleanup.delete_all_snapshots` helper rather
-    than the old weaker raw ``snapshot-delete`` reimplementation (issue #84
-    drift fix). The shared util gets the libvirt domain name (not ``vm_name``),
-    and the undefine must come after — virsh refuses to undefine a domain that
-    still owns snapshot metadata."""
-    with (
-        mock.patch(
-            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
-            return_value=["web01_lab"],
-        ),
-        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="shut off"),
-        mock.patch("tkc_lvlab.utils.libvirt.delete_all_snapshots") as cleanup_mock,
-        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
-    ):
-        result = machine.destroy(URI)
-
-    assert result is True
-    cleanup_mock.assert_called_once_with(URI, "web01_lab")
-    # The only run_virsh call left in this path is the undefine — snapshot
-    # deletion now lives entirely inside the shared util.
     calls = [call.args[1] for call in run_mock.call_args_list]
     assert calls == [["undefine", "web01_lab"]]
+
+
+def test_destroy_undefine_drops_snapshots_in_one_shot(
+    machine: Machine,
+) -> None:
+    """``Machine.destroy`` routes undefine through the one-shot teardown
+    (issue #96): a snapshot-blocked undefine retries with
+    ``--snapshots-metadata`` rather than looping ``snapshot-delete``. The
+    undefine still comes after the force-off."""
+    run_mock = mock.Mock(
+        side_effect=lambda uri, args, **kw: (
+            _raise_snapshot_block()
+            if args == ["undefine", "web01_lab"]
+            else mock.DEFAULT
+        )
+    )
+    with (
+        mock.patch(
+            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
+            return_value=["web01_lab"],
+        ),
+        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="shut off"),
+        mock.patch("tkc_lvlab.utils.libvirt.run_virsh", run_mock),
+        mock.patch("tkc_lvlab.utils.snapshot_cleanup.run_virsh", run_mock),
+    ):
+        result = machine.destroy(URI)
+
+    assert result is True
+    calls = [call.args[1] for call in run_mock.call_args_list]
+    # Plain undefine (snapshot-blocked) -> retry with --snapshots-metadata.
+    assert calls == [
+        ["undefine", "web01_lab"],
+        ["undefine", "web01_lab", "--snapshots-metadata"],
+    ]
+
+
+def _raise_snapshot_block():
+    """Raise the snapshot-blocked undefine VirshError (test helper)."""
+    from tkc_lvlab.utils.virsh import VirshError
+
+    raise VirshError(
+        1,
+        "error: cannot delete inactive domain with 2 snapshots",
+        ["undefine"],
+    )
 
 
 def test_destroy_absent_domain_returns_false(machine: Machine) -> None:
@@ -162,10 +184,10 @@ def test_destroy_destroy_failure_skips_undefine(machine: Machine) -> None:
             return_value=["web01_lab"],
         ),
         mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="running"),
-        mock.patch("tkc_lvlab.utils.libvirt.delete_all_snapshots"),
         mock.patch(
             "tkc_lvlab.utils.libvirt.run_virsh", side_effect=fake_run
         ) as run_mock,
+        mock.patch("tkc_lvlab.utils.snapshot_cleanup.run_virsh", side_effect=fake_run),
     ):
         result = machine.destroy(URI)
 
@@ -196,8 +218,8 @@ def test_destroy_undefine_failure_skips_file_cleanup(
             return_value=["web01_lab"],
         ),
         mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="shut off"),
-        mock.patch("tkc_lvlab.utils.libvirt.delete_all_snapshots"),
         mock.patch("tkc_lvlab.utils.libvirt.run_virsh", side_effect=fake_run),
+        mock.patch("tkc_lvlab.utils.snapshot_cleanup.run_virsh", side_effect=fake_run),
     ):
         result = machine.destroy(URI)
 
@@ -205,28 +227,10 @@ def test_destroy_undefine_failure_skips_file_cleanup(
     assert sentinel.exists(), "file cleanup must not run when undefine failed"
 
 
-def test_destroy_snapshot_cleanup_failure_skips_undefine(machine: Machine) -> None:
-    """A ``VirshError`` from the shared snapshot-cleanup util (e.g. a stalled
-    teardown) aborts the flow before undefining; the domain would refuse
-    undefine anyway, and proceeding could mask a real error mid-cleanup. The
-    method returns False and never calls ``virsh undefine``."""
-    with (
-        mock.patch(
-            "tkc_lvlab.utils.libvirt.virsh_list_all_names",
-            return_value=["web01_lab"],
-        ),
-        mock.patch("tkc_lvlab.utils.libvirt.virsh_domstate", return_value="shut off"),
-        mock.patch(
-            "tkc_lvlab.utils.libvirt.delete_all_snapshots",
-            side_effect=VirshError(1, "snapshot busy", ["snapshot-delete"]),
-        ),
-        mock.patch("tkc_lvlab.utils.libvirt.run_virsh") as run_mock,
-    ):
-        result = machine.destroy(URI)
-
-    assert result is False
-    called_subcommands = [call.args[1][0] for call in run_mock.call_args_list]
-    assert "undefine" not in called_subcommands
+# (The former ``test_destroy_snapshot_cleanup_failure_skips_undefine`` is gone:
+# issue #96 folded snapshot teardown into the one-shot undefine, so there is no
+# longer a separate pre-undefine snapshot step that can fail independently. A
+# failing one-shot undefine is covered by the undefine-failure test above.)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_snapshot_cleanup.py
+++ b/tests/test_snapshot_cleanup.py
@@ -1,18 +1,17 @@
 """Unit tests for :mod:`tkc_lvlab.utils.snapshot_cleanup`.
 
+After issue #96 the teardown uses the virt-manager-style **one-shot**
+``undefine --snapshots-metadata`` instead of a snapshot-delete loop.
 Locked-in contracts:
 
-- ``undefine_with_snapshot_cleanup`` succeeds on a clean undefine
-    without touching snapshots at all.
-- A non-snapshot VirshError from undefine propagates unchanged (we
-    don't paper over unrelated failures).
-- A snapshot-blocked undefine triggers ``delete_all_snapshots`` then
-    retries.
-- ``delete_all_snapshots`` walks the snapshot list, prefers
-    ``--children``, and falls back to ``--metadata`` on the specific
-    "external children" error.
-- A stalled progress loop (same snapshot set seen twice) raises
-    rather than spinning forever.
+- A clean ``undefine`` succeeds without the ``--snapshots-metadata`` flag
+    (no snapshots to remove).
+- A non-snapshot ``VirshError`` propagates unchanged (we don't paper over
+    unrelated failures like an unreachable URI).
+- A snapshot-blocked ``undefine`` retries **once** with
+    ``--snapshots-metadata`` — wording-independent, so it can't regress the
+    way issue #95's exact-string ``snapshot-delete`` matcher did.
+- A failure of the ``--snapshots-metadata`` retry propagates.
 """
 
 from __future__ import annotations
@@ -23,15 +22,18 @@ from unittest import mock
 import pytest
 
 from tkc_lvlab.utils import snapshot_cleanup as sc_mod
-from tkc_lvlab.utils.snapshot_cleanup import (
-    delete_all_snapshots,
-    undefine_with_snapshot_cleanup,
-)
+from tkc_lvlab.utils.snapshot_cleanup import undefine_with_snapshot_cleanup
 from tkc_lvlab.utils.virsh import VirshError
 
 
 URI = "qemu:///system"
 DOMAIN = "oneoff-testvm.local"
+
+# The snapshot-blocked undefine stderr libvirt emits. The detector matches
+# "cannot delete inactive domain" + "snapshot", not a fixed phrase.
+_SNAPSHOT_BLOCK = (
+    "error: Failed to undefine domain: cannot delete inactive domain with 2 snapshots"
+)
 
 
 def _ok() -> subprocess.CompletedProcess[str]:
@@ -41,22 +43,16 @@ def _ok() -> subprocess.CompletedProcess[str]:
     )
 
 
-# ---------------------------------------------------------------------------
-# undefine_with_snapshot_cleanup
-# ---------------------------------------------------------------------------
-
-
-def test_undefine_clean_path_does_not_touch_snapshots(
+def test_undefine_clean_path_uses_no_snapshots_flag(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When undefine succeeds, snapshot helpers aren't consulted."""
-    snap_names_mock = mock.Mock()
-    monkeypatch.setattr(sc_mod, "virsh_snapshot_names", snap_names_mock)
-    monkeypatch.setattr(sc_mod, "run_virsh", mock.Mock(return_value=_ok()))
+    """A domain with no snapshots is undefined plainly — no --snapshots-metadata."""
+    run = mock.Mock(return_value=_ok())
+    monkeypatch.setattr(sc_mod, "run_virsh", run)
 
     undefine_with_snapshot_cleanup(URI, DOMAIN)  # Must not raise.
 
-    snap_names_mock.assert_not_called()
+    run.assert_called_once_with(URI, ["undefine", DOMAIN])
 
 
 def test_undefine_non_snapshot_error_propagates(
@@ -64,173 +60,60 @@ def test_undefine_non_snapshot_error_propagates(
 ) -> None:
     """A failure unrelated to snapshots is re-raised as-is.
 
-    Real-bug surface: silently retrying on unrelated errors masks bugs
-    (e.g. URI unreachable, permission denied). Lock the
-    snapshot-specific match.
+    Real-bug surface: silently retrying on unrelated errors (URI
+    unreachable, permission denied) masks bugs. Lock the snapshot-specific
+    match — and prove no --snapshots-metadata retry happens.
     """
     err = VirshError(1, "error: failed to connect to the hypervisor", ["undefine"])
-    monkeypatch.setattr(sc_mod, "run_virsh", mock.Mock(side_effect=err))
+    run = mock.Mock(side_effect=err)
+    monkeypatch.setattr(sc_mod, "run_virsh", run)
 
     with pytest.raises(VirshError, match="failed to connect"):
         undefine_with_snapshot_cleanup(URI, DOMAIN)
 
+    # Only the first plain undefine was attempted; no metadata retry.
+    assert run.call_count == 1
 
-def test_undefine_snapshot_blocked_triggers_cleanup_then_retries(
+
+def test_undefine_snapshot_blocked_retries_with_snapshots_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The snapshot-blocked failure path runs delete_all_snapshots, then retries undefine."""
-    # First undefine: snapshot-blocked. Second undefine: success.
-    snapshot_block = VirshError(
-        1,
-        "error: Failed to undefine domain: cannot delete inactive domain with 2 snapshots",
-        ["undefine"],
-    )
+    """A snapshot-blocked undefine retries once with --snapshots-metadata (the one-shot).
 
+    This is the issue #96 behaviour: drop the domain + all snapshot
+    metadata in a single wording-independent call, replacing the old
+    snapshot-delete loop.
+    """
     calls: list[list[str]] = []
 
     def fake_run(uri: str, args: list[str], **kwargs):
         calls.append(args)
-        # First undefine fails; subsequent virsh calls (snapshot-delete + retry undefine) succeed.
-        if args[0] == "undefine" and not any(
-            c[0] == "snapshot-delete" for c in calls[:-1]
-        ):
-            raise snapshot_block
+        # First (plain) undefine: snapshot-blocked. Retry: success.
+        if args == ["undefine", DOMAIN]:
+            raise VirshError(1, _SNAPSHOT_BLOCK, ["undefine"])
         return _ok()
 
-    snap_names = mock.Mock(
-        side_effect=[["snap1"], []]
-    )  # one snap, then empty after delete
-
     monkeypatch.setattr(sc_mod, "run_virsh", fake_run)
-    monkeypatch.setattr(sc_mod, "virsh_snapshot_names", snap_names)
 
     undefine_with_snapshot_cleanup(URI, DOMAIN)
 
-    # Sequence: undefine (fails) -> snapshot-delete --children -> undefine (succeeds)
-    cmds = [c[0] for c in calls]
-    assert cmds == ["undefine", "snapshot-delete", "undefine"], cmds
+    assert calls == [
+        ["undefine", DOMAIN],
+        ["undefine", DOMAIN, "--snapshots-metadata"],
+    ]
 
 
-# ---------------------------------------------------------------------------
-# delete_all_snapshots
-# ---------------------------------------------------------------------------
-
-
-def test_delete_all_snapshots_no_snapshots_is_no_op(
+def test_undefine_snapshots_metadata_retry_failure_propagates(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An empty snapshot list means immediate return; run_virsh is never called."""
-    snap_names = mock.Mock(return_value=[])
-    run = mock.Mock()
-    monkeypatch.setattr(sc_mod, "virsh_snapshot_names", snap_names)
-    monkeypatch.setattr(sc_mod, "run_virsh", run)
-
-    delete_all_snapshots(URI, DOMAIN)
-
-    run.assert_not_called()
-
-
-def test_delete_all_snapshots_uses_children_flag_by_default(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Each snapshot is deleted with the --children cascading flag first."""
-    # Three snapshots; each deletion shrinks the list by one.
-    snap_lists = [["a", "b", "c"], ["b", "c"], ["c"], []]
-    snap_names = mock.Mock(side_effect=snap_lists)
-    monkeypatch.setattr(sc_mod, "virsh_snapshot_names", snap_names)
-
-    deleted: list[str] = []
+    """If the --snapshots-metadata retry also fails, that error propagates."""
 
     def fake_run(uri: str, args: list[str], **kwargs):
-        # args is like ["snapshot-delete", domain, "--snapshotname", name, "--children"]
-        assert args[0] == "snapshot-delete"
-        assert args[-1] == "--children"
-        deleted.append(args[3])
-        return _ok()
+        if args == ["undefine", DOMAIN]:
+            raise VirshError(1, _SNAPSHOT_BLOCK, ["undefine"])
+        raise VirshError(1, "error: something else went wrong", ["undefine"])
 
     monkeypatch.setattr(sc_mod, "run_virsh", fake_run)
 
-    delete_all_snapshots(URI, DOMAIN)
-
-    assert deleted == ["a", "b", "c"]
-
-
-# Real ``virsh snapshot-delete --children`` stderr seen in the wild. libvirt
-# 12.0.0 emits BOTH of these on one host depending on the snapshot's position
-# in the chain, and the exact phrasing has shifted across versions — so the
-# detector must match the family, not one fixed phrase (issue #95).
-_EXTERNAL_SNAPSHOT_WORDINGS = [
-    # Parent-with-children (matched the pre-#95 exact-string marker).
-    "error: unsupported configuration: external children disk snapshots not supported",
-    # Leaf / newer wording (the one that aborted teardown on the user's host).
-    "error: unsupported configuration: "
-    "deletion of external disk snapshots with children not supported",
-]
-
-
-@pytest.mark.parametrize("stderr_msg", _EXTERNAL_SNAPSHOT_WORDINGS)
-def test_delete_all_snapshots_falls_back_to_metadata_on_external_children(
-    monkeypatch: pytest.MonkeyPatch,
-    stderr_msg: str,
-) -> None:
-    """A --children failure naming an unsupported external snapshot → retry with --metadata.
-
-    Regression for issue #95: the fallback must fire for every libvirt
-    wording of the external-snapshot limitation, not just the one phrase
-    the original exact-substring marker happened to carry.
-    """
-    snap_lists = [["only-snap"], []]
-    snap_names = mock.Mock(side_effect=snap_lists)
-    monkeypatch.setattr(sc_mod, "virsh_snapshot_names", snap_names)
-
-    external_children_err = VirshError(1, stderr_msg, ["snapshot-delete"])
-
-    calls: list[list[str]] = []
-
-    def fake_run(uri: str, args: list[str], **kwargs):
-        calls.append(args)
-        # First call (--children): fail with external-snapshot message.
-        # Second call (--metadata): succeed.
-        if args[-1] == "--children":
-            raise external_children_err
-        return _ok()
-
-    monkeypatch.setattr(sc_mod, "run_virsh", fake_run)
-
-    delete_all_snapshots(URI, DOMAIN)
-
-    # Two calls: one with --children (failing), one with --metadata (succeeding).
-    assert len(calls) == 2
-    assert calls[0][-1] == "--children"
-    assert calls[1][-1] == "--metadata"
-
-
-def test_delete_all_snapshots_other_children_failure_propagates(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A --children failure that isn't 'external children' propagates."""
-    snap_names = mock.Mock(side_effect=[["snap1"], []])
-    monkeypatch.setattr(sc_mod, "virsh_snapshot_names", snap_names)
-
-    other_err = VirshError(
-        1,
-        "error: invalid argument: somehow this is a different problem",
-        ["snapshot-delete"],
-    )
-    monkeypatch.setattr(sc_mod, "run_virsh", mock.Mock(side_effect=other_err))
-
-    with pytest.raises(VirshError, match="different problem"):
-        delete_all_snapshots(URI, DOMAIN)
-
-
-def test_delete_all_snapshots_progress_stall_raises(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """If the snapshot list is the same on consecutive passes, we refuse to loop forever."""
-    # virsh_snapshot_names returns the same list twice in a row.
-    snap_names = mock.Mock(side_effect=[["stuck"], ["stuck"]])
-    monkeypatch.setattr(sc_mod, "virsh_snapshot_names", snap_names)
-    monkeypatch.setattr(sc_mod, "run_virsh", mock.Mock(return_value=_ok()))
-
-    with pytest.raises(VirshError, match="stalled"):
-        delete_all_snapshots(URI, DOMAIN)
+    with pytest.raises(VirshError, match="something else went wrong"):
+        undefine_with_snapshot_cleanup(URI, DOMAIN)


### PR DESCRIPTION
Closes #96.

## Evaluation (the issue's ask)
Verified the virt-manager one-shot on **real libvirt 12.0.0 / QEMU 10.2.2** against a throwaway, prefixed domain with an external snapshot chain (`snap1` → `snap2`):
```
$ virsh undefine <dom>                       # plain
error: ... cannot delete inactive domain with 2 snapshots
$ virsh undefine <dom> --snapshots-metadata  # one-shot
Domain '<dom>' has been undefined            # exit 0; domain + all snapshot metadata gone
```
Overlay qcow2 files remain (same as before) — the teardown `rmtree`s the VM dir next, so nothing is orphaned.

**Decision (per the issue's criterion "if cleaner & passes, replace the loop"):** it's genuinely cleaner and **wording-independent**, so it structurally can't regress the way #95 did (one libvirt version emitting two different "external snapshot unsupported" phrasings broke the exact-string fallback). Replace the loop.

## Changes
- `undefine_with_snapshot_cleanup`: try `undefine`; on the snapshot-blocked error, retry `undefine --snapshots-metadata`. Removed the `delete_all_snapshots` loop + the external-children token matcher (superseded).
- `Machine.destroy` (`_DomainDestroyer`) and `deletevm` route undefine through it; the separate pre-undefine snapshot-delete step is gone.
- **Consent preserved:** deletevm's tier-1/tier-2 prompts and `--force --snapshots-too` are unchanged — they still gate whether we reach the one-shot undefine for a snapshot-bearing VM.
- **No change for `--nvram` / `--managed-save`:** neither old nor new path passes them, so the one-shot is identical there (the issue flagged checking this).
- `_SnapshotManager` keeps its single-snapshot ops (the `lvlab snapshot` commands); only its now-unused `delete_all` was removed.

## Tests
Rewrote `test_snapshot_cleanup` for the one-shot (clean undefine uses no flag; non-snapshot error propagates; snapshot-blocked retries with `--snapshots-metadata`; retry-failure propagates). Updated the lifecycle + deletevm teardown tests (both modules' `run_virsh` funneled into one mock to keep ordering assertions); removed the obsolete separate-snapshot-step tests. Full suite **520 passed, 39 skipped**. `pre-commit` + `zensical build -s` clean. Real-libvirt verified (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)