### PR TITLE
0.6.0: IPv6 dual-stack (#137) + lvlab up user_data parity (#140)

### DIFF
--- a/.github/release-notes/0.6.0.md
+++ b/.github/release-notes/0.6.0.md
@@ -38,6 +38,14 @@ remaining parity gaps to closure so the project can be parked for a while.
     shared with createvm — no forked substitution logic. See the
     walkthrough's "`user_data` cloud-config override" section.
 
+- **`createvm` argument errors use the standard Typer boxed format (#147).**
+    Running `createvm` with no arguments (or only one of the two
+    positional args) used to print a plain red one-liner; it now renders
+    the same `╭─ Error ─╮` panel with a `Usage:` line + `Try 'createvm   --help'` hint that `deletevm` and every other lvlab CLI surface
+    already use. Body-level argument validation now raises
+    `click.UsageError` instead of calling `_fail()`; the
+    `--init-cloud-images` exception path is unaffected.
+
 ## Breaking changes
 
 None. Every change is additive — manifests without any `ip6` field

--- a/.github/release-notes/0.6.0.md
+++ b/.github/release-notes/0.6.0.md
@@ -46,6 +46,16 @@ remaining parity gaps to closure so the project can be parked for a while.
     `click.UsageError` instead of calling `_fail()`; the
     `--init-cloud-images` exception path is unaffected.
 
+- **`lvlab status` has a friendly landing without a manifest (#149).**
+    Running `lvlab status` from a directory with no `Lvlab.yml` used to
+    die with a cryptic `Could not parse config file` error. It now
+    prints a "no manifest" hint, the built-in cloud-images table (so a
+    first-time user can see what's downloadable out of the box), a
+    pointer to `createvm` for one-off VMs, and a link to the project
+    docs for the manifest-driven workflow. Exit 0 — missing context is
+    not a misconfiguration. A *malformed* manifest still exits 1
+    loudly through the unchanged strict path.
+
 ## Breaking changes
 
 None. Every change is additive — manifests without any `ip6` field

--- a/.github/release-notes/0.6.0.md
+++ b/.github/release-notes/0.6.0.md
@@ -1,0 +1,56 @@
+## Highlights
+
+Feature release on top of [0.5.4](https://github.com/memblin/tkc-lvlab-py/releases/tag/0.5.4).
+The 0.6.0 line is the planned "stable + park" release — bringing the two
+remaining parity gaps to closure so the project can be parked for a while.
+
+- **Dual-stack IPv4 + IPv6 (#137).** Both `createvm` and the manifest
+    workflow now accept an IPv6 address alongside the existing v4 path.
+    For `createvm`: `--ip6 ADDR`, `--ip6 NETWORK,ADDR`, `--ip6 dhcp`, and
+    bare `--ip6 NETWORK` mirror every shape `--ip4` already supports;
+    `--gateway6` / `--dns6` cover the bridge case where libvirt has no
+    v6 gateway to self-derive. For the manifest: an `interface` entry can
+    carry `ip6` and `ip6gw` (mirroring `ip4`/`ip4gw`); `nameservers.addresses`
+    accepts mixed v4/v6 freely. Both the v1 ENI (`static6` subnet) and
+    v2 netplan (`addresses` + `routes::/0`) templates render the v6 stanza
+    when an interface carries `ip6`. `validate_static_ip` is now
+    dual-stack-aware (subnet + DHCP range checks route to the right
+    family). See the "Dual-stack IPv4 + IPv6" section in
+    `docs/walkthrough.md` for worked examples.
+
+    **First-cut scope.** Dual-stack only (v4 + optionally v6). v6-only
+    guests are deliberately out of scope — lvlab's helper commands
+    (`ssh`, `smoke`, `hosts`) all resolve VM IPs as v4 today, so removing
+    the v4 leg would leave them targetless. Per-network v6 defaults
+    under the layered `networks:` map (a `gateway6` / `dns6` field on a
+    `networks[<name>]` entry) are also deferred.
+
+## Breaking changes
+
+None. Every change is additive — manifests without any `ip6` field
+behave exactly as on 0.5.4. The v2 netplan template preserves the
+historical "static-v4 leaves `dhcp6: false`" defensive behaviour so a
+v4-only manifest renders byte-for-byte identical output to 0.5.4.
+
+## Install / upgrade
+
+```bash
+uv tool install --upgrade \
+  https://github.com/memblin/tkc-lvlab-py/releases/download/0.6.0/tkc_lvlab-0.6.0-py3-none-any.whl
+```
+
+## Supported hosts
+
+Unchanged from 0.5.4 — Debian 12 (3.11), Debian 13 (3.13), AlmaLinux 10
+(3.12), Fedora 44 (3.14). See
+[`docs-extra/host-validation.md`](https://github.com/memblin/tkc-lvlab-py/blob/0.6.0/docs-extra/host-validation.md)
+for the matrix.
+
+## Full commit log
+
+```
+git log --oneline 0.5.4..0.6.0
+```
+
+See the compare view at
+<https://github.com/memblin/tkc-lvlab-py/compare/0.5.4...0.6.0>.

--- a/.github/release-notes/0.6.0.md
+++ b/.github/release-notes/0.6.0.md
@@ -25,6 +25,19 @@ remaining parity gaps to closure so the project can be parked for a while.
     under the layered `networks:` map (a `gateway6` / `dns6` field on a
     `networks[<name>]` entry) are also deferred.
 
+- **`lvlab up` honors a `user_data` cloud-config override (#140).** The
+    full cloud-config override that `createvm` got in 0.5.2 (#138 §4)
+    now applies to the manifest workflow too. Set
+    `cloud_init.user_data` (per-machine or in `config_defaults.cloud_init`)
+    to a complete cloud-config mapping and lvlab renders that document
+    as `user-data` instead of the structured template, with placeholder
+    substitution (`{vm_name}`, `{vm_hostname}`, `{fqdn}`,
+    `{default_vm_username}`, `{password_hash}`, `{environment}`),
+    discovered-pubkey append, and a manifest-wide `/etc/hosts` runcmd
+    prepend (skipped when `manage_etc_hosts: false`). One renderer is
+    shared with createvm — no forked substitution logic. See the
+    walkthrough's "`user_data` cloud-config override" section.
+
 ## Breaking changes
 
 None. Every change is additive — manifests without any `ip6` field

--- a/docs/Lvlab.example.yml
+++ b/docs/Lvlab.example.yml
@@ -117,6 +117,22 @@ environment:
           - name: eth0
             network_type: user
 
+      # Dual-stack IPv4 + IPv6 (#137). Requires a libvirt network with
+      # both an <ip> and an <ip family='ipv6'> element in net-dumpxml.
+      # nameservers.addresses accepts mixed v4/v6 freely.
+      - vm_name: dual01.local
+        hostname: dual01
+        os: debian12
+        interfaces:
+          - name: eth0
+            ip4: 192.168.122.40/24
+            ip4gw: 192.168.122.1
+            ip6: 2001:db8:122::40/64
+            ip6gw: 2001:db8:122::1
+        nameservers:
+          addresses: [192.168.122.1, 2001:db8:122::1]
+          search: [lab.local]
+
 images:
   debian13:
     image_url: https://cloud.debian.org/images/cloud/trixie/latest/debian-13-generic-amd64.qcow2

--- a/docs/cloud-init-examples.md
+++ b/docs/cloud-init-examples.md
@@ -172,6 +172,49 @@ also disambiguates multiple NICs in principle (the old driver match
 could not) — though multi-NIC manifests are not yet exercised
 end-to-end in `lvlab`.
 
+## network-config (v2, dual-stack)
+
+When the manifest interface carries both `ip6` and `ip6gw` alongside the
+v4 fields, the v2 template emits a second `addresses` entry and a v6
+default route. `dhcp6` is set to `false` whenever either family has a
+static address — a defensive behaviour preserved from the v4-only days
+since netplan's DHCPv6 client hangs on some distros, and v4-only
+operators never opted into SLAAC implicitly.
+
+```yaml
+network:
+  version: 2
+  ethernets:
+    eth0:
+      match:
+        macaddress: "52:54:00:1a:2b:3c"
+      dhcp4: false
+      dhcp6: false
+      addresses:
+        - 192.168.122.50/24
+        - 2001:db8:122::50/64
+      nameservers:
+        addresses: [192.168.122.1, 2001:db8:122::1]
+        search: [local, example.lab]
+      routes:
+        - to: 0.0.0.0/0
+          via: 192.168.122.1
+        - to: ::/0
+          via: 2001:db8:122::1
+```
+
+`nameservers.addresses` is a flat list — netplan and the v1 ENI
+renderer both accept mixed v4/v6 freely. The v1 (ENI) renderer emits
+the dual-stack form as two subnet entries on the same physical
+interface, one `type: static` (v4) and one `type: static6` (v6).
+
+> Out of scope for `lvlab` today: **v6-only** guests with no v4. The
+> render passes through, but the `lvlab` helper commands (`ssh`, `smoke`,
+> `hosts`) all resolve VM IPs as v4 and would have no target. See the
+> "Dual-stack IPv4 + IPv6" section of the
+> [Walkthrough](walkthrough.md#dual-stack-ipv4-ipv6-137) for the
+> scope statement.
+
 ## See also
 
 - [`network-config.v1.j2`](https://github.com/memblin/tkc-lvlab-py/blob/main/src/tkc_lvlab/templates/network-config.v1.j2)

--- a/docs/example-manifest.md
+++ b/docs/example-manifest.md
@@ -11,9 +11,11 @@ out the gotchas that bite first-time users.
     as the libvirt URI.
 - **`config_defaults`** that apply to every machine — CPU, memory,
     one default disk, one default interface, cloud-init credentials.
-- **Six machines** exercising a representative spread: Debian 12
+- **Seven machines** exercising a representative spread: Debian 12
     (static), Debian 13 (static and DHCP), AlmaLinux 10 (static),
-    Fedora 44 (static), and one user-mode VM.
+    Fedora 44 (static), one user-mode VM, and a **dual-stack IPv4 + IPv6**
+    machine (`dual01`) that pairs `ip4`/`ip4gw` with `ip6`/`ip6gw` on
+    the same NIC.
 - **An `images:` block cataloguing all eight supported cloud images** —
     Debian 11/12/13, AlmaLinux 9/10, Ubuntu 22.04/24.04, and Fedora 44 —
     plus two custom intranet examples. A machine only needs an entry for

--- a/docs/one-off-vms.md
+++ b/docs/one-off-vms.md
@@ -48,6 +48,13 @@ sudo createvm testvm.local debian12
 # then rendered into the guest's cloud-init network-config.
 sudo createvm testvm.local debian13 --ip4 192.168.122.50
 
+# Dual-stack: both v4 and v6 statics on the same NIC. v6 mirrors
+# every shape v4 accepts (ADDR / NETWORK,ADDR / dhcp / bare NETWORK).
+# /64 is appended if --ip6 lacks a CIDR.
+sudo createvm testvm.local debian13 \
+    --ip4 192.168.122.50 \
+    --ip6 2001:db8:122::50
+
 # Pre-download every catalog image (built-ins + any cwd Lvlab.yml).
 # DEPRECATED: prefer `lvlab init`, which initializes the built-in
 # defaults when there's no Lvlab.yml. This flag still works for now.
@@ -66,6 +73,9 @@ and must be given together.
 | `VM_DISTRO` (positional) | Image key, matched case-insensitively against the built-in catalog (`debian11`, `debian12`, `debian13`, `almalinux9`, `almalinux10`, `ubuntu2204`, `ubuntu2404`, `fedora44`) merged with any `images:` in a cwd `Lvlab.yml`. Required together with `VM_NAME`.                                         |
 | `--ip4`                  | Optional static IPv4. Accepts `IP` (uses `--network`), `NETWORK,IP`, or a bare `NETWORK` name (DHCP on that network). Validated against the network's subnet AND DHCP range, then rendered into the guest's cloud-init network-config. For DHCP, pass `dhcp` (or `default` / `auto`) or omit the flag. |
 | `--netmask`              | CIDR prefix appended to `--ip4` when it lacks one. Default `24`.                                                                                                                                                                                                                                       |
+| `--ip6`                  | Optional static IPv6 (dual-stack with `--ip4`, or v6-static on its own). Same shapes as `--ip4`: `ADDR`, `NETWORK,ADDR`, bare `NETWORK` (SLAAC/DHCPv6), or `dhcp`/`default`/`auto`. `/64` is appended when missing. `validate_static_ip` routes by family — same subnet + DHCP-range guards apply.     |
+| `--gateway6`             | IPv6 gateway for a static `--ip6` on a **bridge** network. Required (with `--dns6`) for a bridge; ignored for NAT (self-derived from the v6 `<ip>` element of the network XML).                                                                                                                        |
+| `--dns6`                 | Comma-separated IPv6 DNS server(s) for a static `--ip6` on a **bridge** network. Required (with `--gateway6`) for a bridge; ignored for NAT.                                                                                                                                                           |
 | `--disk-size`            | qcow2 disk size. Default `35G`.                                                                                                                                                                                                                                                                        |
 | `--cpu`                  | vCPU count. Default `2`.                                                                                                                                                                                                                                                                               |
 | `--memory`               | RAM, optional unit suffix (`2048`, `2G`, `512M`). Default `2048` (MiB).                                                                                                                                                                                                                                |
@@ -81,10 +91,13 @@ and must be given together.
 
 `createvm` attaches the guest to a managed libvirt network
 (`--network network=<name>,model=virtio`), defaulting to the stock NAT
-`default`, with spice graphics on the loopback. With `--ip4` it renders a
-static address (plus the NAT gateway as resolver) into the guest's
-network-config; without it the guest uses DHCP and `createvm` waits up to
-20s for the NAT lease, then prints the discovered SSH target.
+`default`, with spice graphics on the loopback. With `--ip4` (and/or
+`--ip6`) it renders the static address(es) — plus the NAT gateway(s) as
+resolver — into the guest's network-config. Without static flags the
+guest uses DHCP and `createvm` waits up to 20s for the NAT lease, then
+prints the discovered SSH target. The DHCP-lease wait remains v4-only:
+`lvlab`'s SSH/lookup paths target v4, so a v6-only assignment would
+boot but the lease wait would still need a v4 address to report.
 
 ### Host-wide config (`/etc/Lvlab.yml`)
 
@@ -176,12 +189,14 @@ user_data:
 Placeholders (anything else is a hard error — a typo fails the run before a VM
 is created, rather than booting with a blank value):
 
-| Placeholder             | Filled with                                                                          |
-| ----------------------- | ------------------------------------------------------------------------------------ |
-| `{vm_name}`             | the `VM_NAME` you passed (used as `fqdn`)                                            |
-| `{vm_hostname}`         | the short hostname (`VM_NAME` up to the first `.`)                                   |
-| `{default_vm_username}` | the resolved first-boot account (image `username:` → `default_vm_username` → family) |
-| `{password_hash}`       | the generated password hash (the plaintext is still printed)                         |
+| Placeholder             | Filled with                                                                                                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `{vm_name}`             | the `VM_NAME` you passed (used as `fqdn`)                                                                                                                    |
+| `{vm_hostname}`         | the short hostname (`VM_NAME` up to the first `.`)                                                                                                           |
+| `{fqdn}`                | fully-qualified domain name (for `createvm` this equals `{vm_name}`; differs in the manifest path, where machines are env-namespaced)                        |
+| `{default_vm_username}` | the resolved first-boot account (image `username:` → `default_vm_username` → family)                                                                         |
+| `{password_hash}`       | the generated password hash (the plaintext is still printed)                                                                                                 |
+| `{environment}`         | for `createvm`: empty string (no environment concept). The placeholder is shared with the manifest path (`lvlab up`), where it carries the environment name. |
 
 Behavior to know:
 

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -207,6 +207,20 @@ Output is two tables (the shared CLI table style — see
 When stdout is piped or redirected the tables render as plain text
 (no ANSI), widened so long image URLs aren't clipped.
 
+### Without a manifest (#149)
+
+`lvlab status` is also the friendly first-run landing: run it from a
+directory with no `Lvlab.yml` and it prints a "no manifest here"
+hint, the **built-in cloud-images table** (so you see what's
+downloadable out of the box), a pointer that `createvm` is the right
+tool for one-off VMs without writing a manifest, and a link to the
+project documentation site for the manifest-driven workflow. Exit 0
+— a missing manifest is missing-context, not a misconfiguration.
+
+A *malformed* `Lvlab.yml` (file exists but is structurally invalid)
+still exits 1 with the strict `Could not parse config file` error;
+only the genuine file-absent case routes to the landing.
+
 ## ssh-config
 
 Print SSH config snippets you can append to `~/.ssh/config`.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -583,6 +583,68 @@ are not in this cut. Bridges require the `--gateway6`/`--dns6` flags or
 v6 fields on every per-machine interface; a follow-up tracks adding the
 v6 keys to `networks:`.
 
+## `user_data` cloud-config override (#140)
+
+For machines that need a non-trivial cloud-config — multiple users,
+`write_files`, package installs, custom mounts, anything beyond the
+structured per-machine `cloud_init` keys — set
+`cloud_init.user_data` to a raw cloud-config mapping. The whole
+mapping replaces the structured `user-data` render for that machine
+(an existing parallel of the `createvm` flag added in 0.5.2).
+
+```yaml
+machines:
+  - vm_name: salt-master
+    hostname: salt-master
+    os: debian12
+    cloud_init:
+      pubkey: ~/.ssh/id_ed25519.pub
+      user_data:
+        users:
+          - name: "{default_vm_username}"
+            sudo: ALL=(ALL) NOPASSWD:ALL
+            shell: /bin/bash
+            passwd: "{password_hash}"
+          - name: deploy
+            sudo: ALL=(ALL) NOPASSWD:ALL
+            shell: /bin/bash
+            ssh_authorized_keys:
+              - ssh-ed25519 AAAA... ops@laptop
+        write_files:
+          - path: /etc/motd
+            content: |
+              {fqdn} — managed by lvlab ({environment})
+        package_update: true
+        packages: [vim, jq]
+        runcmd:
+          - systemctl enable --now salt-master
+```
+
+**Placeholders.** `{vm_name}`, `{vm_hostname}`, `{fqdn}`,
+`{default_vm_username}`, `{password_hash}`, `{environment}` are
+substituted from the per-machine resolved context. An override that
+references anything else raises a clean error rather than emitting a
+silent blank. The placeholder set is shared with `createvm` (which
+fills `fqdn` from `VM_NAME` and `environment` as the empty string).
+
+**SSH keys.** A literal `cloud_init.pubkey` (or path) is appended to
+every user's `ssh_authorized_keys` automatically — the same `pubkey`
+mechanism the structured path uses. An override that hard-codes its
+own `ssh_authorized_keys` is fine; the discovered keys are appended
+without duplication.
+
+**Layering.** A `cloud_init.user_data` set at the `config_defaults`
+level applies to every machine; a per-machine `cloud_init.user_data`
+replaces it wholesale (overriding two whole cloud-config documents
+has no clean merge semantics — the per-machine declaration owns the
+document).
+
+**`/etc/hosts` + runcmd.** When `cloud_init.manage_etc_hosts` is on
+(the default), lvlab's two manifest-wide `/etc/hosts` heredocs are
+still prepended to the override's `runcmd` — same composition rule
+`createvm` applies. Operators who want full control set
+`cloud_init.manage_etc_hosts: false` (#120).
+
 ## Where things live on disk
 
 Two paths are configurable in the manifest's `config_defaults`:

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -519,6 +519,70 @@ machines:
         network_type: user
 ```
 
+## Dual-stack IPv4 + IPv6 (#137)
+
+When the libvirt network is configured for dual-stack
+(`<ip family='ipv6' …>` alongside the v4 `<ip>` element in
+`virsh net-dumpxml`), a guest can request both a v4 and a v6 static
+address on the same NIC. Both `createvm` and the manifest workflow accept
+this.
+
+**`createvm`** mirrors the `--ip4` shapes with `--ip6`:
+
+```bash
+# Static dual-stack on the default NAT network. /64 is appended if the
+# v6 lacks a CIDR; the v6 gateway and DNS come from the network XML.
+createvm web01.lab debian12 \
+    --ip4 192.168.122.50 \
+    --ip6 2001:db8:122::50
+
+# Bridge networks need both v4 AND v6 gateway/DNS supplied explicitly
+# (libvirt doesn't manage them).
+createvm web02.lab debian12 \
+    --network vlan10 \
+    --ip4 vlan10,100.64.10.50 --gateway 100.64.10.1 --dns 100.64.10.10 \
+    --ip6 vlan10,2001:db8:10::50 --gateway6 2001:db8:10::1 --dns6 2001:db8:10::1
+```
+
+`--ip6 dhcp` (or omitting the flag) leaves cloud-init with `dhcp6: true`
+so the guest accepts SLAAC / DHCPv6 from the network. `--ip6 vlan10`
+(bare network name) selects that network with SLAAC/DHCPv6, same as the
+v4 shape.
+
+**Manifest workflow** carries the same fields on the interface dict:
+
+```yaml
+machines:
+  - vm_name: dual01
+    hostname: dual01
+    os: debian12
+    interfaces:
+      - name: eth0
+        ip4: 192.168.122.50/24
+        ip4gw: 192.168.122.1
+        ip6: 2001:db8:122::50/64
+        ip6gw: 2001:db8:122::1
+    nameservers:
+      addresses: [192.168.122.1, 2001:db8:122::1]
+      search: [lab.local]
+```
+
+`nameservers.addresses` is a flat list — mix v4 and v6 freely; netplan
+and the v1 ENI renderer both accept it.
+
+**First-cut scope.** Dual-stack only — i.e. v4 + optionally v6. **v6-only
+guests** (no v4) are deliberately out of scope: lvlab's helper commands
+(`lvlab ssh`, `lvlab smoke`, `lvlab hosts`) all resolve VM IPs as v4
+today, so removing the v4 leg would leave them without a target. A
+v6-only guest can still boot — the render passes through — but the
+tooling around it expects a v4 address to exist.
+
+**Per-network v6 defaults under `networks:`** (i.e. a `gateway6` /
+`dns6` field on an entry in the layered host config's `networks:` map)
+are not in this cut. Bridges require the `--gateway6`/`--dns6` flags or
+v6 fields on every per-machine interface; a follow-up tracks adding the
+v6 keys to `networks:`.
+
 ## Where things live on disk
 
 Two paths are configurable in the manifest's `config_defaults`:

--- a/src/tkc_lvlab/cli.py
+++ b/src/tkc_lvlab/cli.py
@@ -1554,7 +1554,7 @@ def status() -> None:
     console.print()
 
 
-_DOCS_URL = "https://github.com/memblin/tkc-lvlab-py"
+_DOCS_URL = "https://memblin.github.io/tkc-lvlab-py/"
 
 
 def _render_no_manifest_landing() -> None:
@@ -1567,8 +1567,14 @@ def _render_no_manifest_landing() -> None:
     2. The built-in cloud-images table (same shape as the happy-path
         Images table, just with ``images=None`` so only built-ins land).
     3. A ``createvm`` pointer with a concrete usage hint for the
-        no-manifest one-off path.
-    4. A link to the project docs for the manifest-authoring workflow.
+        no-manifest one-off path. The example uses DHCP (no ``--ip4``)
+        so it works on the stock libvirt default network without
+        tripping the static-IP/DHCP-range validation — the libvirt
+        default's DHCP pool spans the entire host range, so any
+        hard-coded static address would either collide or require the
+        operator to narrow the pool first.
+    4. A link to the published mkdocs documentation for the
+        manifest-authoring workflow.
 
     Exits cleanly (returns to the caller, which returns to Typer with
     exit 0). A *malformed* manifest still routes through the strict
@@ -1584,7 +1590,13 @@ def _render_no_manifest_landing() -> None:
         "Need a one-off VM? Use [bold]createvm[/bold] — no manifest required:"
     )
     console.print()
-    console.print("    createvm web01.example debian13 --ip4 192.168.122.50")
+    console.print("    createvm web01.example debian13")
+    console.print()
+    console.print(
+        "(That uses the libvirt default network with DHCP. Pass "
+        "[bold]--ip4 <ADDR>[/bold] / [bold]--ip6 <ADDR>[/bold] for a "
+        "static address — see [bold]createvm --help[/bold].)"
+    )
     console.print()
     console.print(
         "For the manifest-driven workflow (multi-VM environments, snapshots, "

--- a/src/tkc_lvlab/cli.py
+++ b/src/tkc_lvlab/cli.py
@@ -1495,8 +1495,29 @@ def status() -> None:
     manifest's ``images:`` — labelling each image's source (``manifest``
     vs ``default``) and whether it's cached on disk — so defaults show
     up even when the manifest doesn't reference them.
+
+    Issue #149: when no ``Lvlab.yml`` is present in the current
+    directory, ``status`` renders a friendly landing (built-in images
+    table + ``createvm`` pointer + docs URL) instead of erroring — this
+    is the most common first-run command and a missing manifest is a
+    missing-context signal, not a misconfiguration. A *malformed*
+    manifest still exits 1 loudly through :func:`_load_config`.
     """
-    environment, images, config_defaults, machines = _load_config().as_tuple()
+    # Detect the genuine "no Lvlab.yml" case directly via parse_config so
+    # the landing only triggers on file-absent. Anything else (structural
+    # invalid → ConfigError; missing-file-as-TypeError some tests still
+    # simulate) routes through _load_config and keeps the loud exit-1.
+    try:
+        parsed = parse_config()
+    except (ConfigError, TypeError):
+        logger.error(CONFIG_PARSE_ERROR_MSG)
+        raise typer.Exit(code=1)
+    if parsed is None:
+        _render_no_manifest_landing()
+        return
+    environment, images, config_defaults, machines = ConfigManager.from_parsed(
+        parsed
+    ).as_tuple()
 
     uri = environment.get("libvirt_uri", DEFAULT_LIBVIRT_URI)
     env_name = environment.get("name", "no-name-lvlab")
@@ -1530,6 +1551,46 @@ def status() -> None:
 
     console.print()
     console.print(_build_images_table(images, environment, config_defaults))
+    console.print()
+
+
+_DOCS_URL = "https://github.com/memblin/tkc-lvlab-py"
+
+
+def _render_no_manifest_landing() -> None:
+    """Render the friendly landing for ``lvlab status`` without a manifest (#149).
+
+    Triggered when ``parse_config()`` returns ``None`` (the file is
+    genuinely absent — distinct from a parse error). Prints:
+
+    1. A short "no manifest here" line — informational, not an error.
+    2. The built-in cloud-images table (same shape as the happy-path
+        Images table, just with ``images=None`` so only built-ins land).
+    3. A ``createvm`` pointer with a concrete usage hint for the
+        no-manifest one-off path.
+    4. A link to the project docs for the manifest-authoring workflow.
+
+    Exits cleanly (returns to the caller, which returns to Typer with
+    exit 0). A *malformed* manifest still routes through the strict
+    error path in :func:`status`.
+    """
+    console = get_console()
+    console.print()
+    console.print("No Lvlab.yml in this directory. Showing built-in cloud images.")
+    console.print()
+    console.print(_build_images_table(images=None, environment={}, config_defaults={}))
+    console.print()
+    console.print(
+        "Need a one-off VM? Use [bold]createvm[/bold] — no manifest required:"
+    )
+    console.print()
+    console.print("    createvm web01.example debian13 --ip4 192.168.122.50")
+    console.print()
+    console.print(
+        "For the manifest-driven workflow (multi-VM environments, snapshots, "
+        "runcmd composition, IPv6 dual-stack, user_data overrides, ...) see:"
+    )
+    console.print(f"    {_DOCS_URL}")
     console.print()
 
 

--- a/src/tkc_lvlab/scripts/createvm.py
+++ b/src/tkc_lvlab/scripts/createvm.py
@@ -823,8 +823,15 @@ def _build_createvm_context(
             context={
                 "vm_name": vm_name,
                 "vm_hostname": vm_name.split(".")[0],
+                # createvm has no environment concept and treats the bare
+                # ``vm_name`` as the fully-qualified name (no env-namespacing
+                # like ``lvlab up`` does). #140 added ``fqdn``/``environment``
+                # to the shared placeholder set; createvm populates them with
+                # the closest equivalents.
+                "fqdn": vm_name,
                 "default_vm_username": username,
                 "password_hash": password_hash,
+                "environment": "",
             },
             authorized_keys=authorized_keys,
             runcmd_prefix=runcmd or [],

--- a/src/tkc_lvlab/scripts/createvm.py
+++ b/src/tkc_lvlab/scripts/createvm.py
@@ -62,6 +62,7 @@ from ..utils.network import (
     generate_mac,
     get_network_info,
     resolve_network_settings,
+    resolve_network_settings6,
     validate_static_ip,
 )
 from ..utils.osinfo import OsInfoLookupError, resolve_os_variant
@@ -98,9 +99,13 @@ from ..utils.virsh import VirshError, run_virsh, vm_exists
 _SYSTEM_URI = "qemu:///system"
 DEFAULT_NETWORK = "default"
 DEFAULT_NETMASK = "24"
-# Values for ``--ip4`` that mean "no static IP — use DHCP", equivalent to
-# omitting the flag. None of these are valid IPv4 addresses, so there's no
-# ambiguity with a real address (issue #105).
+# Default IPv6 prefix length appended to a bare ``--ip6`` address that
+# lacks a ``/CIDR`` suffix. /64 is the universal lab-network default —
+# the same convention libvirt's dual-stack examples use (#137).
+DEFAULT_PREFIX6 = "64"
+# Values for ``--ip4`` and ``--ip6`` that mean "no static IP — use DHCP",
+# equivalent to omitting the flag. None of these are valid IP addresses,
+# so there's no ambiguity with a real address (issue #105).
 _DHCP_SENTINELS = frozenset({"dhcp", "default", "auto"})
 DEFAULT_DISK_SIZE = "35G"
 DEFAULT_CPU = "2"
@@ -202,7 +207,56 @@ def parse_ip4_option(value: str, default_network: str) -> tuple[str, str | None]
     # tokens stay on the static path so a numeric typo still gets the clean
     # "not a valid IPv4 address" error rather than a confusing network lookup
     # (issue #105 / #136).
-    if not re.fullmatch(r"[0-9.]+(/[0-9]+)?", raw_ip):
+    if not re.fullmatch(r"[\d.]+(/\d+)?", raw_ip):
+        return raw_ip, None
+    return default_network, raw_ip
+
+
+def parse_ip6_option(value: str, default_network: str) -> tuple[str, str | None]:
+    """IPv6 sibling of :func:`parse_ip4_option`.
+
+    Mirrors every shape ``parse_ip4_option`` accepts, just with an IPv6
+    IP-ish heuristic (hex digits + colons + optional ``/CIDR``):
+
+    - ``ADDR`` (e.g. ``2001:db8::5``) → static v6 on ``default_network``.
+    - ``NETWORK,ADDR`` → static v6 on a named network.
+    - ``dhcp`` / ``default`` / ``auto`` (case-insensitive) → DHCPv6/SLAAC
+        on ``default_network``, same as omitting ``--ip6``.
+    - Bare network name (e.g. ``--ip6 vlan10``) → DHCPv6/SLAAC on that
+        network.
+
+    Args:
+        value: The raw value from ``--ip6``.
+        default_network: Network to assume when ``value`` is bare.
+
+    Returns:
+        ``(network_name, raw_ip)`` where ``raw_ip`` is ``None`` for the
+        DHCPv6/SLAAC paths.
+
+    Raises:
+        ValueError: ``value`` has a comma but either side is empty.
+    """
+    if "," in value:
+        network, _, raw_ip = value.partition(",")
+        network = network.strip()
+        raw_ip = raw_ip.strip()
+        if not network or not raw_ip:
+            raise ValueError(
+                f"Invalid --ip6 value '{value}'. Expected ADDR or NETWORK,ADDR."
+            )
+        if raw_ip.lower() in _DHCP_SENTINELS:
+            return network, None
+        return network, raw_ip
+    raw_ip = value.strip()
+    if raw_ip.lower() in _DHCP_SENTINELS:
+        return default_network, None
+    # A bare token that isn't v6-ish (only hex digits / colons, optional
+    # ``/CIDR``) is treated as a network name → SLAAC/DHCPv6 on it. The
+    # IP-ish gate parallels the v4 path: a bare token that looks like an
+    # address stays on the static path so a malformed v6 typo still hits
+    # the clean ``not a valid IPv6 address`` error rather than a
+    # confusing network lookup.
+    if not re.fullmatch(r"[\da-fA-F:]+(/\d+)?", raw_ip):
         return raw_ip, None
     return default_network, raw_ip
 
@@ -419,6 +473,13 @@ class _CreateVmContext:  # pylint: disable=too-many-instance-attributes
     # (#138 §4). When set, it is written verbatim and the structured one-off
     # template is skipped. ``None`` means "use the structured template".
     user_data_override: str | None = None
+    # IPv6 dual-stack (#137). All v6 fields are ``None`` / empty list when
+    # the run is v4-only. ``vm_ip6`` is the resolved CIDR static address;
+    # ``gateway6`` and ``dns_servers6`` come from the network's v6 settings
+    # (NAT self-derives, bridge requires explicit ``--gateway6``/``--dns6``).
+    vm_ip6: str | None = None
+    gateway6: str | None = None
+    dns_servers6: list[str] = field(default_factory=list)
 
 
 def _resolve_network_and_ip(
@@ -462,6 +523,134 @@ def _resolve_static_vm_ip(
     return vm_ip
 
 
+def _resolve_v6_settings(
+    *,
+    ip6: str | None,
+    network_name: str | None,
+    config_default_network: str | None,
+    resolved_network: str,
+    network_info: LibvirtNetworkInfo,
+    prefix6: str,
+    default_dns6: list[str] | None,
+    default_gateway6: str | None,
+    default_search: list[str] | None,
+) -> tuple[str | None, str | None, list[str]]:
+    """Resolve the v6 leg of a (potentially dual-stack) createvm run.
+
+    The v6 path is independent of v4 — it may target a different libvirt
+    network — but the common case is a dual-stack manifest that shares
+    one network for both families, in which case the v4 ``network_info``
+    is reused without re-probing libvirt.
+
+    Args:
+        ip6: Raw ``--ip6`` flag value, or ``None`` when the run is v4-only.
+        network_name: Explicit ``--network`` value, used when ``--ip6``
+            doesn't include its own ``NETWORK,`` prefix.
+        config_default_network: Layered-config default network name.
+        resolved_network: The network already resolved by the v4 path —
+            lets us reuse ``network_info`` when v6 lands on the same one.
+        network_info: The v4 path's :class:`LibvirtNetworkInfo`. Reused
+            verbatim when ``ip6`` targets the same network.
+        prefix6: Default IPv6 prefix length appended to a bare static v6.
+        default_dns6: ``--dns6`` value, parsed to a list (or ``None``).
+        default_gateway6: ``--gateway6`` value (or ``None``).
+        default_search: Reused for the v6 search-domain pass through.
+
+    Returns:
+        ``(vm_ip6, gateway6, dns_servers6)``. A SLAAC/DHCPv6 result
+        comes back as ``(None, None, [])`` so the network-config render
+        leaves the v6 stanza alone and dhcp6 stays enabled.
+
+    Raises:
+        ValueError: Static ``--ip6`` on a bridge network without both
+            ``--gateway6`` and ``--dns6``, OR an unparseable static
+            address (chained from :class:`ValueError` raised by
+            :func:`_resolve_static_vm_ip6`).
+        LibvirtNetworkError: ``resolve_network_settings6`` policy
+            rejection (e.g. NAT network with no v6 gateway in its XML).
+    """
+    if ip6 is None:
+        return None, None, []
+    resolved_network6, raw_ip6 = parse_ip6_option(
+        ip6, network_name or config_default_network or DEFAULT_NETWORK
+    )
+    network_info6 = (
+        network_info
+        if resolved_network6 == resolved_network
+        else get_network_info(_SYSTEM_URI, resolved_network6)
+    )
+    # ``networks:`` entries are v4-only today; v6 defaults come from
+    # ``--gateway6``/``--dns6``. Per-network v6 defaults under
+    # ``networks[<name>].gateway6``/``.dns6`` are a tracked enhancement,
+    # not in this first cut.
+    if (
+        raw_ip6 is not None
+        and network_info6.forward_mode.lower() == "bridge"
+        and not (default_gateway6 and default_dns6)
+    ):
+        raise ValueError(
+            f"Network '{resolved_network6}' is a bridge; a static --ip6 "
+            "needs --gateway6 <addr> and --dns6 <addr[,addr]> (no "
+            "'networks:' entry covers v6 yet). Or use "
+            f"'--ip6 {resolved_network6}' for SLAAC/DHCPv6 on it."
+        )
+    dns_servers6, gateway6, _ = resolve_network_settings6(
+        network_info6,
+        default_dns6=default_dns6,
+        default_gateway6=default_gateway6,
+        default_search=default_search,
+    )
+    vm_ip6 = _resolve_static_vm_ip6(
+        raw_ip=raw_ip6, prefix6=prefix6, network_info=network_info6
+    )
+    # An ``--ip6`` that resolved to SLAAC/DHCPv6 (no static address)
+    # should NOT inject v6 gateway/DNS into the static render path —
+    # cloud-init's network-config leaves dhcp6 enabled and the
+    # router-advertised values take effect at runtime.
+    if vm_ip6 is None:
+        return None, None, []
+    return vm_ip6, gateway6, list(dns_servers6)
+
+
+def _resolve_static_vm_ip6(
+    *, raw_ip: str | None, prefix6: str, network_info: LibvirtNetworkInfo
+) -> str | None:
+    """IPv6 sibling of :func:`_resolve_static_vm_ip`.
+
+    A ``raw_ip`` of ``None`` means SLAAC/DHCPv6. A non-``None`` value
+    gets a ``/prefix6`` appended when it lacks one and is then validated
+    by :func:`validate_static_ip` (dual-stack-aware: routes to v6 subnet
+    + v6 DHCP range based on the address family).
+
+    Args:
+        raw_ip: Bare IPv6 address (with or without ``/CIDR``), or
+            ``None`` for SLAAC/DHCPv6.
+        prefix6: Default prefix length string (e.g. ``"64"``).
+        network_info: A populated :class:`LibvirtNetworkInfo`.
+
+    Returns:
+        The CIDR string ready for the cloud-init render, or ``None`` for
+        the SLAAC/DHCPv6 path.
+
+    Raises:
+        ValueError: ``raw_ip`` is not a parseable IPv6 address, or it
+            collides with the network's static-IP policy.
+    """
+    if raw_ip is None:
+        return None
+    vm_ip = raw_ip if "/" in raw_ip else f"{raw_ip}/{prefix6}"
+    try:
+        ipaddress.IPv6Interface(vm_ip)
+    except ValueError as exc:
+        raise ValueError(
+            f"--ip6 value {raw_ip!r} is not a valid IPv6 address. Pass an "
+            "address like 2001:db8::5 (or NETWORK,2001:db8::5), or use "
+            "--ip6 dhcp (or omit --ip6) for SLAAC/DHCPv6."
+        ) from exc
+    validate_static_ip(vm_ip, network_info)
+    return vm_ip
+
+
 def _resolve_authorized_keys(public_key: Path | None) -> list[str]:
     """Discover default SSH keys, append ``--public-key``, and dedupe.
 
@@ -492,6 +681,10 @@ def _build_createvm_context(
     default_vm_username: str | None = None,
     runcmd: list[str] | None = None,
     user_data: dict[str, Any] | None = None,
+    ip6: str | None = None,
+    prefix6: str = DEFAULT_PREFIX6,
+    default_dns6: list[str] | None = None,
+    default_gateway6: str | None = None,
 ) -> _CreateVmContext:
     """Resolve image, network, addressing, and credentials.
 
@@ -594,6 +787,18 @@ def _build_createvm_context(
         raw_ip=raw_ip, netmask=netmask, network_info=network_info
     )
 
+    vm_ip6, gateway6, dns_servers6 = _resolve_v6_settings(
+        ip6=ip6,
+        network_name=network_name,
+        config_default_network=config_default_network,
+        resolved_network=resolved_network,
+        network_info=network_info,
+        prefix6=prefix6,
+        default_dns6=default_dns6,
+        default_gateway6=default_gateway6,
+        default_search=default_search,
+    )
+
     memory_mib = parse_memory_to_mib(memory)
     password_plain = generate_password_phrase()
     password_hash = hash_password_sha512(password_plain)
@@ -644,6 +849,9 @@ def _build_createvm_context(
         authorized_keys=authorized_keys,
         runcmd=list(runcmd or []),
         user_data_override=user_data_override,
+        vm_ip6=vm_ip6,
+        gateway6=gateway6,
+        dns_servers6=dns_servers6,
     )
 
 
@@ -700,6 +908,15 @@ def _render_cloud_init(*, vm_dir: Path, vm_name: str, ctx: _CreateVmContext) -> 
         iface["ip4"] = ctx.vm_ip
         iface["ip4gw"] = ctx.gateway
         nameservers = {"addresses": ctx.dns_servers, "search": ctx.search_domains}
+    # IPv6 dual-stack (#137): a separate static v6 also feeds the same
+    # interface dict. netplan accepts a mixed-family ``addresses`` list,
+    # so v6 DNS appends onto the v4 DNS list.
+    if ctx.vm_ip6 is not None:
+        iface["ip6"] = ctx.vm_ip6
+        iface["ip6gw"] = ctx.gateway6
+        existing_addresses = list(nameservers.get("addresses", []))
+        nameservers["addresses"] = existing_addresses + list(ctx.dns_servers6)
+        nameservers.setdefault("search", ctx.search_domains)
 
     network_config = NetworkConfig(ctx.entry.network_version, [iface], nameservers)
 
@@ -1199,6 +1416,31 @@ def createvm(  # pylint: disable=too-many-arguments,too-many-locals
         "--search-domain",
         help="Comma-separated DNS search domain(s) (honored on NAT and bridge).",
     ),
+    ip6: str | None = typer.Option(
+        None,
+        "--ip6",
+        help=(
+            "Static IPv6 address (dual-stack with --ip4): ADDR or NETWORK,ADDR. "
+            "Use 'dhcp' (or 'default'/'auto'), or omit the flag, for "
+            "SLAAC/DHCPv6."
+        ),
+    ),
+    gateway6: str | None = typer.Option(
+        None,
+        "--gateway6",
+        help=(
+            "IPv6 gateway for a static --ip6 on a bridge network. Required with "
+            "--dns6 for a bridge; ignored for NAT (self-derived)."
+        ),
+    ),
+    dns6: str | None = typer.Option(
+        None,
+        "--dns6",
+        help=(
+            "Comma-separated IPv6 DNS server(s) for a static --ip6 on a bridge "
+            "network. Required with --gateway6 for a bridge; ignored for NAT."
+        ),
+    ),
     public_key: Path | None = typer.Option(
         None,
         "--public-key",
@@ -1277,6 +1519,7 @@ def createvm(  # pylint: disable=too-many-arguments,too-many-locals
     _ensure_storage_root_writable(storage_root)
 
     dns_servers = [s.strip() for s in dns.split(",") if s.strip()] if dns else None
+    dns_servers6 = [s.strip() for s in dns6.split(",") if s.strip()] if dns6 else None
     search_domains = (
         [s.strip() for s in search_domain.split(",") if s.strip()]
         if search_domain
@@ -1301,6 +1544,9 @@ def createvm(  # pylint: disable=too-many-arguments,too-many-locals
             default_vm_username=host_config.default_vm_username,
             runcmd=host_config.runcmd,
             user_data=host_config.user_data,
+            ip6=ip6,
+            default_dns6=dns_servers6,
+            default_gateway6=gateway6,
         )
     except (
         LibvirtNetworkError,

--- a/src/tkc_lvlab/scripts/createvm.py
+++ b/src/tkc_lvlab/scripts/createvm.py
@@ -41,6 +41,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+import click
 import typer
 from rich.progress import BarColumn, Progress, TextColumn, TimeRemainingColumn
 
@@ -1493,10 +1494,15 @@ def createvm(  # pylint: disable=too-many-arguments,too-many-locals
     has_vm_args = vm_name is not None or vm_distro is not None
     has_all_vm_args = vm_name is not None and vm_distro is not None
 
+    # Argument-shape errors render through Typer/Click's boxed Error panel
+    # (#147) so ``createvm`` aligns with every other lvlab CLI surface
+    # (``deletevm``, the manifest commands) instead of dropping out as a
+    # plain red one-liner. ``_fail`` is reserved for operator-facing
+    # errors deeper in the flow (image download, virt-install, etc.).
     if has_vm_args and not has_all_vm_args:
-        _fail("VM_NAME and VM_DISTRO must be provided together.")
+        raise click.UsageError("VM_NAME and VM_DISTRO must be provided together.")
     if not init_cloud_images and not has_all_vm_args:
-        _fail("Missing required arguments: VM_NAME and VM_DISTRO.")
+        raise click.UsageError("Missing required arguments: VM_NAME and VM_DISTRO.")
 
     try:
         host_config: HostConfig = load_host_config(config_path)

--- a/src/tkc_lvlab/templates/network-config.v1.j2
+++ b/src/tkc_lvlab/templates/network-config.v1.j2
@@ -14,15 +14,23 @@ network:
       # config to the device carrying this MAC.
       mac_address: {{ iface.macaddress }}
       {%- endif %}
-      {%- if iface.ip4 %}
       subnets:
+         {%- if iface.ip4 %}
          - type: static
            address: {{ iface.ip4 }}
            gateway: {{ iface.ip4gw }}
-      {%- else %}
-      subnets:
+         {%- endif %}
+         {%- if iface.ip6 %}
+         # static6 is cloud-init's ENI shape for a per-family IPv6 static
+         # assignment alongside (or instead of) the v4 ``static`` subnet
+         # above (#137).
+         - type: static6
+           address: {{ iface.ip6 }}
+           gateway: {{ iface.ip6gw }}
+         {%- endif %}
+         {%- if not iface.ip4 and not iface.ip6 %}
          - type: dhcp4
-      {%- endif %}
+         {%- endif %}
     {%- if config.nameservers.search is defined and config.nameservers.search | length > 0 %}
     - type: nameserver
       address:

--- a/src/tkc_lvlab/templates/network-config.v2.j2
+++ b/src/tkc_lvlab/templates/network-config.v2.j2
@@ -28,6 +28,13 @@
 # Per-interface MAC matching also disambiguates multiple NICs (the old
 # driver match could not), though multi-NIC manifests are not yet exercised
 # end-to-end.
+#
+# IPv6 (#137): when ``iface.ip6`` is set, the stanza emits a second
+# ``addresses`` entry and a ``::/0`` route via ``iface.ip6gw``. netplan
+# accepts mixed-family addresses and per-family routes — dual-stack
+# guests get both. ``dhcp4``/``dhcp6`` are switched off only for the
+# families that have a static address, so a v4-only manifest can still
+# accept SLAAC/DHCPv6 and a v6-only manifest can still accept DHCPv4.
 network:
   version: {{ config.network_version.value }}
   ethernets:
@@ -43,14 +50,27 @@ network:
       {%- endif %}
       {%- if iface.ip4 %}
       dhcp4: false
-      dhcp6: false
       {%- else %}
       dhcp4: true
+      {%- endif %}
+      {%- if iface.ip4 or iface.ip6 %}
+      # dhcp6 is turned off when EITHER family has a static address. The
+      # historical v4-only behaviour (always disabling dhcp6 on a static
+      # interface) is preserved as a defensive measure — netplan's DHCPv6
+      # client hangs on some distros, and operators on v4-only manifests
+      # have never opted into SLAAC/DHCPv6 implicitly.
+      dhcp6: false
+      {%- else %}
       dhcp6: true
       {%- endif %}
-      {%- if iface.ip4 %}
+      {%- if iface.ip4 or iface.ip6 %}
       addresses:
+        {%- if iface.ip4 %}
         - {{ iface.ip4 }}
+        {%- endif %}
+        {%- if iface.ip6 %}
+        - {{ iface.ip6 }}
+        {%- endif %}
       {%- set ns_addresses = config.nameservers.addresses if config.nameservers.addresses is defined else [] %}
       {%- set ns_search = config.nameservers.search if config.nameservers.search is defined else [] %}
       {%- if ns_addresses | length > 0 or ns_search | length > 0 %}
@@ -69,8 +89,14 @@ network:
         {%- endif %}
       {%- endif %}
       routes:
+        {%- if iface.ip4 %}
         - to: 0.0.0.0/0
           via: {{ iface.ip4gw }}
+        {%- endif %}
+        {%- if iface.ip6 %}
+        - to: ::/0
+          via: {{ iface.ip6gw }}
+        {%- endif %}
       {%- endif %}
    {%- endfor %}
 

--- a/src/tkc_lvlab/utils/libvirt.py
+++ b/src/tkc_lvlab/utils/libvirt.py
@@ -31,6 +31,7 @@ from .subprocess_env import system_first_env
 from .vdisk import VirtualDisk
 from .cloud_init import MetaData, NetworkConfig, UserData
 from .network import NETWORK_TYPES, USER_MODE_NETWORK_TYPES, generate_mac
+from .standalone_cloud_init import render_user_data_override
 from .snapshot_cleanup import undefine_with_snapshot_cleanup
 from .virsh import (
     DEAD_STATES,
@@ -540,6 +541,32 @@ class _CloudInitComposer:
                 logger.error("Could not parse config file.")
                 raise ConfigError("Could not parse config file.") from exc
 
+        # Compute the manifest-wide /etc/hosts heredocs once; both the
+        # structured render path and the user_data override path use the
+        # same prefix when ``manage_etc_hosts`` (#120) is on.
+        hosts_runcmd_prefix = self._build_hosts_runcmd_prefix(
+            cloud_init_config, config_defaults, machines
+        )
+
+        # User-data override (#140) — a per-machine ``cloud_init.user_data``
+        # (or config-defaults equivalent; manifest precedence applies via
+        # _merge_cloud_init_config) is a full cloud-config document owned
+        # by the operator. When set, it replaces the structured UserData
+        # template render. The hosts heredocs from above are prepended to
+        # the override's runcmd (same as createvm prepends its
+        # host-wide runcmd), so manifest-wide /etc/hosts bootstrap still
+        # happens; an operator who wants full control sets
+        # ``manage_etc_hosts: false`` (then ``hosts_runcmd_prefix`` is empty).
+        user_data_override = cloud_init_config.pop("user_data", None)
+        if user_data_override is not None:
+            userdata_config_fpath = self._render_user_data_override(
+                user_data_override,
+                cloud_init_config,
+                password_hash,
+                hosts_runcmd_prefix,
+            )
+            return metadata_config_fpath, userdata_config_fpath, network_config_fpath
+
         # The manage_etc_hosts flag (#120) gates BOTH halves of lvlab's
         # in-guest /etc/hosts management together: the cloud-init template's
         # ``manage_etc_hosts: true`` line AND the two runcmd heredocs that
@@ -547,21 +574,13 @@ class _CloudInitComposer:
         # today's behaviour; set ``cloud_init.manage_etc_hosts: false`` (in
         # config_defaults or per-machine) when an external CM tool (Salt /
         # Ansible) owns /etc/hosts on the guest.
-        if cloud_init_config.get("manage_etc_hosts", True):
-            hosts_snippet = generate_hosts(
-                machine.environment, config_defaults, machines, heredoc="/etc/hosts"
-            )
-            template_fpath = self._resolve_hosts_template_path()
-            hosts_template_snippet = generate_hosts(
-                machine.environment, config_defaults, machines, heredoc=template_fpath
-            )
+        if hosts_runcmd_prefix:
             # Prepend the two hosts heredoc snippets so /etc/hosts (and the
             # cloud-init template) are populated before any runcmd entry that
             # does DNS-ish work.
-            cloud_init_config["runcmd"] = [
-                hosts_snippet,
-                hosts_template_snippet,
-            ] + cloud_init_config.get("runcmd", [])
+            cloud_init_config["runcmd"] = list(
+                hosts_runcmd_prefix
+            ) + cloud_init_config.get("runcmd", [])
 
         userdata_config_fpath = self._render_and_write(
             UserData(cloud_init_config, machine.hostname, machine.domain, machine.fqdn),
@@ -569,6 +588,145 @@ class _CloudInitComposer:
         )
 
         return metadata_config_fpath, userdata_config_fpath, network_config_fpath
+
+    def _build_hosts_runcmd_prefix(
+        self,
+        cloud_init_config: dict[str, Any],
+        config_defaults: dict[str, Any],
+        machines: list[dict[str, Any]],
+    ) -> list[str]:
+        """Build the two manifest-wide /etc/hosts heredocs as a runcmd prefix.
+
+        Returns an empty list when ``cloud_init.manage_etc_hosts`` is
+        ``False`` (the #120 opt-out). Otherwise returns the
+        ``/etc/hosts`` heredoc followed by the distro-specific
+        ``hosts.*.tmpl`` heredoc — the same two snippets the structured
+        path has prepended since #120, factored out so the user_data
+        override path (#140) can also consume them.
+
+        Args:
+            cloud_init_config: The merged cloud_init mapping (defaults +
+                per-machine, after :meth:`_merge_cloud_init_config`).
+            config_defaults: The manifest's ``config_defaults`` block,
+                used by :func:`generate_hosts` for hostname/domain.
+            machines: The machine list from the manifest, used to render
+                each machine into ``/etc/hosts``.
+
+        Returns:
+            ``[hosts_snippet, hosts_template_snippet]`` when
+            ``manage_etc_hosts`` is on, else ``[]``.
+
+        Raises:
+            ValueError: When the machine's ``os`` matches no known
+                ``/etc/cloud/templates/hosts.*.tmpl`` distro family.
+        """
+        if not cloud_init_config.get("manage_etc_hosts", True):
+            return []
+        machine = self.machine
+        hosts_snippet = generate_hosts(
+            machine.environment, config_defaults, machines, heredoc="/etc/hosts"
+        )
+        template_fpath = self._resolve_hosts_template_path()
+        hosts_template_snippet = generate_hosts(
+            machine.environment, config_defaults, machines, heredoc=template_fpath
+        )
+        return [hosts_snippet, hosts_template_snippet]
+
+    def _render_user_data_override(
+        self,
+        user_data: Any,
+        cloud_init_config: dict[str, Any],
+        password_hash: str | None,
+        runcmd_prefix: list[str],
+    ) -> str:
+        """Render a manifest ``cloud_init.user_data`` override and write to disk.
+
+        The override is a full cloud-config document owned by the
+        operator. Placeholder context covers the manifest's per-machine
+        identity (``vm_name`` / ``vm_hostname`` / ``fqdn`` /
+        ``environment``), the resolved first-boot username (defaulted
+        from the image when not set), and the optional generated
+        password hash. The ``cloud_init.pubkey`` (when set) is resolved
+        to a literal SSH public key and appended to every user's
+        ``ssh_authorized_keys`` via :func:`render_user_data_override`.
+
+        Args:
+            user_data: The raw ``user_data:`` mapping popped out of
+                ``cloud_init_config``.
+            cloud_init_config: The remaining merged cloud_init mapping
+                (after the ``user_data`` pop). Consulted for the
+                resolved first-boot username (``user``), password hash
+                (``passwd``, when manifest-set), and the SSH public key
+                (``pubkey``).
+            password_hash: The generated console password hash from
+                ``Machine.cloud_init(password_hash=...)``. The
+                placeholder reflects whichever the manifest path would
+                have used: a manifest-set ``passwd`` wins, else this
+                generated hash, else empty string.
+            runcmd_prefix: Hosts heredocs to inject ahead of the
+                override's own ``runcmd`` (from
+                :meth:`_build_hosts_runcmd_prefix`).
+
+        Returns:
+            The file path of the written ``user-data`` document.
+        """
+        machine = self.machine
+        # Resolve the first-boot username: prefer an explicit setting,
+        # then the image's default that was setdefault-ed above.
+        resolved_user = cloud_init_config.get("user", "")
+        # Mirror the structured-path precedence: a manifest-set passwd
+        # wins over the generated password_hash; otherwise use whichever
+        # the structured path would have rendered (or "" when neither).
+        resolved_password_hash = cloud_init_config.get("passwd") or password_hash or ""
+        context = {
+            "vm_name": machine.vm_name,
+            "vm_hostname": machine.hostname,
+            "fqdn": machine.fqdn,
+            "default_vm_username": resolved_user,
+            "password_hash": resolved_password_hash,
+            "environment": machine.environment.get("name", ""),
+        }
+        authorized_keys = self._resolve_pubkey_list(cloud_init_config)
+        rendered = render_user_data_override(
+            user_data,
+            context=context,
+            authorized_keys=authorized_keys,
+            runcmd_prefix=runcmd_prefix,
+        )
+        fpath = os.path.join(machine.config_fpath, "user-data")
+        logger.info("Writing cloud-init user-data file (override) %s", fpath)
+        with open(fpath, "w", encoding="utf-8") as fh:
+            fh.write(rendered)
+        return fpath
+
+    @staticmethod
+    def _resolve_pubkey_list(cloud_init_config: dict[str, Any]) -> list[str]:
+        """Resolve a single ``cloud_init.pubkey`` value to a list of SSH keys.
+
+        The manifest accepts ``cloud_init.pubkey`` as either a literal
+        SSH key string or a path on disk (``~``-expanded). The structured
+        path resolves it in :class:`UserData.__post_init__`; the override
+        path needs the same resolution to feed into
+        :func:`render_user_data_override`'s ``authorized_keys``.
+
+        Returns:
+            A single-element list (or empty list when no pubkey is set).
+            A path that doesn't exist or doesn't look like an SSH key is
+            logged and dropped — same forgiving behaviour as the
+            structured path.
+        """
+        pubkey = cloud_init_config.get("pubkey")
+        if not pubkey:
+            return []
+        if "~" in pubkey or "/" in pubkey:
+            pubkey_path = os.path.expanduser(pubkey)
+            try:
+                with open(pubkey_path, "r", encoding="utf-8") as fh:
+                    return [fh.read().strip()]
+            except OSError as exc:
+                logger.warning("Could not read pubkey file %s: %s", pubkey_path, exc)
+                return []
+        return [pubkey.strip()]
 
     def _ensure_config_dir(self) -> None:
         """Create the machine's ``config_fpath`` if absent.

--- a/src/tkc_lvlab/utils/libvirt.py
+++ b/src/tkc_lvlab/utils/libvirt.py
@@ -761,13 +761,17 @@ class Machine:
                     f"{iface.get('name', '<unnamed>')!r}. "
                     f"Valid values: {', '.join(NETWORK_TYPES)}."
                 )
-            if network_type in USER_MODE_NETWORK_TYPES and iface.get("ip4"):
+            if network_type in USER_MODE_NETWORK_TYPES and (
+                iface.get("ip4") or iface.get("ip6")
+            ):
+                static_field = "ip4" if iface.get("ip4") else "ip6"
                 raise ValueError(
                     f"Interface {iface.get('name', '<unnamed>')!r} declares "
                     f"network_type={network_type!r} together with a static "
-                    f"ip4 ({iface['ip4']!r}). User-mode networking "
-                    f"(SLIRP/passt) does not honour static IPs — remove the "
-                    f"ip4 field or switch to network_type='network'."
+                    f"{static_field} ({iface[static_field]!r}). User-mode "
+                    f"networking (SLIRP/passt) does not honour static IPs — "
+                    f"remove the {static_field} field or switch to "
+                    f"network_type='network'."
                 )
 
         # Apply disk defaults

--- a/src/tkc_lvlab/utils/network.py
+++ b/src/tkc_lvlab/utils/network.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 import ipaddress
 import secrets
+from typing import Any
 import xml.etree.ElementTree as ET
 
 from ..exceptions import LibvirtNetworkError, VirshError
@@ -77,6 +78,13 @@ USER_MODE_NETWORK_TYPES: frozenset[str] = frozenset({"user", "passt"})
 class LibvirtNetworkInfo:
     """Network details resolved from ``virsh net-dumpxml``.
 
+    A dual-stack network exposes both ``gateway_ip``/``netmask`` (IPv4)
+    and ``gateway_ip6``/``prefix6`` (IPv6) — libvirt emits them as two
+    separate ``<ip>`` elements within the same ``<network>``. The v4 side
+    uses ``netmask`` and omits the ``family`` attribute; the v6 side uses
+    ``family='ipv6'`` and ``prefix``. v4-only and v6-only networks leave
+    the unused family's fields ``None``.
+
     Attributes:
         name: The libvirt network name (passed to ``net-dumpxml``).
         forward_mode: Lowercase forward mode reported by libvirt — typically
@@ -85,9 +93,15 @@ class LibvirtNetworkInfo:
         gateway_ip: First IPv4 gateway address declared in the network XML,
             or ``None`` if absent.
         netmask: First IPv4 netmask declared, or ``None`` if absent.
-        dhcp_start: First IP of the DHCP range, or ``None`` when no DHCP
+        dhcp_start: First IP of the v4 DHCP range, or ``None`` when no DHCP
             range is configured (typical for bridge networks).
-        dhcp_end: Last IP of the DHCP range, or ``None``.
+        dhcp_end: Last IP of the v4 DHCP range, or ``None``.
+        gateway_ip6: First IPv6 gateway address declared, or ``None`` when
+            the network is v4-only.
+        prefix6: IPv6 prefix length (integer, e.g. ``64``) declared on the
+            v6 ``<ip>`` element, or ``None`` when v6 is absent.
+        dhcp6_start: First IP of the IPv6 DHCP range, or ``None``.
+        dhcp6_end: Last IP of the IPv6 DHCP range, or ``None``.
     """
 
     name: str
@@ -96,6 +110,10 @@ class LibvirtNetworkInfo:
     netmask: str | None
     dhcp_start: str | None
     dhcp_end: str | None
+    gateway_ip6: str | None = None
+    prefix6: int | None = None
+    dhcp6_start: str | None = None
+    dhcp6_end: str | None = None
 
     @property
     def subnet(self) -> ipaddress.IPv4Network | None:
@@ -110,6 +128,19 @@ class LibvirtNetworkInfo:
         if self.gateway_ip is None or self.netmask is None:
             return None
         return ipaddress.IPv4Network(f"{self.gateway_ip}/{self.netmask}", strict=False)
+
+    @property
+    def subnet6(self) -> ipaddress.IPv6Network | None:
+        """Return the IPv6 subnet inferred from ``gateway_ip6`` + ``prefix6``.
+
+        Returns:
+            The :class:`ipaddress.IPv6Network` covering the v6 gateway
+            address with ``strict=False``, or ``None`` if either
+            ``gateway_ip6`` or ``prefix6`` is missing.
+        """
+        if self.gateway_ip6 is None or self.prefix6 is None:
+            return None
+        return ipaddress.IPv6Network(f"{self.gateway_ip6}/{self.prefix6}", strict=False)
 
 
 def get_network_info(uri: str, network_name: str) -> LibvirtNetworkInfo:
@@ -156,43 +187,123 @@ def get_network_info(uri: str, network_name: str) -> LibvirtNetworkInfo:
         else "none"
     )
 
-    ip_element = root.find("ip")
-    gateway_ip = ip_element.attrib.get("address") if ip_element is not None else None
-    netmask = ip_element.attrib.get("netmask") if ip_element is not None else None
-
-    dhcp_range = ip_element.find("dhcp/range") if ip_element is not None else None
-    dhcp_start = dhcp_range.attrib.get("start") if dhcp_range is not None else None
-    dhcp_end = dhcp_range.attrib.get("end") if dhcp_range is not None else None
+    # libvirt represents IPv4 and IPv6 as separate ``<ip>`` siblings.
+    # _split_ip_elements_by_family routes each one to the right slot so
+    # dual-stack networks expose both pairs of fields.
+    v4, v6 = _split_ip_elements_by_family(root, network_name)
 
     return LibvirtNetworkInfo(
         name=network_name,
         forward_mode=forward_mode,
-        gateway_ip=gateway_ip,
-        netmask=netmask,
-        dhcp_start=dhcp_start,
-        dhcp_end=dhcp_end,
+        gateway_ip=v4.get("gateway_ip"),
+        netmask=v4.get("netmask"),
+        dhcp_start=v4.get("dhcp_start"),
+        dhcp_end=v4.get("dhcp_end"),
+        gateway_ip6=v6.get("gateway_ip6"),
+        prefix6=v6.get("prefix6"),
+        dhcp6_start=v6.get("dhcp6_start"),
+        dhcp6_end=v6.get("dhcp6_end"),
     )
+
+
+def _split_ip_elements_by_family(
+    root: ET.Element, network_name: str
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Walk ``<ip>`` siblings and split their attributes by address family.
+
+    v4 elements omit ``family`` or set it to ``ipv4``; v6 carries
+    ``family='ipv6'``. Each family's fields come from the FIRST matching
+    element (later duplicates are ignored — libvirt allows multiple
+    same-family ``<ip>`` elements for secondary addresses but the lvlab
+    callers only need one of each).
+
+    Args:
+        root: The ``<network>`` element from ``virsh net-dumpxml``.
+        network_name: Used in the error message when an IPv6 ``prefix``
+            attribute is non-integer.
+
+    Returns:
+        Tuple ``(v4_attrs, v6_attrs)`` where each dict carries the
+        family-specific keys consumed by :class:`LibvirtNetworkInfo`.
+        Missing fields are simply absent from the dict (the caller uses
+        ``.get(...)`` and forwards ``None`` defaults).
+
+    Raises:
+        LibvirtNetworkError: An IPv6 ``<ip>`` element declared a
+            ``prefix`` attribute that wasn't an integer.
+    """
+    v4: dict[str, Any] = {}
+    v6: dict[str, Any] = {}
+    for ip_element in root.findall("ip"):
+        family = ip_element.attrib.get("family", "ipv4").lower()
+        dhcp_range = ip_element.find("dhcp/range")
+        range_start = dhcp_range.attrib.get("start") if dhcp_range is not None else None
+        range_end = dhcp_range.attrib.get("end") if dhcp_range is not None else None
+        if family == "ipv6":
+            if v6:
+                continue
+            v6["gateway_ip6"] = ip_element.attrib.get("address")
+            v6["prefix6"] = _parse_ipv6_prefix(
+                ip_element.attrib.get("prefix"), network_name
+            )
+            v6["dhcp6_start"] = range_start
+            v6["dhcp6_end"] = range_end
+        else:
+            if v4:
+                continue
+            v4["gateway_ip"] = ip_element.attrib.get("address")
+            v4["netmask"] = ip_element.attrib.get("netmask")
+            v4["dhcp_start"] = range_start
+            v4["dhcp_end"] = range_end
+    return v4, v6
+
+
+def _parse_ipv6_prefix(prefix_attr: str | None, network_name: str) -> int | None:
+    """Coerce a libvirt ``<ip prefix='N'>`` attribute to an integer.
+
+    Raises:
+        LibvirtNetworkError: ``prefix_attr`` is present but non-integer.
+    """
+    if prefix_attr is None:
+        return None
+    try:
+        return int(prefix_attr)
+    except ValueError as exc:
+        raise LibvirtNetworkError(
+            f"Network '{network_name}' has a non-integer IPv6 "
+            f"prefix '{prefix_attr}' in net-dumpxml output."
+        ) from exc
 
 
 def validate_static_ip(vm_ip: str, network_info: LibvirtNetworkInfo) -> None:
     """Verify a candidate static IP fits within the network's subnet and avoids the DHCP pool.
 
-    Two checks:
+    Dual-stack aware: ``vm_ip``'s address family (v4 vs v6) selects which
+    subnet and DHCP range to check against. A v4 address validates against
+    :attr:`LibvirtNetworkInfo.subnet` / ``dhcp_start``/``dhcp_end``; a v6
+    address validates against :attr:`LibvirtNetworkInfo.subnet6` /
+    ``dhcp6_start``/``dhcp6_end``. When the relevant family's subnet is
+    unknown (e.g. validating a v6 address against a v4-only network), the
+    checks are skipped — same opt-out as the v4-only path that predated
+    dual-stack.
 
-    1. The IP must be inside :attr:`LibvirtNetworkInfo.subnet` when subnet
-        information is available. (When gateway or netmask is missing from
-        the network XML the subnet is ``None`` and the check is skipped —
-        the operator has implicitly opted out of subnet validation by
-        configuring an incomplete network.)
-    1. When the network has a DHCP range declared, the IP must NOT fall
-        inside ``[dhcp_start, dhcp_end]`` inclusive. A static IP inside
-        the DHCP range would race the libvirt DHCP server on every
-        boot.
+    Two checks (per family):
+
+    1. The IP must be inside the family-appropriate subnet when subnet
+        information is available. (When gateway or netmask/prefix is
+        missing from the network XML the subnet is ``None`` and the
+        check is skipped — the operator has implicitly opted out of
+        subnet validation by configuring an incomplete network.)
+    1. When the network has a DHCP range declared for that family, the
+        IP must NOT fall inside ``[dhcp_start, dhcp_end]`` inclusive. A
+        static IP inside the DHCP range would race the libvirt DHCP
+        server on every boot.
 
     Args:
-        vm_ip: The candidate IP, either as a bare address (``192.168.122.50``)
-            or with a CIDR suffix (``192.168.122.50/24``). The CIDR is
-            stripped before comparison.
+        vm_ip: The candidate IP, either as a bare address
+            (``192.168.122.50`` or ``2001:db8::5``) or with a CIDR
+            suffix (``192.168.122.50/24`` or ``2001:db8::5/64``). The
+            CIDR is stripped before comparison.
         network_info: A populated :class:`LibvirtNetworkInfo`.
 
     Raises:
@@ -202,19 +313,28 @@ def validate_static_ip(vm_ip: str, network_info: LibvirtNetworkInfo) -> None:
     """
     ip_value = ipaddress.ip_interface(vm_ip).ip
 
-    if network_info.subnet is not None and ip_value not in network_info.subnet:
+    if ip_value.version == 6:
+        subnet = network_info.subnet6
+        dhcp_start_str = network_info.dhcp6_start
+        dhcp_end_str = network_info.dhcp6_end
+    else:
+        subnet = network_info.subnet
+        dhcp_start_str = network_info.dhcp_start
+        dhcp_end_str = network_info.dhcp_end
+
+    if subnet is not None and ip_value not in subnet:
         raise ValueError(
-            f"IP address '{ip_value}' is not in subnet '{network_info.subnet}' "
+            f"IP address '{ip_value}' is not in subnet '{subnet}' "
             f"for network '{network_info.name}'."
         )
 
-    if network_info.dhcp_start and network_info.dhcp_end:
-        dhcp_start = ipaddress.ip_address(network_info.dhcp_start)
-        dhcp_end = ipaddress.ip_address(network_info.dhcp_end)
+    if dhcp_start_str and dhcp_end_str:
+        dhcp_start = ipaddress.ip_address(dhcp_start_str)
+        dhcp_end = ipaddress.ip_address(dhcp_end_str)
         if dhcp_start <= ip_value <= dhcp_end:
             raise ValueError(
                 f"IP address '{ip_value}' falls within DHCP range "
-                f"'{network_info.dhcp_start}-{network_info.dhcp_end}' for "
+                f"'{dhcp_start_str}-{dhcp_end_str}' for "
                 f"network '{network_info.name}'. Choose a static IP outside "
                 "that range."
             )
@@ -289,4 +409,70 @@ def resolve_network_settings(
         f"Network '{network_info.name}' forward mode "
         f"'{network_info.forward_mode}' is unsupported. Use a NAT network, "
         "or a bridge network with default_dns/default_gateway provided."
+    )
+
+
+def resolve_network_settings6(
+    network_info: LibvirtNetworkInfo,
+    *,
+    default_dns6: list[str] | None = None,
+    default_gateway6: str | None = None,
+    default_search: list[str] | None = None,
+) -> tuple[list[str], str, list[str]]:
+    """IPv6 sibling of :func:`resolve_network_settings`.
+
+    Same forward-mode policy as the v4 variant, but everything is keyed
+    off the v6 fields (``gateway_ip6``, ``dhcp6_*``):
+
+    - **NAT networks** derive DNS6 and gateway6 from the v6 ``<ip>``
+        element of the network XML (libvirt's optional dnsmasq6 listens
+        on the v6 gateway address when configured). ``default_dns6`` /
+        ``default_gateway6`` are ignored.
+    - **Bridge networks** require the caller to supply both
+        ``default_dns6`` and ``default_gateway6``.
+    - Any other forward mode raises :class:`LibvirtNetworkError`.
+
+    Args:
+        network_info: A populated :class:`LibvirtNetworkInfo`.
+        default_dns6: IPv6 DNS servers for the bridge case. Ignored for NAT.
+        default_gateway6: IPv6 gateway for the bridge case. Ignored for NAT.
+        default_search: Search domains, passed through verbatim. Defaults
+            to an empty list when omitted.
+
+    Returns:
+        ``(dns6_servers, gateway6, search_domains)``.
+
+    Raises:
+        LibvirtNetworkError: NAT network without a v6 gateway, bridge
+            without both ``default_dns6`` and ``default_gateway6``, or
+            an unsupported forward mode.
+    """
+    mode = network_info.forward_mode.lower()
+    search_domains = list(default_search or [])
+
+    if mode == "nat":
+        if network_info.gateway_ip6 is None:
+            raise LibvirtNetworkError(
+                f"Network '{network_info.name}' is NAT but has no IPv6 gateway "
+                "address configured."
+            )
+        return (
+            [network_info.gateway_ip6],
+            network_info.gateway_ip6,
+            search_domains,
+        )
+
+    if mode == "bridge":
+        if not default_dns6 or not default_gateway6:
+            raise LibvirtNetworkError(
+                f"Network '{network_info.name}' is a bridge. Supply explicit "
+                "default_dns6 and default_gateway6, or use a NAT network."
+            )
+        return list(default_dns6), default_gateway6, search_domains
+
+    raise LibvirtNetworkError(
+        f"Network '{network_info.name}' forward mode "
+        f"'{network_info.forward_mode}' is unsupported for IPv6. Use a NAT "
+        "network, or a bridge network with default_dns6/default_gateway6 "
+        "provided."
     )

--- a/src/tkc_lvlab/utils/standalone_cloud_init.py
+++ b/src/tkc_lvlab/utils/standalone_cloud_init.py
@@ -37,14 +37,21 @@ from ..exceptions import CloudInitError
 _DEFAULT_SUDO = "ALL=(ALL) NOPASSWD:ALL"
 _DEFAULT_SHELL = "/bin/bash"
 
-# Placeholders a ``user_data:`` override may reference. ``createvm`` fills
-# these from the resolved create context; an override naming anything else is
-# a hard error (see ``render_user_data_override``) rather than a silent blank.
+# Placeholders a ``user_data:`` override may reference. ``createvm`` and
+# the manifest ``lvlab up`` path both fill these from their resolved per-VM
+# context; an override naming anything else is a hard error (see
+# ``render_user_data_override``) rather than a silent blank.
+#
+# ``fqdn`` and ``environment`` were added for #140 (lvlab up parity).
+# createvm has no environment concept and fills ``environment`` as the
+# empty string; its ``fqdn`` mirrors ``vm_name``.
 USER_DATA_PLACEHOLDERS: tuple[str, ...] = (
     "vm_name",
     "vm_hostname",
+    "fqdn",
     "default_vm_username",
     "password_hash",
+    "environment",
 )
 
 

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -255,3 +255,82 @@ def test_status_image_missing_url_does_not_crash(tmp_path) -> None:
     assert result.exit_code == 0, result.output
     assert "broken" in result.output
     assert "missing image_url" in result.output
+
+
+# ---------------------------------------------------------------------------
+# #149: friendly landing when Lvlab.yml is absent (vs. invalid)
+# ---------------------------------------------------------------------------
+
+
+def test_status_no_manifest_renders_friendly_landing() -> None:
+    """``lvlab status`` from a directory with no Lvlab.yml shows the landing.
+
+    Distinct from a parse error: ``parse_config`` returning ``None`` is the
+    soft "file doesn't exist" signal. The landing exit-0s with: a
+    no-manifest hint, the built-in images table, a ``createvm`` pointer,
+    and a docs URL. A first-time user gets an actionable starting point
+    instead of the pre-#149 ``ERROR Could not parse config file.`` line.
+    """
+    runner = CliRunner()
+    with (
+        mock.patch.object(cli, "parse_config", return_value=None),
+        mock.patch.object(cli, "virsh_list_all_names") as list_mock,
+    ):
+        result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0, result.output
+    out = result.output
+    # No-manifest hint clearly informational, not an error.
+    assert "No Lvlab.yml" in out
+    # Built-in images table renders even without a manifest — same shape
+    # _build_images_table uses on the happy path.
+    assert "Images" in out
+    assert "default" in out
+    # Confirm a couple of the built-ins from the catalog are listed so the
+    # user can see what's downloadable out of the box.
+    assert "debian13" in out
+    assert "fedora44" in out
+    # createvm pointer + a concrete usage hint.
+    assert "createvm" in out
+    # Docs link so the manifest-authoring path is reachable.
+    assert "github.com/memblin/tkc-lvlab-py" in out
+    # Never touches the hypervisor — there's no environment to query.
+    list_mock.assert_not_called()
+
+
+def test_status_no_manifest_does_not_emit_parse_error_log() -> None:
+    """Absence is NOT an error — no ``Could not parse config file`` log.
+
+    Regression guard for the #149 split: the pre-#149 behaviour treated
+    file-absent and file-invalid identically, dumping the same error
+    line. The landing path must stay silent on the error log.
+    """
+    runner = CliRunner()
+    with mock.patch.object(cli, "parse_config", return_value=None):
+        result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert "Could not parse config file" not in result.output
+
+
+def test_status_invalid_manifest_still_exits_one() -> None:
+    """A structurally-invalid manifest (ConfigError) still exits 1 loudly.
+
+    Regression guard for the OTHER half of the #149 split: only the
+    soft "file missing" path routes to the landing. A real parse error
+    keeps today's error-log + exit-1 behaviour so misconfigurations
+    don't silently hide behind a friendly screen.
+    """
+    from tkc_lvlab.exceptions import ConfigError
+
+    runner = CliRunner()
+    with (
+        mock.patch.object(
+            cli, "parse_config", side_effect=ConfigError("manifest malformed")
+        ),
+        mock.patch.object(cli, "virsh_list_all_names") as list_mock,
+    ):
+        result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 1
+    list_mock.assert_not_called()

--- a/tests/test_cli_status.py
+++ b/tests/test_cli_status.py
@@ -292,8 +292,8 @@ def test_status_no_manifest_renders_friendly_landing() -> None:
     assert "fedora44" in out
     # createvm pointer + a concrete usage hint.
     assert "createvm" in out
-    # Docs link so the manifest-authoring path is reachable.
-    assert "github.com/memblin/tkc-lvlab-py" in out
+    # Docs link → the published mkdocs site (not the source repo).
+    assert "memblin.github.io/tkc-lvlab-py" in out
     # Never touches the hypervisor — there's no environment to query.
     list_mock.assert_not_called()
 

--- a/tests/test_cloud_init_network_config.py
+++ b/tests/test_cloud_init_network_config.py
@@ -251,3 +251,172 @@ def test_v1_matches_by_mac_address_when_pinned() -> None:
     # Still ENI, never netplan match keywords.
     assert "virtio_net" not in rendered
     assert "set-name" not in rendered
+
+
+# ---------------------------------------------------------------------------
+# IPv6 dual-stack rendering (#137) — v2 (netplan)
+# ---------------------------------------------------------------------------
+
+
+def test_v2_dual_stack_renders_both_v4_and_v6_addresses() -> None:
+    """A dual-stack interface emits BOTH v4 and v6 addresses, a v6 route, and disables both DHCPs.
+
+    netplan accepts a mixed-family ``addresses`` list and per-family
+    routes. Disabling ``dhcp4`` and ``dhcp6`` is what stops cloud-init
+    from also requesting a DHCPv6 lease that would conflict with our
+    static v6 (#137).
+    """
+    nc = NetworkConfig(
+        network_version=NetworkVersion.V2,
+        interfaces=[
+            {
+                "name": "eth0",
+                "macaddress": "52:54:00:ab:cd:ef",
+                "ip4": "192.168.130.50/24",
+                "ip4gw": "192.168.130.1",
+                "ip6": "2001:db8:130::50/64",
+                "ip6gw": "2001:db8:130::1",
+            }
+        ],
+        nameservers=_empty_nameservers(),
+    )
+    parsed = yaml.safe_load(nc.render_config())
+
+    eth0 = parsed["network"]["ethernets"]["eth0"]
+    assert eth0["dhcp4"] is False
+    assert eth0["dhcp6"] is False
+    # Both addresses present, in v4-then-v6 order.
+    assert "192.168.130.50/24" in eth0["addresses"]
+    assert "2001:db8:130::50/64" in eth0["addresses"]
+    # Both default-routes rendered.
+    routes = eth0["routes"]
+    v4_route = {"to": "0.0.0.0/0", "via": "192.168.130.1"}
+    v6_route = {"to": "::/0", "via": "2001:db8:130::1"}
+    assert v4_route in routes
+    assert v6_route in routes
+
+
+def test_v2_v6_only_static_renders_v6_with_dhcp4_unchanged() -> None:
+    """A v6-static-only interface (no ip4) still leaves dhcp4 on by default.
+
+    First-cut scope of #137 is dual-stack only — v6-only guests are
+    explicitly out of scope (the maintainer keeps v4 reachability for
+    lvlab's IP-resolution paths). But the renderer should still emit
+    coherent output when only ``ip6`` is set: dhcp6 off, v6 address +
+    route present, dhcp4 stays at its default (true) so the operator
+    can opt in to v4 reachability via DHCP.
+    """
+    nc = NetworkConfig(
+        network_version=NetworkVersion.V2,
+        interfaces=[
+            {
+                "name": "eth0",
+                "macaddress": "52:54:00:ab:cd:ef",
+                "ip6": "2001:db8:130::5/64",
+                "ip6gw": "2001:db8:130::1",
+            }
+        ],
+        nameservers=_empty_nameservers(),
+    )
+    parsed = yaml.safe_load(nc.render_config())
+
+    eth0 = parsed["network"]["ethernets"]["eth0"]
+    assert eth0["dhcp6"] is False
+    assert "2001:db8:130::5/64" in eth0["addresses"]
+    assert {"to": "::/0", "via": "2001:db8:130::1"} in eth0["routes"]
+
+
+def test_v2_dhcp_only_does_not_emit_addresses_or_routes() -> None:
+    """A purely-DHCP interface (no ip4 and no ip6) emits no addresses/routes block.
+
+    Regression guard: adding IPv6 support must not regress the DHCP-only
+    render path that #128 et al rely on.
+    """
+    nc = NetworkConfig(
+        network_version=NetworkVersion.V2,
+        interfaces=[{"name": "eth0", "macaddress": "52:54:00:aa:bb:cc"}],
+        nameservers=_empty_nameservers(),
+    )
+    parsed = yaml.safe_load(nc.render_config())
+
+    eth0 = parsed["network"]["ethernets"]["eth0"]
+    assert eth0["dhcp4"] is True
+    assert eth0["dhcp6"] is True
+    assert "addresses" not in eth0
+    assert "routes" not in eth0
+
+
+# ---------------------------------------------------------------------------
+# IPv6 dual-stack rendering (#137) — v1 (ENI)
+# ---------------------------------------------------------------------------
+
+
+def test_v1_dual_stack_renders_static6_subnet_alongside_static4() -> None:
+    """v1 ENI emits a ``type: static6`` subnet entry next to the v4 ``type: static``.
+
+    cloud-init's ENI renderer accepts a list of subnets per physical
+    interface; one per address family is the canonical shape for
+    dual-stack (used by Debian 11 cloud images, which lvlab pins to
+    network-config v1 to dodge the netplan DHCPv6 hang).
+    """
+    nc = NetworkConfig(
+        network_version=NetworkVersion.V1,
+        interfaces=[
+            {
+                "name": "eth0",
+                "macaddress": "52:54:00:ab:cd:ef",
+                "ip4": "192.168.130.50/24",
+                "ip4gw": "192.168.130.1",
+                "ip6": "2001:db8:130::50/64",
+                "ip6gw": "2001:db8:130::1",
+            }
+        ],
+        nameservers=_empty_nameservers(),
+    )
+    parsed = yaml.safe_load(nc.render_config())
+
+    iface = parsed["network"]["config"][0]
+    subnets = iface["subnets"]
+    # Two subnets, one v4 static and one v6 static.
+    types = {s["type"] for s in subnets}
+    assert types == {"static", "static6"}
+    v6_entry = next(s for s in subnets if s["type"] == "static6")
+    assert v6_entry["address"] == "2001:db8:130::50/64"
+    assert v6_entry["gateway"] == "2001:db8:130::1"
+
+
+def test_v1_v6_only_renders_static6_subnet_alone() -> None:
+    """A v6-only ip6/ip6gw interface emits just the static6 subnet."""
+    nc = NetworkConfig(
+        network_version=NetworkVersion.V1,
+        interfaces=[
+            {
+                "name": "eth0",
+                "macaddress": "52:54:00:ab:cd:ef",
+                "ip6": "2001:db8:130::5/64",
+                "ip6gw": "2001:db8:130::1",
+            }
+        ],
+        nameservers=_empty_nameservers(),
+    )
+    parsed = yaml.safe_load(nc.render_config())
+
+    iface = parsed["network"]["config"][0]
+    subnets = iface["subnets"]
+    types = [s["type"] for s in subnets]
+    # Without ip4 there is no v4 ``static`` entry — only static6.
+    assert "static6" in types
+    assert "static" not in types
+
+
+def test_v1_dhcp_only_renders_dhcp4_subnet() -> None:
+    """v1 DHCP-only stays unchanged — regression guard for #137."""
+    nc = NetworkConfig(
+        network_version=NetworkVersion.V1,
+        interfaces=[{"name": "eth0", "macaddress": "52:54:00:aa:bb:cc"}],
+        nameservers=_empty_nameservers(),
+    )
+    parsed = yaml.safe_load(nc.render_config())
+
+    iface = parsed["network"]["config"][0]
+    assert iface["subnets"] == [{"type": "dhcp4"}]

--- a/tests/test_createvm.py
+++ b/tests/test_createvm.py
@@ -1116,3 +1116,222 @@ def test_no_color_flag_disables_color(monkeypatch: pytest.MonkeyPatch) -> None:
         assert output.color_disabled() is True
     finally:
         output.set_no_color(False)
+
+
+# ---------------------------------------------------------------------------
+# IPv6 dual-stack (#137)
+# ---------------------------------------------------------------------------
+
+
+def _dualstack_nat_network_info() -> LibvirtNetworkInfo:
+    """A NAT network with both v4 and v6 ranges (libvirt dual-stack default)."""
+    return LibvirtNetworkInfo(
+        name="default",
+        forward_mode="nat",
+        gateway_ip="192.168.122.1",
+        netmask="255.255.255.0",
+        dhcp_start="192.168.122.2",
+        dhcp_end="192.168.122.254",
+        gateway_ip6="2001:db8:122::1",
+        prefix6=64,
+        dhcp6_start="2001:db8:122::100",
+        dhcp6_end="2001:db8:122::1ff",
+    )
+
+
+def test_parse_ip6_bare_uses_default_network() -> None:
+    """A bare v6 address uses the default network — mirrors parse_ip4_option."""
+    from tkc_lvlab.scripts.createvm import parse_ip6_option
+
+    assert parse_ip6_option("2001:db8::5", "default") == ("default", "2001:db8::5")
+
+
+def test_parse_ip6_network_comma_ip() -> None:
+    """NETWORK,IP form splits into network + IP for v6 too."""
+    from tkc_lvlab.scripts.createvm import parse_ip6_option
+
+    assert parse_ip6_option("vlan10,2001:db8:10::5", "default") == (
+        "vlan10",
+        "2001:db8:10::5",
+    )
+
+
+@pytest.mark.parametrize("sentinel", ["dhcp", "default", "auto"])
+def test_parse_ip6_dhcp_sentinel_means_dhcp(sentinel: str) -> None:
+    """DHCP sentinels in --ip6 mean SLAAC/DHCPv6 — raw IP comes back as None."""
+    from tkc_lvlab.scripts.createvm import parse_ip6_option
+
+    assert parse_ip6_option(sentinel, "default") == ("default", None)
+
+
+def test_parse_ip6_bare_network_name_means_dhcp_on_that_network() -> None:
+    """``--ip6 vlan10`` selects vlan10 with SLAAC/DHCPv6 (no static)."""
+    from tkc_lvlab.scripts.createvm import parse_ip6_option
+
+    assert parse_ip6_option("vlan10", "default") == ("vlan10", None)
+
+
+def test_parse_ip6_rejects_empty_segments() -> None:
+    """Comma form with empty network or empty IP is rejected."""
+    from tkc_lvlab.scripts.createvm import parse_ip6_option
+
+    with pytest.raises(ValueError, match="Invalid --ip6"):
+        parse_ip6_option("vlan10,", "default")
+    with pytest.raises(ValueError, match="Invalid --ip6"):
+        parse_ip6_option(",2001:db8::5", "default")
+
+
+def test_ip6_renders_into_network_config(
+    all_external_mocked: dict, tmp_path: Path
+) -> None:
+    """A --ip6 argument reaches the guest network-config as a v6 address + route."""
+    all_external_mocked["get_network_info"].return_value = _dualstack_nat_network_info()
+    result = _invoke(
+        ["testvm.local", "debian12", "--ip6", "2001:db8:122::50"], tmp_path
+    )
+    assert result.exit_code == 0, result.output
+    network_config = (tmp_path / "testvm.local" / "network-config").read_text()
+    assert "2001:db8:122::50/64" in network_config
+    # v6 default route via the network's v6 gateway.
+    assert "::/0" in network_config
+    assert "2001:db8:122::1" in network_config
+
+
+def test_ip6_dual_stack_renders_both_addresses(
+    all_external_mocked: dict, tmp_path: Path
+) -> None:
+    """--ip4 + --ip6 together: both addresses + both gateways land in network-config."""
+    all_external_mocked["get_network_info"].return_value = _dualstack_nat_network_info()
+    result = _invoke(
+        [
+            "testvm.local",
+            "debian12",
+            "--ip4",
+            "192.168.122.50",
+            "--ip6",
+            "2001:db8:122::50",
+        ],
+        tmp_path,
+    )
+    assert result.exit_code == 0, result.output
+    network_config = (tmp_path / "testvm.local" / "network-config").read_text()
+    assert "192.168.122.50/24" in network_config
+    assert "2001:db8:122::50/64" in network_config
+    # Both default routes.
+    assert "0.0.0.0/0" in network_config
+    assert "::/0" in network_config
+
+
+def test_ip6_dhcp_sentinel_does_not_render_static(
+    all_external_mocked: dict, tmp_path: Path
+) -> None:
+    """--ip6 dhcp leaves the dhcp6 path — no static v6 in network-config."""
+    all_external_mocked["get_network_info"].return_value = _dualstack_nat_network_info()
+    result = _invoke(["testvm.local", "debian12", "--ip6", "dhcp"], tmp_path)
+    assert result.exit_code == 0, result.output
+    network_config = (tmp_path / "testvm.local" / "network-config").read_text()
+    # No static v6 address rendered (only the dhcp6 path).
+    assert "2001:db8" not in network_config
+
+
+def test_ip6_in_dhcp6_range_errors(all_external_mocked: dict, tmp_path: Path) -> None:
+    """A static v6 inside the v6 DHCP range errors via validate_static_ip."""
+    all_external_mocked["get_network_info"].return_value = _dualstack_nat_network_info()
+
+    # Simulate the dual-stack-aware validator rejecting only the v6 boundary.
+    def _validate_side(vm_ip: str, _info: LibvirtNetworkInfo) -> None:
+        if ":" in vm_ip:  # v6
+            raise ValueError(
+                "IP address '2001:db8:122::100' falls within DHCP range "
+                "'2001:db8:122::100-2001:db8:122::1ff' for network 'default'."
+            )
+
+    all_external_mocked["validate_static_ip"].side_effect = _validate_side
+    result = _invoke(
+        ["testvm.local", "debian12", "--ip6", "2001:db8:122::100"], tmp_path
+    )
+    assert result.exit_code != 0
+    assert "DHCP range" in result.output
+
+
+def test_ip6_invalid_address_gives_clean_error(
+    all_external_mocked: dict, tmp_path: Path
+) -> None:
+    """A malformed --ip6 value yields the createvm-shaped actionable error.
+
+    The value here is hex-and-colons only (so it passes the IP-ish gate
+    and stays on the static path) but has too many groups to be a valid
+    IPv6 address. Mirrors how ``--ip4 192.168.1.300`` reaches the v4
+    validator: parser-rejected, not network-name-treated.
+    """
+    all_external_mocked["get_network_info"].return_value = _dualstack_nat_network_info()
+    result = _invoke(
+        ["testvm.local", "debian12", "--ip6", "2001:db8::1:2:3:4:5:6:7"], tmp_path
+    )
+    assert result.exit_code != 0
+    out = result.output
+    # The createvm-shaped error names the flag and points at --ip6 dhcp.
+    assert "--ip6" in out
+    assert "dhcp" in out
+
+
+def test_ip6_on_bridge_without_gateway6_dns6_errors(
+    all_external_mocked: dict, tmp_path: Path
+) -> None:
+    """Static --ip6 on a bridge requires --gateway6 + --dns6 (parallel to v4)."""
+    bridge_with_v6 = LibvirtNetworkInfo(
+        name="vlan10",
+        forward_mode="bridge",
+        gateway_ip=None,
+        netmask=None,
+        dhcp_start=None,
+        dhcp_end=None,
+        # Bridges typically have no libvirt-managed v6 gateway either —
+        # the operator picks it.
+        gateway_ip6=None,
+        prefix6=None,
+        dhcp6_start=None,
+        dhcp6_end=None,
+    )
+    all_external_mocked["get_network_info"].return_value = bridge_with_v6
+    result = _invoke(
+        ["testvm.local", "debian12", "--ip6", "vlan10,2001:db8:10::50"], tmp_path
+    )
+    assert result.exit_code != 0
+    assert "--gateway6" in result.output and "--dns6" in result.output
+
+
+def test_ip6_on_bridge_with_gateway6_dns6_passes_through(
+    all_external_mocked: dict, tmp_path: Path
+) -> None:
+    """--gateway6/--dns6 supplied: a bridge static v6 is accepted and renders."""
+    bridge_with_v6 = LibvirtNetworkInfo(
+        name="vlan10",
+        forward_mode="bridge",
+        gateway_ip=None,
+        netmask=None,
+        dhcp_start=None,
+        dhcp_end=None,
+        gateway_ip6=None,
+        prefix6=None,
+        dhcp6_start=None,
+        dhcp6_end=None,
+    )
+    all_external_mocked["get_network_info"].return_value = bridge_with_v6
+    result = _invoke(
+        [
+            "testvm.local",
+            "debian12",
+            "--ip6",
+            "vlan10,2001:db8:10::50",
+            "--gateway6",
+            "2001:db8:10::1",
+            "--dns6",
+            "2001:db8:10::1",
+        ],
+        tmp_path,
+    )
+    assert result.exit_code == 0, result.output
+    network_config = (tmp_path / "testvm.local" / "network-config").read_text()
+    assert "2001:db8:10::50/64" in network_config
+    assert "2001:db8:10::1" in network_config  # gateway/DNS

--- a/tests/test_createvm.py
+++ b/tests/test_createvm.py
@@ -368,17 +368,48 @@ def test_happy_path_positional_args(all_external_mocked: dict, tmp_path: Path) -
 
 
 def test_missing_arguments_errors(all_external_mocked: dict, tmp_path: Path) -> None:
-    """No positional args (and no --init-cloud-images) errors clearly."""
+    """No positional args (and no --init-cloud-images) errors with the boxed format.
+
+    Matches deletevm and every other lvlab CLI surface — Typer's
+    ``╭─ Error ─╮`` panel with a Usage hint, not the plain one-liner the
+    pre-#147 ``_fail`` path emitted.
+    """
     result = _invoke([], tmp_path)
     assert result.exit_code != 0
-    assert "Missing required arguments" in result.output
+    out = result.output
+    assert "Missing required arguments" in out
+    # The boxed format renders the message with the panel edge character
+    # in front of it. Locking this in stops the regression to the plain
+    # red one-liner.
+    assert "Usage:" in out
+    assert "Try 'createvm --help'" in out
+    assert "╭─ Error" in out
 
 
 def test_half_positional_pair_errors(all_external_mocked: dict, tmp_path: Path) -> None:
-    """Only VM_NAME (no VM_DISTRO) errors: they must be provided together."""
+    """Only VM_NAME (no VM_DISTRO) errors with the boxed format too."""
     result = _invoke(["testvm.local"], tmp_path)
     assert result.exit_code != 0
-    assert "must be provided together" in result.output
+    out = result.output
+    assert "must be provided together" in out
+    assert "Usage:" in out
+    assert "╭─ Error" in out
+
+
+def test_init_cloud_images_without_vm_args_does_not_error(
+    all_external_mocked: dict, tmp_path: Path
+) -> None:
+    """The --init-cloud-images path is the deliberate exception to the
+    "VM_NAME + VM_DISTRO required" rule — it must NOT trip the new
+    UsageError when invoked alone.
+
+    Regression guard for #147: the fix replaces the body-level ``_fail``
+    with ``click.UsageError`` only on the missing-args paths; the
+    init-only path stays intact.
+    """
+    result = _invoke(["--init-cloud-images"], tmp_path)
+    assert result.exit_code == 0, result.output
+    assert "Cloud images initialized" in result.output
 
 
 def test_version_flag() -> None:

--- a/tests/test_createvm.py
+++ b/tests/test_createvm.py
@@ -27,6 +27,7 @@ All subprocess calls are intercepted; pytest never invokes a real binary.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from pathlib import Path
 from unittest import mock
@@ -50,6 +51,20 @@ from tkc_lvlab.scripts.createvm import (
 )
 from tkc_lvlab.utils.network import LibvirtNetworkError, LibvirtNetworkInfo
 from tkc_lvlab.utils.requirements import DependencyError
+
+# Rich (Typer's error renderer) injects ANSI colour spans around literals
+# when the destination looks colour-capable — locally pytest usually runs
+# without TTY so they're absent, but CI's terminal detection often differs
+# and the codes split substring matches across boundaries (``Try `` in one
+# span, ``'createvm`` in another). Strip them before substring assertions
+# so the tests are terminal-agnostic.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    """Return ``text`` with all ANSI colour escape sequences stripped."""
+    return _ANSI_RE.sub("", text)
+
 
 _GIB = 1024**3
 
@@ -376,7 +391,7 @@ def test_missing_arguments_errors(all_external_mocked: dict, tmp_path: Path) -> 
     """
     result = _invoke([], tmp_path)
     assert result.exit_code != 0
-    out = result.output
+    out = _plain(result.output)
     assert "Missing required arguments" in out
     # The boxed format renders the message with the panel edge character
     # in front of it. Locking this in stops the regression to the plain
@@ -390,7 +405,7 @@ def test_half_positional_pair_errors(all_external_mocked: dict, tmp_path: Path) 
     """Only VM_NAME (no VM_DISTRO) errors with the boxed format too."""
     result = _invoke(["testvm.local"], tmp_path)
     assert result.exit_code != 0
-    out = result.output
+    out = _plain(result.output)
     assert "must be provided together" in out
     assert "Usage:" in out
     assert "╭─ Error" in out

--- a/tests/test_libvirt_cloud_init.py
+++ b/tests/test_libvirt_cloud_init.py
@@ -405,3 +405,177 @@ def test_cloud_init_emits_hosts_heredocs_by_default_when_flag_unset(
     _run_cloud_init(machine, {"cloud_init": {}}, captured)
     runcmd = captured[0].get("runcmd", [])
     assert len(_hosts_heredocs(runcmd)) == 2, runcmd
+
+
+# ---------------------------------------------------------------------------
+# user_data cloud-config override (#140) — lvlab up parity with createvm
+# ---------------------------------------------------------------------------
+
+
+def _run_cloud_init_capturing_userdata_file(
+    machine, config_defaults, **kwargs
+) -> tuple[str, list]:
+    """Variant of _run_cloud_init that returns (rendered_user_data_text, structured_capture).
+
+    The override path bypasses the ``UserData`` template render and writes
+    directly. This helper reads the on-disk user-data file the composer
+    produced and ALSO captures any structured render that happened, so
+    tests can assert the override path was taken (file content includes
+    the override) and the structured path was not (capture empty).
+    """
+    captured: list = []
+    _run_cloud_init(machine, config_defaults, captured, **kwargs)
+    user_data_path = Path(machine.config_fpath) / "user-data"
+    text = user_data_path.read_text() if user_data_path.exists() else ""
+    return text, captured
+
+
+def _override_doc() -> dict:
+    """A minimal user_data override exercising all six placeholders."""
+    return {
+        "hostname": "{vm_hostname}",
+        "fqdn": "{fqdn}",
+        "users": [
+            {
+                "name": "{default_vm_username}",
+                "passwd": "{password_hash}",
+                "shell": "/bin/bash",
+            }
+        ],
+        "runcmd": [
+            "echo {vm_name} in {environment}",
+        ],
+    }
+
+
+def test_cloud_init_user_data_override_renders_placeholders(
+    tmp_path: Path,
+) -> None:
+    """An override doc with placeholders is rendered with the resolved values.
+
+    The override path bypasses the structured UserData template — the
+    rendered text starts with ``#cloud-config`` (the override renderer's
+    convention) and contains every substituted value from the placeholder
+    context (vm_name, vm_hostname, fqdn, default_vm_username,
+    password_hash, environment).
+    """
+    machine = _make_machine(tmp_path)
+    machine.cloud_init_config = {"user_data": _override_doc()}
+    text, _ = _run_cloud_init_capturing_userdata_file(
+        machine,
+        {"cloud_init": {}},
+        password_hash="$6$rounds=4096$abc$xyz",
+    )
+    assert text.startswith("#cloud-config")
+    # Placeholder substitutions present:
+    assert "web01" in text  # {vm_name} and {vm_hostname}
+    assert "web01.test.local" in text  # {fqdn}
+    assert "debian" in text  # {default_vm_username} from image default
+    assert "$6$rounds=4096$abc$xyz" in text  # {password_hash}
+    assert "in test-env" in text  # {environment}
+
+
+def test_cloud_init_user_data_override_skips_structured_userdata_render(
+    tmp_path: Path,
+) -> None:
+    """The override path must NOT call into the structured UserData template.
+
+    Regression guard: if both paths fired, the override would be silently
+    clobbered by the structured render writing over the same file.
+    """
+    machine = _make_machine(tmp_path)
+    machine.cloud_init_config = {"user_data": _override_doc()}
+    _, structured_capture = _run_cloud_init_capturing_userdata_file(
+        machine,
+        {"cloud_init": {}},
+        password_hash="$6$abc$xyz",
+    )
+    # The structured-path UserData mock captures the cloud_init_config it
+    # was constructed with; an empty list means the structured render
+    # never fired.
+    assert structured_capture == []
+
+
+def test_cloud_init_user_data_override_prepends_hosts_heredocs(
+    tmp_path: Path,
+) -> None:
+    """manage_etc_hosts (default true) prepends hosts heredocs to override runcmd.
+
+    Decision matches createvm's runcmd-prefix behavior (#140): the
+    operator owns the override body, but lvlab still injects its
+    manifest-wide /etc/hosts bootstrap ahead of it. An operator who
+    doesn't want that prepend sets cloud_init.manage_etc_hosts: false.
+    """
+    machine = _make_machine(tmp_path)
+    machine.cloud_init_config = {"user_data": _override_doc()}
+    text, _ = _run_cloud_init_capturing_userdata_file(
+        machine,
+        {"cloud_init": {}},
+        password_hash="$6$abc$xyz",
+    )
+    # Both /etc/hosts heredocs appear ahead of the override's runcmd entry.
+    hosts_idx = text.find("## hosts heredoc for /etc/hosts")
+    template_idx = text.find("## hosts heredoc for /etc/cloud/templates/")
+    override_idx = text.find("echo web01 in test-env")
+    assert hosts_idx >= 0 and template_idx >= 0 and override_idx >= 0
+    assert hosts_idx < override_idx
+    assert template_idx < override_idx
+
+
+def test_cloud_init_user_data_override_skips_hosts_heredocs_when_manage_etc_hosts_false(
+    tmp_path: Path,
+) -> None:
+    """manage_etc_hosts: false → the override runcmd is rendered untouched."""
+    machine = _make_machine(tmp_path)
+    machine.cloud_init_config = {
+        "manage_etc_hosts": False,
+        "user_data": _override_doc(),
+    }
+    text, _ = _run_cloud_init_capturing_userdata_file(
+        machine,
+        {"cloud_init": {}},
+        password_hash="$6$abc$xyz",
+    )
+    assert "hosts heredoc" not in text
+    # Override runcmd is intact.
+    assert "echo web01 in test-env" in text
+
+
+def test_cloud_init_user_data_override_inherits_from_config_defaults(
+    tmp_path: Path,
+) -> None:
+    """A user_data set ONLY in config_defaults.cloud_init applies to the machine.
+
+    Mirrors how every other cloud_init knob layers: defaults provide the
+    document; per-machine can override.
+    """
+    machine = _make_machine(tmp_path)
+    machine.cloud_init_config = {}
+    text, _ = _run_cloud_init_capturing_userdata_file(
+        machine,
+        {"cloud_init": {"user_data": _override_doc()}},
+        password_hash="$6$abc$xyz",
+    )
+    assert text.startswith("#cloud-config")
+    assert "web01" in text
+
+
+def test_cloud_init_user_data_override_per_machine_wins_over_defaults(
+    tmp_path: Path,
+) -> None:
+    """A per-machine user_data fully replaces the defaults' user_data.
+
+    The override is a complete cloud-config document; merging two whole
+    documents has no clean semantics. The per-machine declaration is the
+    operator's "this machine is special" lever and must NOT be diluted
+    by the defaults.
+    """
+    machine = _make_machine(tmp_path)
+    machine.cloud_init_config = {"user_data": {"hostname": "special-host"}}
+    text, _ = _run_cloud_init_capturing_userdata_file(
+        machine,
+        {"cloud_init": {"user_data": {"hostname": "default-host"}}},
+        password_hash="$6$abc$xyz",
+    )
+    assert "special-host" in text
+    assert "default-host" not in text

--- a/tests/test_libvirt_machine.py
+++ b/tests/test_libvirt_machine.py
@@ -355,6 +355,97 @@ def test_init_no_networks_leaves_interface_and_nameservers_untouched() -> None:
 
 
 # ---------------------------------------------------------------------------
+# __init__ — IPv6 dual-stack (#137)
+# ---------------------------------------------------------------------------
+
+
+def test_init_preserves_dual_stack_interface_fields() -> None:
+    """A manifest interface with both ip4/ip4gw and ip6/ip6gw round-trips intact.
+
+    Machine.__init__ does field-by-field merge of defaults + per-machine
+    interface dicts. The IPv6 fields must travel through unmodified so
+    the cloud-init render pipeline sees them.
+    """
+    config_defaults = _minimal_config_defaults()
+    machine_cfg = {
+        "vm_name": "web01",
+        "interfaces": [
+            {
+                "name": "eth0",
+                "network": "default-dualstack",
+                "ip4": "192.168.130.50/24",
+                "ip4gw": "192.168.130.1",
+                "ip6": "2001:db8:130::50/64",
+                "ip6gw": "2001:db8:130::1",
+            }
+        ],
+    }
+    m = Machine(machine_cfg, {"name": "lab"}, config_defaults)
+    iface = m.interfaces[0]
+    assert iface["ip4"] == "192.168.130.50/24"
+    assert iface["ip4gw"] == "192.168.130.1"
+    assert iface["ip6"] == "2001:db8:130::50/64"
+    assert iface["ip6gw"] == "2001:db8:130::1"
+
+
+def test_init_merges_ip6_defaults_into_interface() -> None:
+    """An ``interfaces.ip6gw`` declared at config_defaults level merges into
+    each per-machine interface that lacks one.
+
+    Mirrors the existing pattern where ``config_defaults['interfaces']``
+    seeds per-interface defaults. Lets a manifest say "every machine on
+    this network uses this v6 gateway" without repeating per-VM.
+    """
+    config_defaults = {
+        "interfaces": {
+            "nameservers": {},
+            "ip6gw": "2001:db8:130::1",
+        }
+    }
+    machine_cfg = {
+        "vm_name": "web01",
+        "interfaces": [
+            {
+                "name": "eth0",
+                "ip6": "2001:db8:130::50/64",
+            }
+        ],
+    }
+    m = Machine(machine_cfg, {"name": "lab"}, config_defaults)
+    assert m.interfaces[0]["ip6gw"] == "2001:db8:130::1"
+
+
+def test_init_rejects_user_network_with_static_ip6() -> None:
+    """User-mode networking + ip6 is contradictory; refuse at __init__ time.
+
+    SLIRP/passt don't honour static IPv6 any more than they honour static
+    IPv4 — surface the misconfiguration loudly before any state is created.
+    """
+    config_defaults = _minimal_config_defaults()
+    machine_cfg = {
+        "vm_name": "web01",
+        "interfaces": [
+            {"name": "eth0", "network_type": "user", "ip6": "2001:db8::5/64"}
+        ],
+    }
+    with pytest.raises(ValueError, match="does not honour static IPs"):
+        Machine(machine_cfg, {"name": "lab"}, config_defaults)
+
+
+def test_init_rejects_passt_network_with_static_ip6() -> None:
+    """Same invariant for passt: static v6 is rejected."""
+    config_defaults = _minimal_config_defaults()
+    machine_cfg = {
+        "vm_name": "web01",
+        "interfaces": [
+            {"name": "eth0", "network_type": "passt", "ip6": "2001:db8::5/64"}
+        ],
+    }
+    with pytest.raises(ValueError, match="does not honour static IPs"):
+        Machine(machine_cfg, {"name": "lab"}, config_defaults)
+
+
+# ---------------------------------------------------------------------------
 # _virt_install_network_arg — Phase 12 virt-install argument assembly
 # ---------------------------------------------------------------------------
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -88,6 +88,45 @@ OPEN_NETWORK_XML = """\
 </network>
 """
 
+# Dual-stack NAT network: v4 + v6 ``<ip>`` elements, each with its own
+# ``<dhcp>`` range. libvirt uses ``family='ipv6'`` and ``prefix='N'``
+# (no netmask attribute) for the v6 ``<ip>`` element; v4 omits the family
+# attribute and uses ``netmask``. This is the realistic shape we expect
+# from a libvirt 8.x+ network defined for dual-stack lab use (#137).
+DUAL_STACK_NAT_XML = """\
+<network>
+  <name>default-dualstack</name>
+  <forward mode='nat'>
+    <nat>
+      <port start='1024' end='65535'/>
+    </nat>
+  </forward>
+  <bridge name='virbr1' stp='on' delay='0'/>
+  <mac address='52:54:00:dd:ee:ff'/>
+  <ip address='192.168.130.1' netmask='255.255.255.0'>
+    <dhcp>
+      <range start='192.168.130.2' end='192.168.130.254'/>
+    </dhcp>
+  </ip>
+  <ip family='ipv6' address='2001:db8:130::1' prefix='64'>
+    <dhcp>
+      <range start='2001:db8:130::100' end='2001:db8:130::1ff'/>
+    </dhcp>
+  </ip>
+</network>
+"""
+
+# v6-only network (NAT). Same shape but no v4 ``<ip>`` element. Used to
+# confirm v4 fields stay ``None`` when only v6 is configured.
+V6_ONLY_NAT_XML = """\
+<network>
+  <name>v6only</name>
+  <forward mode='nat'/>
+  <bridge name='virbr-v6'/>
+  <ip family='ipv6' address='fd00:cafe::1' prefix='64'/>
+</network>
+"""
+
 
 def _fake_completed(stdout: str) -> subprocess.CompletedProcess[str]:
     """Return a CompletedProcess shaped like run_virsh's success return."""
@@ -169,6 +208,205 @@ def test_get_network_info_malformed_xml_translates_to_libvirt_network_error() ->
     ):
         with pytest.raises(LibvirtNetworkError, match="Invalid net-dumpxml response"):
             get_network_info("qemu:///system", "default")
+
+
+# ---------------------------------------------------------------------------
+# get_network_info — IPv6 parsing (#137 dual-stack)
+# ---------------------------------------------------------------------------
+
+
+def test_get_network_info_parses_dual_stack_nat() -> None:
+    """A dual-stack NAT network parses BOTH v4 and v6 fields independently.
+
+    libvirt emits two ``<ip>`` elements — one with no ``family`` (v4,
+    ``netmask``) and one with ``family='ipv6'`` (``prefix``). Each may
+    carry its own ``<dhcp>`` range. The parser must not let v6 overwrite
+    v4 fields or vice versa.
+    """
+    with mock.patch.object(
+        net_mod, "run_virsh", return_value=_fake_completed(DUAL_STACK_NAT_XML)
+    ):
+        info = get_network_info("qemu:///system", "default-dualstack")
+
+    # v4 side unchanged.
+    assert info.gateway_ip == "192.168.130.1"
+    assert info.netmask == "255.255.255.0"
+    assert info.dhcp_start == "192.168.130.2"
+    assert info.dhcp_end == "192.168.130.254"
+    # v6 side populated.
+    assert info.gateway_ip6 == "2001:db8:130::1"
+    assert info.prefix6 == 64
+    assert info.dhcp6_start == "2001:db8:130::100"
+    assert info.dhcp6_end == "2001:db8:130::1ff"
+
+
+def test_get_network_info_parses_v6_only_network() -> None:
+    """A v6-only network leaves v4 fields ``None`` but populates v6 fields.
+
+    Even though lvlab's #137 first-cut scope is dual-stack only, the
+    parser layer must not crash on v6-only networks (operators may use
+    them with non-lvlab tooling on the same hypervisor).
+    """
+    with mock.patch.object(
+        net_mod, "run_virsh", return_value=_fake_completed(V6_ONLY_NAT_XML)
+    ):
+        info = get_network_info("qemu:///system", "v6only")
+
+    assert info.gateway_ip is None
+    assert info.netmask is None
+    assert info.gateway_ip6 == "fd00:cafe::1"
+    assert info.prefix6 == 64
+    assert info.dhcp6_start is None
+    assert info.dhcp6_end is None
+
+
+def test_get_network_info_v4_only_leaves_v6_fields_none() -> None:
+    """A v4-only network (the existing default) parses with v6 fields ``None``.
+
+    Regression guard for the dual-stack work: extending
+    ``LibvirtNetworkInfo`` with v6 fields must not change behavior for
+    callers that only see v4 networks today.
+    """
+    with mock.patch.object(
+        net_mod, "run_virsh", return_value=_fake_completed(NAT_NETWORK_XML)
+    ):
+        info = get_network_info("qemu:///system", "default")
+
+    assert info.gateway_ip == "192.168.122.1"  # v4 still parses
+    assert info.gateway_ip6 is None
+    assert info.prefix6 is None
+    assert info.dhcp6_start is None
+    assert info.dhcp6_end is None
+
+
+# ---------------------------------------------------------------------------
+# LibvirtNetworkInfo.subnet6
+# ---------------------------------------------------------------------------
+
+
+def test_subnet6_inferred_from_gateway_and_prefix() -> None:
+    """subnet6 is an IPv6Network derived from gateway_ip6 + prefix6, strict=False."""
+    info = LibvirtNetworkInfo(
+        name="default-dualstack",
+        forward_mode="nat",
+        gateway_ip="192.168.130.1",
+        netmask="255.255.255.0",
+        dhcp_start=None,
+        dhcp_end=None,
+        gateway_ip6="2001:db8:130::1",
+        prefix6=64,
+        dhcp6_start=None,
+        dhcp6_end=None,
+    )
+    assert info.subnet6 == ipaddress.IPv6Network("2001:db8:130::/64")
+
+
+def test_subnet6_is_none_when_v6_gateway_missing() -> None:
+    """Without a v6 gateway, subnet6 returns None (mirrors subnet's behavior)."""
+    info = LibvirtNetworkInfo(
+        name="v4only",
+        forward_mode="nat",
+        gateway_ip="192.168.122.1",
+        netmask="255.255.255.0",
+        dhcp_start=None,
+        dhcp_end=None,
+        gateway_ip6=None,
+        prefix6=None,
+        dhcp6_start=None,
+        dhcp6_end=None,
+    )
+    assert info.subnet6 is None
+
+
+def test_subnet6_is_none_when_prefix_missing() -> None:
+    """A v6 gateway without a prefix can't infer a subnet — return None."""
+    info = LibvirtNetworkInfo(
+        name="weird",
+        forward_mode="nat",
+        gateway_ip=None,
+        netmask=None,
+        dhcp_start=None,
+        dhcp_end=None,
+        gateway_ip6="2001:db8::1",
+        prefix6=None,
+        dhcp6_start=None,
+        dhcp6_end=None,
+    )
+    assert info.subnet6 is None
+
+
+# ---------------------------------------------------------------------------
+# validate_static_ip — IPv6 routing (#137)
+# ---------------------------------------------------------------------------
+
+
+def _dualstack_default() -> LibvirtNetworkInfo:
+    """Build a NAT dual-stack info object reused across v6 validation tests."""
+    return LibvirtNetworkInfo(
+        name="default-dualstack",
+        forward_mode="nat",
+        gateway_ip="192.168.130.1",
+        netmask="255.255.255.0",
+        dhcp_start="192.168.130.2",
+        dhcp_end="192.168.130.254",
+        gateway_ip6="2001:db8:130::1",
+        prefix6=64,
+        dhcp6_start="2001:db8:130::100",
+        dhcp6_end="2001:db8:130::1ff",
+    )
+
+
+def test_validate_static_ip_accepts_v6_in_subnet_outside_dhcp() -> None:
+    """A v6 address inside the v6 subnet but outside the v6 DHCP range is accepted."""
+    info = _dualstack_default()
+    # ::1 is the gateway — outside DHCP range, inside the /64.
+    validate_static_ip("2001:db8:130::1", info)  # Must not raise.
+    # ::2 is below the dhcp6 range start (::100).
+    validate_static_ip("2001:db8:130::2", info)  # Must not raise.
+
+
+def test_validate_static_ip_rejects_v6_inside_dhcp6_range() -> None:
+    """A v6 static IP inside the v6 DHCP range races libvirt's dnsmasq6 — rejected."""
+    info = _dualstack_default()
+    with pytest.raises(ValueError, match="DHCP range"):
+        validate_static_ip("2001:db8:130::100", info)  # boundary
+    with pytest.raises(ValueError, match="DHCP range"):
+        validate_static_ip("2001:db8:130::150", info)  # mid
+    with pytest.raises(ValueError, match="DHCP range"):
+        validate_static_ip("2001:db8:130::1ff", info)  # boundary
+
+
+def test_validate_static_ip_rejects_v6_outside_subnet() -> None:
+    """A v6 address outside the network's /64 is rejected, ignoring v4 fields entirely."""
+    info = _dualstack_default()
+    with pytest.raises(ValueError, match="not in subnet"):
+        validate_static_ip("2001:db8:999::5", info)
+
+
+def test_validate_static_ip_v4_still_uses_v4_subnet_on_dual_stack() -> None:
+    """A v4 address validated against a dual-stack network checks the v4 side only.
+
+    Regression guard: the dual-stack extension must not let v6 fields
+    interfere with v4 validation. A v4 address far from the v6 subnet
+    must still validate against the v4 subnet.
+    """
+    info = _dualstack_default()
+    validate_static_ip("192.168.130.1", info)  # v4 gateway, must not raise
+    with pytest.raises(ValueError, match="DHCP range"):
+        validate_static_ip("192.168.130.50", info)  # in v4 dhcp range
+
+
+def test_validate_static_ip_v6_with_cidr_suffix() -> None:
+    """A v6 address with a /prefix suffix still validates — strip the CIDR first."""
+    info = _dualstack_default()
+    validate_static_ip("2001:db8:130::1/64", info)  # Must not raise.
+
+
+def test_validate_static_ip_v6_skips_checks_when_v6_subnet_unknown() -> None:
+    """A v6 address validated against a v4-only network skips checks (no v6 subnet)."""
+    info = _nat_default()  # v4-only fixture
+    # Operator picked a v6 address; we have no v6 info — accept it.
+    validate_static_ip("2001:db8::5", info)  # Must not raise.
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The two parity gaps the 0.6.0 plan calls out as in-scope. After this lands the
project is ready for the planned park.

- **#137 — IPv6 dual-stack.** Both `createvm` (`--ip6`, `--gateway6`, `--dns6`) and the manifest workflow (`interfaces.ip6` / `ip6gw`) accept a v6 address alongside v4. `LibvirtNetworkInfo` learned `gateway_ip6` / `prefix6` / `dhcp6_start` / `dhcp6_end` + `subnet6`; `validate_static_ip` routes by family; new `resolve_network_settings6`. Templates (v1 ENI `static6`, v2 netplan addresses + `::/0` route) render the v6 stanza only when an interface carries `ip6`. **v6-only guests deliberately out of scope** for this cut — lvlab's helper commands (`ssh`, `smoke`, `hosts`) still resolve VM IPs as v4 today. Per-network v6 defaults under the `networks:` map also deferred.

- **#140 — `lvlab up` user_data override parity with createvm.** A per-machine `cloud_init.user_data` (or `config_defaults.cloud_init.user_data`) is now honored: the full cloud-config mapping replaces the structured user-data render, with `{vm_name}` / `{vm_hostname}` / `{fqdn}` / `{default_vm_username}` / `{password_hash}` / `{environment}` substituted from the resolved per-machine context. **One renderer is shared with createvm** (`render_user_data_override` in `utils/standalone_cloud_init.py`) — no forked substitution logic. `cloud_init.pubkey` is appended to every user's `ssh_authorized_keys`; the manifest-wide `/etc/hosts` heredocs (#120) are prepended to the override's `runcmd` (opt-out via `manage_etc_hosts: false`); per-machine override fully replaces defaults override.

## What changed

| Surface | Changed |
| --- | --- |
| `utils/network.py` | `LibvirtNetworkInfo` v6 fields + `subnet6`; `get_network_info` parses dual-stack `<ip>` siblings via extracted `_split_ip_elements_by_family`; `validate_static_ip` dual-stack; new `resolve_network_settings6` |
| `utils/libvirt.py` | `Machine.__init__` propagates `ip6`/`ip6gw` and rejects them on user/passt (parallels the `ip4` guard); `_CloudInitComposer` factors `_build_hosts_runcmd_prefix` so the structured + override paths share the heredoc prefix; new `_render_user_data_override` + `_resolve_pubkey_list` |
| `scripts/createvm.py` | `--ip6` / `--gateway6` / `--dns6` typer options; `parse_ip6_option`; `_resolve_static_vm_ip6`; `_resolve_v6_settings` helper that encapsulates the v6 leg (bridge guard + resolve + validate + SLAAC/DHCPv6 fall-through). `_CreateVmContext` gains `vm_ip6`/`gateway6`/`dns_servers6`. Updated `render_user_data_override` call to populate the two new placeholders. |
| `templates/network-config.v1.j2` | Emits `type: static6` subnet alongside the v4 `static` when iface has `ip6` |
| `templates/network-config.v2.j2` | Emits a second `addresses` entry + `::/0` route via `ip6gw`; preserves the v4-only `dhcp6: false` defensive behaviour |
| `utils/standalone_cloud_init.py` | `USER_DATA_PLACEHOLDERS` adds `fqdn` and `environment` (createvm fills the latter as `""`) |
| Docs | Walkthrough sections "Dual-stack IPv4 + IPv6" and "`user_data` cloud-config override"; `docs/Lvlab.example.yml` dual-stack example; `.github/release-notes/0.6.0.md` |

## Tests

- **769 pass, 39 skip** (was 749 + 14 new IPv6 tests + 6 new user_data override tests).
- TDD throughout: each layer's tests landed RED, then GREEN, then full-suite + sonar.
- Backwards-compat regression guards: a v4-only manifest renders byte-identical to 0.5.4 (templates preserved); the user_data override path is gated on the key being present — manifests without `cloud_init.user_data` go through the structured path unchanged.

## Sonar

network.py clean. createvm.py and libvirt.py findings present are all pre-existing categories (parameter counts, cognitive complexity, duplicated log literals); the IPv6 work actually reduced `_build_createvm_context` complexity from 32 → 22 by extracting `_resolve_v6_settings`.

## Test plan

- [ ] Local smoke on Fedora 44 (taken by maintainer) — `lvlab up` + `lvlab cloudinit` against a dual-stack manifest + a `cloud_init.user_data` override manifest
- [ ] Belt-and-suspenders: cloud-init log on a booted guest confirms the override `user-data` was applied (correct users, correct `write_files`, `runcmd` prefix order is hosts-heredocs-first)

## Out of scope (after 0.6.0 ships)

- #107 output-unify epic remaining sweep
- #122 snapshot-revert (still on `experiment/snapshot-revert`)
- #141 smoke "booting" linger / multi-source IP resolve
- Per-network v6 defaults under `networks[<name>].gateway6` / `.dns6` (deferred enhancement on #137)

🤖 Generated with [Claude Code](https://claude.com/claude-code)