### PR TITLE
feat(smoke): live-updating per-VM phase table (#101)

### DIFF
--- a/src/tkc_lvlab/smoke.py
+++ b/src/tkc_lvlab/smoke.py
@@ -38,18 +38,21 @@ authoritative source — plus a per-distro overhead allowance from
 
 from __future__ import annotations
 
+import concurrent.futures
 import dataclasses
 import json
 import os
 import platform
 import shutil
 import subprocess
+import threading
 import time
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Sequence
 
 import yaml
+from rich.live import Live
 
 from ._logging import get_logger
 from .config import parse_config
@@ -58,6 +61,7 @@ from .utils.catalog import derive_username
 from .utils.images import CloudImage
 from .utils.libvirt import Machine
 from .utils.network import LibvirtNetworkInfo, get_network_info
+from .utils.output import get_console, is_tty, styled_table
 from .utils.virsh import VirshError, run_virsh
 
 logger = get_logger(__name__)
@@ -896,6 +900,110 @@ def _ssh_probe(
     )
 
 
+# ---------------------------------------------------------------------------
+# Live status table (issue #101)
+# ---------------------------------------------------------------------------
+
+
+class SmokePhase:
+    """The per-case phases shown in the live smoke table (issue #101)."""
+
+    PENDING = "pending"
+    UP = "up"
+    BOOTING = "booting"
+    VERIFYING = "verifying"
+    TEARDOWN = "tearing down"
+    PASS = "PASS"
+    FAIL = "FAIL"
+
+    #: Phases that mean the case is finished (for the running/done footer tally).
+    TERMINAL = frozenset({PASS, FAIL})
+
+
+@dataclass
+class _CaseProgress:
+    """Mutable per-case row state for the live table."""
+
+    vm_name: str
+    mode: str
+    ip: str | None = None
+    phase: str = SmokePhase.PENDING
+
+
+class SmokeProgress:
+    """Thread-safe per-case phase tracker driving the live smoke table.
+
+    Cases run in concurrent batches, so worker threads advance phases
+    through the locked setters while the main thread reads consistent
+    snapshots to render (issue #101) — every Rich call stays on the main
+    thread.
+    """
+
+    def __init__(self, cases: Sequence[SmokeCase]) -> None:
+        self._lock = threading.Lock()
+        self._order = [c.vm_name for c in cases]
+        self._states = {
+            c.vm_name: _CaseProgress(c.vm_name, c.mode, c.static_ip) for c in cases
+        }
+
+    def set_phase(self, vm_name: str, phase: str) -> None:
+        """Advance a case to ``phase``."""
+        with self._lock:
+            self._states[vm_name].phase = phase
+
+    def set_ip(self, vm_name: str, ip: str | None) -> None:
+        """Record a case's resolved IP (a DHCP lease, once it appears)."""
+        with self._lock:
+            self._states[vm_name].ip = ip
+
+    def snapshot(self) -> list["_CaseProgress"]:
+        """Return a consistent copy of every case's state, in declared order."""
+        with self._lock:
+            return [dataclasses.replace(self._states[n]) for n in self._order]
+
+
+def render_smoke_table(states: list["_CaseProgress"], *, pool_size: int):
+    """Build the live smoke status table from a state snapshot (issue #101).
+
+    Args:
+        states: Per-case snapshot from :meth:`SmokeProgress.snapshot`.
+        pool_size: The concurrent batch width, shown in the title.
+
+    Returns:
+        A populated :class:`rich.table.Table` with a running/pending/
+        passed/failed caption.
+    """
+    table = styled_table(
+        title=f"lvlab smoke — {len(states)} cases, pool of {pool_size}"
+    )
+    table.add_column("vm", style="bold")
+    table.add_column("mode")
+    table.add_column("ip")
+    table.add_column("phase")
+
+    passed = failed = pending = running = 0
+    for state in states:
+        table.add_row(
+            state.vm_name,
+            state.mode,
+            state.ip or ("—" if state.mode == "dhcp" else ""),
+            state.phase,
+        )
+        if state.phase == SmokePhase.PASS:
+            passed += 1
+        elif state.phase == SmokePhase.FAIL:
+            failed += 1
+        elif state.phase == SmokePhase.PENDING:
+            pending += 1
+        else:
+            running += 1
+
+    table.caption = (
+        f"running {running} · pending {pending} · passed {passed} · failed {failed}"
+    )
+    return table
+
+
 def _teardown(
     case: SmokeCase, *, lvlab: str, uri: str
 ) -> None:  # pragma: no cover - VM lifecycle
@@ -930,8 +1038,19 @@ def _run_case(
     uri: str,
     network_name: str,
     key_path: str | None,
+    progress: "SmokeProgress | None" = None,
 ) -> CaseResult:  # pragma: no cover - VM lifecycle
-    """Drive the full up -> verify -> down -> destroy lifecycle for one case."""
+    """Drive the full up -> verify -> down -> destroy lifecycle for one case.
+
+    When ``progress`` is supplied, advances the case's phase through it at
+    each step so the live table reflects the run as it proceeds (issue
+    #101).
+    """
+
+    def phase(name: str) -> None:
+        if progress is not None:
+            progress.set_phase(case.vm_name, name)
+
     result = CaseResult(
         distro=case.os,
         vm_name=case.vm_name,
@@ -940,6 +1059,7 @@ def _run_case(
     )
     start = time.monotonic()
 
+    phase(SmokePhase.UP)
     up = subprocess.run(
         [lvlab, "up", case.vm_name],
         stdout=subprocess.PIPE,
@@ -950,19 +1070,25 @@ def _run_case(
     if up.returncode != 0:
         result.detail = f"`lvlab up` failed (rc={up.returncode})"
         result.total_seconds = round(time.monotonic() - start, 1)
+        phase(SmokePhase.TEARDOWN)
         _teardown(case, lvlab=lvlab, uri=uri)
+        phase(SmokePhase.FAIL)
         return result
 
+    phase(SmokePhase.BOOTING)
     ip = (
         case.static_ip
         if case.mode == "static"
         else _resolve_dhcp_ip(case, network_name, uri)
     )
     result.resolved_ip = ip
+    if progress is not None and ip:
+        progress.set_ip(case.vm_name, ip)
 
     if not ip:
         result.detail = "no IP resolved (DHCP lease never appeared)"
     else:
+        phase(SmokePhase.VERIFYING)
         ok, detail = _ssh_probe(case.ssh_user, ip, key_path)
         result.ssh_ok = ok
         result.detail = detail
@@ -970,9 +1096,73 @@ def _run_case(
             result.boot_to_ssh_seconds = round(time.monotonic() - start, 1)
             result.result = "pass"
 
+    phase(SmokePhase.TEARDOWN)
     _teardown(case, lvlab=lvlab, uri=uri)
     result.total_seconds = round(time.monotonic() - start, 1)
+    phase(SmokePhase.PASS if result.result == "pass" else SmokePhase.FAIL)
     return result
+
+
+def _run_batches(
+    plan: "SmokePlan",
+    progress: "SmokeProgress",
+    *,
+    lvlab: str,
+    uri: str,
+    network_name: str,
+    key_path: str | None,
+    live: bool,
+) -> list[CaseResult]:  # pragma: no cover - VM lifecycle
+    """Run every batch's cases concurrently, optionally rendering a live table.
+
+    When ``live`` is true (TEXT format on a terminal), a Rich ``Live`` table
+    is refreshed from the main thread off the shared (locked)
+    :class:`SmokeProgress` while the batch's workers advance their phases
+    (issue #101). Otherwise the batches run exactly as before with no live
+    rendering. Batches run sequentially; cases within a batch run in a
+    thread pool.
+
+    Returns:
+        The collected :class:`CaseResult` list (unordered; the caller sorts).
+    """
+    pool_size = max((len(b.cases) for b in plan.batches), default=1)
+    results: list[CaseResult] = []
+    live_view = Live(console=get_console(), refresh_per_second=8) if live else None
+    if live_view is not None:
+        live_view.start()
+    try:
+        for batch in plan.batches:
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=len(batch.cases)
+            ) as pool:
+                futures = [
+                    pool.submit(
+                        _run_case,
+                        case,
+                        lvlab=lvlab,
+                        uri=uri,
+                        network_name=network_name,
+                        key_path=key_path,
+                        progress=progress,
+                    )
+                    for case in batch.cases
+                ]
+                pending = set(futures)
+                while pending:
+                    _done, pending = concurrent.futures.wait(pending, timeout=0.25)
+                    if live_view is not None:
+                        live_view.update(
+                            render_smoke_table(progress.snapshot(), pool_size=pool_size)
+                        )
+                results.extend(f.result() for f in futures)
+        if live_view is not None:
+            live_view.update(
+                render_smoke_table(progress.snapshot(), pool_size=pool_size)
+            )
+    finally:
+        if live_view is not None:
+            live_view.stop()
+    return results
 
 
 def smoke_env_dir(config_defaults: dict[str, Any], environment: dict[str, Any]) -> str:
@@ -1056,8 +1246,6 @@ def run_smoke(
     Raises:
         SmokeError: Manifest missing/empty, or preflight failed.
     """
-    import concurrent.futures
-
     parsed = parse_config(config_path)
     if parsed is None:
         raise SmokeError(f"No manifest found at '{config_path}'.")
@@ -1099,24 +1287,19 @@ def run_smoke(
 
     lvlab = _lvlab_bin()
     key_path = _ssh_private_key(config_defaults)
-    results: list[CaseResult] = []
-    for batch in plan.batches:
-        with concurrent.futures.ThreadPoolExecutor(
-            max_workers=len(batch.cases)
-        ) as pool:
-            futures = [
-                pool.submit(
-                    _run_case,
-                    case,
-                    lvlab=lvlab,
-                    uri=uri,
-                    network_name=network_name,
-                    key_path=key_path,
-                )
-                for case in batch.cases
-            ]
-            for fut in concurrent.futures.as_completed(futures):
-                results.append(fut.result())
+    progress = SmokeProgress(cases)
+    # Live phase table only for the human-facing TEXT format on a terminal
+    # (issue #101); JSON/YAML and piped output stay exactly as before.
+    live = fmt is OutputFormat.TEXT and is_tty()
+    results = _run_batches(
+        plan,
+        progress,
+        lvlab=lvlab,
+        uri=uri,
+        network_name=network_name,
+        key_path=key_path,
+        live=live,
+    )
 
     order = {c.vm_name: i for i, c in enumerate(cases)}
     results.sort(key=lambda r: order.get(r.vm_name, 0))

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -467,3 +467,66 @@ def test_cleanup_empty_env_dir_missing_dir_is_noop(tmp_path) -> None:
     config_defaults = {"disk_image_basedir": str(tmp_path)}
     environment = {"name": "never-created"}
     assert cleanup_empty_env_dir(config_defaults, environment) is False
+
+
+# ---------------------------------------------------------------------------
+# Live status table (issue #101)
+# ---------------------------------------------------------------------------
+
+
+def test_smoke_progress_tracks_phases_and_ip() -> None:
+    """SmokeProgress setters update per-case phase/ip; snapshot is consistent."""
+    from tkc_lvlab.smoke import SmokePhase, SmokeProgress
+
+    cases = [
+        _case("deb12-static", mode="static", static_ip="192.168.122.10"),
+        _case("fed44-dhcp", mode="dhcp"),
+    ]
+    progress = SmokeProgress(cases)
+
+    # Initial: pending, static ip prefilled, dhcp ip unknown.
+    snap = {s.vm_name: s for s in progress.snapshot()}
+    assert snap["deb12-static"].phase == SmokePhase.PENDING
+    assert snap["deb12-static"].ip == "192.168.122.10"
+    assert snap["fed44-dhcp"].ip is None
+
+    progress.set_phase("fed44-dhcp", SmokePhase.BOOTING)
+    progress.set_ip("fed44-dhcp", "192.168.122.55")
+    progress.set_phase("deb12-static", SmokePhase.PASS)
+
+    snap = {s.vm_name: s for s in progress.snapshot()}
+    assert snap["fed44-dhcp"].phase == SmokePhase.BOOTING
+    assert snap["fed44-dhcp"].ip == "192.168.122.55"
+    assert snap["deb12-static"].phase == SmokePhase.PASS
+
+
+def test_render_smoke_table_tally_and_cells() -> None:
+    """The live table shows each case and a running/pending/passed/failed tally."""
+    import io
+
+    from rich.console import Console
+
+    from tkc_lvlab.smoke import SmokePhase, SmokeProgress, render_smoke_table
+
+    cases = [
+        _case("a", mode="static", static_ip="10.0.0.1"),
+        _case("b", mode="dhcp"),
+        _case("c", mode="dhcp"),
+    ]
+    progress = SmokeProgress(cases)
+    progress.set_phase("a", SmokePhase.PASS)
+    progress.set_phase("b", SmokePhase.VERIFYING)
+    # 'c' stays pending.
+
+    table = render_smoke_table(progress.snapshot(), pool_size=2)
+    assert "passed 1" in table.caption
+    assert "pending 1" in table.caption
+    assert "running 1" in table.caption  # 'b' verifying counts as running
+    assert "failed 0" in table.caption
+
+    out = io.StringIO()
+    Console(file=out, width=120).print(table)
+    rendered = out.getvalue()
+    for name in ("a", "b", "c"):
+        assert name in rendered
+    assert "10.0.0.1" in rendered  # static ip shown


### PR DESCRIPTION
Closes #101.

`lvlab smoke` printed nothing until cases finished, then dumped a final table — no visibility into a long run in flight. Now it shows a **live status table**: every case listed up front, each row updating through its phases.

## Changes
- `SmokePhase` constants + a thread-safe `SmokeProgress` tracker (per-case phase + resolved IP). Cases run in concurrent batches (#90), so workers advance phases through the locked setters while the **main thread renders** — every Rich call stays on the main thread (same safe pattern as #104).
- `_run_case` advances its phase at each step: **up → booting → verifying → tearing down → PASS/FAIL**, and records the DHCP lease IP when it resolves.
- `_run_batches` drives a Rich `Live` table (vm / mode / ip / phase, with a `running · pending · passed · failed` caption) for **the TEXT format on a terminal**. `--format json|yaml` and piped/redirected output are **unchanged** (no live view; structured/final output exactly as before). The final summary still prints after the Live stops.

## Tests
`SmokeProgress` tracks phase + ip and snapshots consistently; `render_smoke_table` lists every case and tallies running/pending/passed/failed in the caption. Full suite **526 passed, 39 skipped**. `pre-commit` + `zensical build -s` clean.

> `run_smoke` / `_run_case` / `_run_batches` stay `# pragma: no cover` (they boot **real** VMs — `lvlab smoke` is manual-only, never in CI); the testable units (tracker + render) are covered. The Live table is the TTY branch; JSON/YAML/piped output is the tested-equivalent path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)