### PR TITLE
feat(init): concurrent downloads + compact live progress table (#104)

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -78,6 +78,11 @@ no need to duplicate images for multiple environments. Unreferenced
 images can be removed with [`lvlab images clean`](#images-clean) (dry-run
 by default).
 
+Images are fetched a few at a time (`--jobs`, default 2). On a terminal
+`init` shows a compact live progress table (image / phase / a segmented
+download bar); when output is piped or redirected it degrades to plain
+per-image completion lines (no ANSI), so logs stay readable.
+
 Downloads tolerate flaky mirrors (connect/read timeouts, retry, and
 resume via a `.partial` file). If a download still fails — a 404, a
 refused connection, or a mirror that simply won't serve a file — `init`

--- a/src/tkc_lvlab/cli.py
+++ b/src/tkc_lvlab/cli.py
@@ -29,17 +29,22 @@ module does not flow through them.
 
 from __future__ import annotations
 
+import concurrent.futures
+import dataclasses
 import os
+import threading
 from typing import Any
 
 import typer
 from rich.console import Console
+from rich.live import Live
 from rich.table import Table
 
 from ._logging import configure_logging, get_logger
 from .utils.catalog import BUILTIN_IMAGES, resolve_catalog
 from .utils.output import (
     get_console,
+    is_tty,
     render_one_time_password,
     render_ssh_hint,
     styled_table,
@@ -627,109 +632,240 @@ def ssh_config(vm_name: str = typer.Argument(None)) -> None:
     typer.echo("\n\n".join(snippets))
 
 
-def _init_ensure_image(image: CloudImage) -> None:
-    """Ensure the cloud image qcow2 is on disk; emit status."""
-    if image.exists_locally("image"):
-        typer.echo(f"CloudImage {image.name} exists locally: {image.image_fpath}")
-        return
-    logger.info("Attempting to download image: %s", image.image_url)
-    if image.download_image():
-        typer.echo(f"CloudImage downloaded to {image.image_fpath}")
-    else:
-        logger.error("CloudImage download failed")
+# ---------------------------------------------------------------------------
+# init: concurrent per-image download + verify with a compact progress view
+# (issue #104)
+# ---------------------------------------------------------------------------
 
 
-def _init_ensure_checksum_gpg(image: CloudImage) -> None:
-    """Ensure the checksum-file GPG keyring is on disk; emit status."""
-    if image.exists_locally(file_type="checksum_gpg"):
-        typer.echo(
-            f"CloudImage {image.name} checksum GPG file exists locally: "
-            f"{image.checksum_gpg_fpath}"
-        )
-        return
-    if image.download_checksum_gpg():
-        typer.echo(
-            f"CloudImage checksum GPG file downloaded to {image.checksum_gpg_fpath}"
-        )
-    else:
-        logger.error("CloudImage checksum GPG file download failed")
+@dataclasses.dataclass
+class _ImageInitState:
+    """Mutable per-image progress for the ``lvlab init`` display (issue #104)."""
+
+    name: str
+    phase: str = "pending"
+    bytes_done: int = 0
+    bytes_total: int = 0
+    error: str = ""
 
 
-def _init_ensure_checksum(image: CloudImage) -> None:
-    """Ensure the checksum manifest is on disk; emit status."""
-    if image.exists_locally(file_type="checksum"):
-        typer.echo(
-            f"CloudImage {image.name} checksum file exists locally: "
-            f"{image.checksum_fpath}"
-        )
-        return
-    logger.info("Attempting to download checksum file URL: %s", image.checksum_url)
-    if image.download_checksum():
-        typer.echo(
-            f"CloudImage {image.name} checksum file downloaded to "
-            f"{image.checksum_fpath}"
-        )
-    else:
-        logger.error("CloudImage %s checksum file download failed", image.name)
+class _InitProgress:
+    """Thread-safe per-image progress shared by init workers and the renderer.
+
+    Worker threads mutate state through the setters (guarded by a lock); the
+    main thread reads consistent snapshots to render, so every Rich call stays
+    on the main thread and the workers never render.
+    """
+
+    def __init__(self, names: list[str]) -> None:
+        self._lock = threading.Lock()
+        self._order = list(names)
+        self._states = {n: _ImageInitState(n) for n in names}
+
+    def set_phase(self, name: str, phase: str) -> None:
+        """Set an image's phase (e.g. ``downloading`` / ``verifying`` / ``done``)."""
+        with self._lock:
+            self._states[name].phase = phase
+
+    def set_bytes(self, name: str, done: int, total: int) -> None:
+        """Record download byte progress for an image (the download callback)."""
+        with self._lock:
+            state = self._states[name]
+            state.phase = "downloading"
+            state.bytes_done = done
+            state.bytes_total = total
+
+    def set_error(self, name: str, message: str) -> None:
+        """Mark an image failed with a message (a fatal download/verify error)."""
+        with self._lock:
+            state = self._states[name]
+            state.phase = "failed"
+            state.error = message
+
+    def snapshot(self) -> list["_ImageInitState"]:
+        """Return a consistent copy of every image's state, in declared order."""
+        with self._lock:
+            return [dataclasses.replace(self._states[n]) for n in self._order]
 
 
-def _init_verify_gpg(image: CloudImage) -> None:
-    """Run GPG verification on the checksum file; emit OK/BAD status."""
-    if image.gpg_verify_checksum_file():
-        typer.echo(f"CloudImage {image.name} checksum file GPG validation OK")
-    else:
-        logger.error("CloudImage %s checksum file GPG validation BAD", image.name)
+def _format_bytes(num: int) -> str:
+    """Compact binary-unit byte string for the progress cell."""
+    value = float(num)
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if value < 1024 or unit == "GiB":
+            return f"{value:.0f}{unit}" if unit == "B" else f"{value:.1f}{unit}"
+        value /= 1024
+    return f"{num}B"
 
 
-def _init_verify_checksum(image: CloudImage) -> None:
-    """Hash-verify the image against the manifest; emit OK/BAD status."""
-    if image.checksum_verify_image():
-        typer.echo(f"CloudImage {image.name} checksum verification OK")
-    else:
-        logger.error("CloudImage %s checksum verification BAD", image.name)
+def _init_progress_cell(state: "_ImageInitState") -> str:
+    """Render the compact progress cell for one image row.
+
+    A segmented block bar with a percentage when the total is known; the raw
+    byte count for a content-encoded body (unknown total); a check / cross for
+    done / failed.
+    """
+    if state.phase == "done":
+        return "[green]✓[/green]"
+    if state.phase == "failed":
+        return f"[red]✗ {state.error}[/red]"
+    if state.phase == "downloading" and state.bytes_total > 0:
+        pct = int(state.bytes_done * 100 / state.bytes_total)
+        filled = max(0, min(10, pct // 10))
+        return f"{'█' * filled}{'░' * (10 - filled)} {pct:3d}%"
+    if state.phase == "downloading" and state.bytes_done:
+        return _format_bytes(state.bytes_done)
+    return ""
 
 
-def _init_process_image(image: CloudImage) -> None:
-    """Download and verify one CloudImage's artefacts in order."""
-    _init_ensure_image(image)
-    if image.checksum_url_gpg:
-        _init_ensure_checksum_gpg(image)
-    if image.checksum_url:
-        _init_ensure_checksum(image)
-    if image.checksum_url_gpg and image.exists_locally(file_type="checksum_gpg"):
-        _init_verify_gpg(image)
-    if image.checksum_url and image.exists_locally(file_type="checksum"):
-        _init_verify_checksum(image)
+def _render_init_table(
+    states: list["_ImageInitState"], *, env_name: str, jobs: int
+) -> Table:
+    """Build the init progress table from a state snapshot."""
+    table = styled_table(
+        title=f"lvlab init — {env_name} · {len(states)} images · {jobs} concurrent"
+    )
+    table.add_column("image", style="bold")
+    table.add_column("phase")
+    table.add_column("progress")
+    for state in states:
+        table.add_row(state.name, state.phase, _init_progress_cell(state))
+    return table
+
+
+def _init_image_worker(image: CloudImage, progress: "_InitProgress") -> bool:
+    """Download + verify one image, updating ``progress``. Returns False on a fatal error.
+
+    Mirrors the previous sequential pipeline's control flow: a transport/HTTP
+    failure (``ImageError`` / ``LvlabError``) is fatal (returns False, so init
+    exits 1); a content-length mismatch or a verify failure is logged but
+    non-fatal (returns True), preserving the prior exit-0 behaviour.
+    """
+    name = image.name
+    try:
+        if not image.exists_locally("image"):
+            progress.set_phase(name, "downloading")
+            if not image.download_image(
+                progress_callback=lambda done, total: progress.set_bytes(
+                    name, done, total
+                )
+            ):
+                logger.error("CloudImage download failed")
+        if image.checksum_url_gpg and not image.exists_locally("checksum_gpg"):
+            progress.set_phase(name, "gpg")
+            if not image.download_checksum_gpg():
+                logger.error("CloudImage %s checksum GPG file download failed", name)
+        if image.checksum_url and not image.exists_locally("checksum"):
+            progress.set_phase(name, "checksum")
+            if not image.download_checksum():
+                logger.error("CloudImage %s checksum file download failed", name)
+        progress.set_phase(name, "verifying")
+        if image.checksum_url_gpg and image.exists_locally("checksum_gpg"):
+            if not image.gpg_verify_checksum_file():
+                logger.error("CloudImage %s checksum file GPG validation BAD", name)
+        if image.checksum_url and image.exists_locally("checksum"):
+            if not image.checksum_verify_image():
+                logger.error("CloudImage %s checksum verification BAD", name)
+        progress.set_phase(name, "done")
+        return True
+    except LvlabError as exc:
+        # Clean boundary (issue #98): a transport/HTTP failure surfaces the
+        # ImageError's actionable message + workaround, not a traceback.
+        logger.error("%s", exc)
+        progress.set_error(name, str(exc))
+        return False
+
+
+def _run_init_concurrent(
+    built: list[CloudImage], progress: "_InitProgress", *, jobs: int, env_name: str
+) -> list[bool]:
+    """Run the per-image workers concurrently, rendering progress.
+
+    On a terminal, a Rich ``Live`` table is refreshed from the main thread off
+    the shared (locked) progress state; piped/redirected output degrades to
+    plain per-image completion lines (no ANSI / no Live), so logs stay clean.
+
+    Returns:
+        A list of per-image booleans (``False`` = a fatal error occurred).
+    """
+    if is_tty():
+        console = get_console()
+        with Live(console=console, refresh_per_second=8) as live:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
+                futures = [
+                    pool.submit(_init_image_worker, img, progress) for img in built
+                ]
+                pending = set(futures)
+                while pending:
+                    _done, pending = concurrent.futures.wait(pending, timeout=0.2)
+                    live.update(
+                        _render_init_table(
+                            progress.snapshot(), env_name=env_name, jobs=jobs
+                        )
+                    )
+            live.update(
+                _render_init_table(progress.snapshot(), env_name=env_name, jobs=jobs)
+            )
+        return [f.result() for f in futures]
+
+    # Non-TTY: plain incremental lines, no ANSI / no Live.
+    results: list[bool] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=jobs) as pool:
+        futures = {
+            pool.submit(_init_image_worker, img, progress): img.name for img in built
+        }
+        for fut in concurrent.futures.as_completed(futures):
+            name = futures[fut]
+            ok = fut.result()
+            state = next(s for s in progress.snapshot() if s.name == name)
+            status = (
+                "done"
+                if ok and state.phase != "failed"
+                else f"FAILED ({state.error or 'see log'})"
+            )
+            typer.echo(f"  {name}: {status}")
+            results.append(ok)
+    return results
 
 
 @app.command()
-def init() -> None:
+def init(
+    jobs: int = typer.Option(
+        2,
+        "--jobs",
+        "-j",
+        min=1,
+        help="Number of images to download/verify concurrently (default 2).",
+    ),
+) -> None:
     """Initialize cloud images: the manifest's, or the built-in defaults.
 
-    With an ``Lvlab.yml`` in the current directory, downloads and verifies
-    the images its ``images:`` section names. **With no manifest, it
-    initializes the built-in default catalog** (issue #97) — so a bare
-    ``lvlab init`` works without writing a manifest first, and is the single
-    image-init path (`createvm --init-cloud-images` is deprecated in favour
-    of it).
+    With an ``Lvlab.yml`` in the current directory, downloads and verifies the
+    images its ``images:`` section names. **With no manifest, it initializes
+    the built-in default catalog** (issue #97). Images are fetched a few at a
+    time (``--jobs``), with a compact live progress table on a terminal that
+    degrades to plain per-image lines when output is piped (issue #104).
     """
     environment, images, config_defaults = _init_image_source()
+    env_name = environment.get("name", "default")
+
+    if not images:
+        typer.echo("No images to initialize.")
+        return
+
+    built = [
+        CloudImage(name, cfg, environment, config_defaults)
+        for name, cfg in images.items()
+    ]
+    progress = _InitProgress([img.name for img in built])
 
     typer.echo()
-    typer.echo(f'Initializing Libvirt Lab Environment: {environment["name"]}\n')
+    typer.echo(f"Initializing Libvirt Lab Environment: {env_name}\n")
 
-    for image_name, image_config in images.items():
-        image = CloudImage(image_name, image_config, environment, config_defaults)
-        try:
-            _init_process_image(image)
-        except LvlabError as exc:
-            # Clean boundary (issue #98): a download/verify failure (e.g. a
-            # gzip-served sidecar that 416s, a 404, connection refused) surfaces
-            # as the ImageError's actionable message + workaround, not a
-            # traceback.
-            logger.error("%s", exc)
-            raise typer.Exit(code=1)
-        typer.echo()
+    results = _run_init_concurrent(built, progress, jobs=jobs, env_name=env_name)
+
+    if not all(results):
+        raise typer.Exit(code=1)
 
 
 def _init_image_source() -> tuple[dict, dict, dict]:

--- a/src/tkc_lvlab/utils/images.py
+++ b/src/tkc_lvlab/utils/images.py
@@ -30,7 +30,7 @@ import re
 import subprocess
 import time
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import urlparse
 
 import gnupg
@@ -43,6 +43,12 @@ from .catalog import derive_os_variant, derive_username
 
 
 logger = get_logger(__name__)
+
+#: ``callback(bytes_done, total)`` for download progress reporting. ``total``
+#: is ``0`` when the server advertised no usable content length. Lets callers
+#: (``lvlab init``, issue #104) drive their own display instead of the
+#: built-in tqdm bar.
+ProgressCallback = Callable[[int, int], None]
 
 VERIFIED_SUFFIX = ".verified"
 
@@ -214,7 +220,13 @@ class CloudImage:  # pylint: disable=too-many-instance-attributes
         return isinstance(exc, _TRANSIENT_EXCEPTIONS)
 
     @classmethod
-    def _stream_to_partial(cls, url: str, partial_path: str) -> bool:
+    def _stream_to_partial(
+        cls,
+        url: str,
+        partial_path: str,
+        *,
+        progress_callback: "ProgressCallback | None" = None,
+    ) -> bool:
         """Stream ``url`` into ``<destination>.partial``, resuming when possible.
 
         Performs a single attempt. If a ``.partial`` file already exists from a
@@ -227,6 +239,12 @@ class CloudImage:  # pylint: disable=too-many-instance-attributes
         Args:
             url: HTTP(S) URL to download.
             partial_path: Path to the ``.partial`` scratch file.
+            progress_callback: Optional ``callback(bytes_done, total)`` invoked
+                as bytes arrive (``total`` is ``0`` when the server advertised
+                no usable length, e.g. a content-encoded body). When supplied,
+                it replaces the built-in ``tqdm`` bar so callers (``lvlab
+                init``) can drive their own display; when ``None`` the ``tqdm``
+                bar is used (issue #104).
 
         Returns:
             ``True`` when the partial is complete (advertised length matched the
@@ -303,16 +321,26 @@ class CloudImage:  # pylint: disable=too-many-instance-attributes
 
         block_size = 1024
         mode = "ab" if resuming else "wb"
-        with tqdm(
-            total=total_size,
-            initial=already,
-            unit="B",
-            unit_scale=True,
-        ) as progress_bar:
+        if progress_callback is not None:
+            # Caller drives its own display (issue #104) — report monotonic
+            # byte progress instead of owning a tqdm bar.
+            done = already
             with open(partial_path, mode) as file:
                 for data in response.iter_content(block_size):
-                    progress_bar.update(len(data))
                     file.write(data)
+                    done += len(data)
+                    progress_callback(done, total_size)
+        else:
+            with tqdm(
+                total=total_size,
+                initial=already,
+                unit="B",
+                unit_scale=True,
+            ) as progress_bar:
+                with open(partial_path, mode) as file:
+                    for data in response.iter_content(block_size):
+                        progress_bar.update(len(data))
+                        file.write(data)
 
         if total_size and os.path.getsize(partial_path) != total_size:
             return False
@@ -320,7 +348,13 @@ class CloudImage:  # pylint: disable=too-many-instance-attributes
         return True
 
     @classmethod
-    def _download_file(cls, url: str, destination: str) -> bool:
+    def _download_file(
+        cls,
+        url: str,
+        destination: str,
+        *,
+        progress_callback: "ProgressCallback | None" = None,
+    ) -> bool:
         """Download a URL to a local file, tolerant of transient mirror failures.
 
         Streams into ``<destination>.partial`` with a connect/read timeout
@@ -340,6 +374,8 @@ class CloudImage:  # pylint: disable=too-many-instance-attributes
         Args:
             url: HTTP(S) URL to download.
             destination: Local filesystem path to write to on success.
+            progress_callback: Optional ``callback(bytes_done, total)`` passed
+                through to :meth:`_stream_to_partial` (issue #104).
 
         Returns:
             ``True`` on a complete, verified-length write. ``False`` if every
@@ -369,7 +405,9 @@ class CloudImage:  # pylint: disable=too-many-instance-attributes
                 time.sleep(backoff)
 
             try:
-                if cls._stream_to_partial(url, partial_path):
+                if cls._stream_to_partial(
+                    url, partial_path, progress_callback=progress_callback
+                ):
                     os.replace(partial_path, destination)
                     return True
                 # Incomplete transfer (content-length mismatch). Treat like a
@@ -401,7 +439,13 @@ class CloudImage:  # pylint: disable=too-many-instance-attributes
         return False
 
     @classmethod
-    def _download_or_raise(cls, url: str, destination: str) -> bool:
+    def _download_or_raise(
+        cls,
+        url: str,
+        destination: str,
+        *,
+        progress_callback: "ProgressCallback | None" = None,
+    ) -> bool:
         """Download ``url`` to ``destination``, raising a clean ImageError on failure.
 
         Thin wrapper over :meth:`_download_file` that translates the raw
@@ -424,7 +468,9 @@ class CloudImage:  # pylint: disable=too-many-instance-attributes
             ImageError: The download failed with a transport or HTTP error.
         """
         try:
-            return cls._download_file(url, destination)
+            return cls._download_file(
+                url, destination, progress_callback=progress_callback
+            )
         except requests.RequestException as exc:
             response = getattr(exc, "response", None)
             status = getattr(response, "status_code", None)
@@ -445,17 +491,25 @@ class CloudImage:  # pylint: disable=too-many-instance-attributes
             logger.info("CloudImage creating image directory: %s", image_dir)
             os.makedirs(image_dir, exist_ok=True)
 
-    def download_image(self) -> bool:
+    def download_image(
+        self, *, progress_callback: "ProgressCallback | None" = None
+    ) -> bool:
         """Download the cloud image to :attr:`image_fpath`.
 
         Creates the cache directory if needed. Returns ``True`` on
         successful download, ``False`` on content-length mismatch.
 
+        Args:
+            progress_callback: Optional ``callback(bytes_done, total)`` for
+                progress reporting (issue #104).
+
         Raises:
             ImageError: The download failed with a transport or HTTP error.
         """
         self._manage_image_dir()
-        return self._download_or_raise(self.image_url, self.image_fpath)
+        return self._download_or_raise(
+            self.image_url, self.image_fpath, progress_callback=progress_callback
+        )
 
     def download_checksum(self) -> bool:
         """Download the checksum manifest to :attr:`checksum_fpath`.

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -72,7 +72,9 @@ def test_init_downloads_all_artefacts_when_nothing_local() -> None:
     img.gpg_verify_checksum_file.assert_not_called()
     img.checksum_verify_image.assert_not_called()
     assert "Initializing Libvirt Lab Environment: test-env" in result.output
-    assert "CloudImage downloaded to /tmp/fedora44/image.qcow2" in result.output
+    # Compact concurrent output (issue #104): a per-image completion line.
+    assert "fedora44" in result.output
+    assert "done" in result.output
 
 
 def test_init_verifies_when_all_artefacts_already_local() -> None:
@@ -87,11 +89,10 @@ def test_init_verifies_when_all_artefacts_already_local() -> None:
     img.download_checksum_gpg.assert_not_called()
     img.gpg_verify_checksum_file.assert_called_once()
     img.checksum_verify_image.assert_called_once()
-    assert "CloudImage fedora44 exists locally" in result.output
-    assert "CloudImage fedora44 checksum file exists locally" in result.output
-    assert "CloudImage fedora44 checksum GPG file exists locally" in result.output
-    assert "CloudImage fedora44 checksum file GPG validation OK" in result.output
-    assert "CloudImage fedora44 checksum verification OK" in result.output
+    # The verifiers fired (the behavioural contract); the compact #104 output
+    # reports the image's completion rather than per-step status lines.
+    assert "fedora44" in result.output
+    assert "done" in result.output
 
 
 def test_init_skips_gpg_branch_when_image_has_no_gpg_url() -> None:
@@ -211,3 +212,52 @@ def test_init_with_no_manifest_still_fails_on_bad_manifest() -> None:
 
     assert result.exit_code == 1
     cloud_image_cls.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Concurrent init: progress state, cell rendering, failure isolation (#104)
+# ---------------------------------------------------------------------------
+
+
+def test_init_progress_state_snapshot_reflects_updates() -> None:
+    """_InitProgress setters update state; snapshot returns a consistent copy."""
+    progress = cli._InitProgress(["a", "b"])
+    progress.set_bytes("a", 50, 100)  # set_bytes implies the downloading phase
+    progress.set_phase("b", "verifying")
+
+    snap = {s.name: s for s in progress.snapshot()}
+    assert snap["a"].phase == "downloading"
+    assert snap["a"].bytes_done == 50 and snap["a"].bytes_total == 100
+    assert snap["b"].phase == "verifying"
+
+
+def test_init_progress_cell_renders_bar_done_and_failed() -> None:
+    """The compact cell shows a % bar while downloading, ✓ done, ✗ failed."""
+    downloading = cli._ImageInitState(
+        "x", phase="downloading", bytes_done=61, bytes_total=100
+    )
+    assert "%" in cli._init_progress_cell(downloading)
+    assert "61%" in cli._init_progress_cell(downloading)
+
+    done = cli._ImageInitState("x", phase="done")
+    assert "✓" in cli._init_progress_cell(done)
+
+    failed = cli._ImageInitState("x", phase="failed", error="HTTP 404")
+    cell = cli._init_progress_cell(failed)
+    assert "✗" in cell and "HTTP 404" in cell
+
+
+def test_init_one_image_failure_exits_1_others_still_processed() -> None:
+    """A fatal ImageError on one image fails init (exit 1) but doesn't wedge the rest."""
+    from tkc_lvlab.exceptions import ImageError
+
+    good = _mock_image("debian12", has_gpg=False, has_checksum=False)
+    bad = _mock_image("fedora44", has_gpg=False, has_checksum=False)
+    bad.download_image.side_effect = ImageError("could not download")
+
+    result = _run_init([good, bad])
+
+    assert result.exit_code == 1
+    # The healthy image was still processed despite the other's failure.
+    good.download_image.assert_called_once()
+    bad.download_image.assert_called_once()

--- a/tests/test_images_download.py
+++ b/tests/test_images_download.py
@@ -310,3 +310,33 @@ def test_download_or_raise_wraps_http_error_with_workaround(tmp_path: Path) -> N
     assert "HTTP 404" in message
     assert str(destination) in message
     assert "place the file manually" in message
+
+
+def test_download_file_progress_callback_reports_monotonic_bytes(
+    tmp_path: Path,
+) -> None:
+    """With a progress_callback, bytes are reported monotonically up to the total.
+
+    The callback decouples progress from the display (issue #104) so callers
+    like `lvlab init` can drive their own rendering instead of the tqdm bar.
+    """
+    destination = tmp_path / "image.qcow2"
+    payload = b"z" * 4500  # several 1024-byte chunks
+    resp = _FakeResponse(body=payload)
+
+    seen: list[tuple[int, int]] = []
+
+    with patch("tkc_lvlab.utils.images.requests.get", return_value=resp):
+        with patch("tkc_lvlab.utils.images.time.sleep"):
+            result = CloudImage._download_file(
+                "https://mirror.example/image.qcow2",
+                str(destination),
+                progress_callback=lambda done, total: seen.append((done, total)),
+            )
+
+    assert result is True
+    assert seen, "callback was never invoked"
+    done_values = [d for d, _ in seen]
+    assert done_values == sorted(done_values)  # monotonic non-decreasing
+    assert done_values[-1] == len(payload)  # ends at the full size
+    assert all(total == len(payload) for _, total in seen)


### PR DESCRIPTION
Closes #104.

`lvlab init` downloaded images strictly one-at-a-time behind full-width **tqdm** bars that dominated the terminal and mauled narrow/resized windows.

## Changes
- **Progress callback** (the refactor deferred from #98): the download primitive (`_stream_to_partial` → `_download_file` → `_download_or_raise` → `download_image`) takes an optional `progress_callback(bytes_done, total)` and reports through it instead of owning a tqdm bar. **No callback → still uses tqdm**, so `createvm`'s download UX is unchanged.
- **Concurrent init**: images are downloaded/verified a few at a time via a `ThreadPoolExecutor` (**`--jobs` / `-j`, default 2**) over a thread-safe `_InitProgress`. Workers only mutate the locked state; **all Rich rendering stays on the main thread** (the safe pattern).
- **Compact display**: on a terminal, a Rich `Live` table (image / phase / segmented download bar) replaces tqdm; **piped/redirected output degrades to plain per-image lines** (no ANSI) so logs stay clean.
- **Control flow preserved**: an `ImageError`/`LvlabError` is fatal (exit 1); a content-length mismatch or verify failure is logged but non-fatal (exit 0) — matching the prior behaviour exactly.

## tqdm
Stays a dependency — `createvm`'s download path still uses it (no callback). Fully dropping it waits for the createvm output conversion (#107). Noted in the issue/epic.

## Tests
- Progress callback reports **monotonic** bytes up to the total.
- `_InitProgress` snapshot reflects setter updates; `_init_progress_cell` renders the bar / ✓ done / ✗ failed.
- **One image's fatal error exits 1 without wedging the rest** (the healthy image is still processed).
- The existing init-pipeline tests keep their method-call assertions (download-if-absent / verify-if-present) and were retargeted from per-step echo strings to the compact output.

Full suite **524 passed, 39 skipped**. `pre-commit` + `zensical build -s` clean. Walkthrough `init` documents `--jobs` + the live/plain display.

> The CliRunner tests exercise the **non-TTY** path (plain lines); the Rich `Live` table is the TTY branch (visual, not unit-tested) but uses the standard main-thread-render-from-locked-state pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)